### PR TITLE
feat: DB2/400 metadata service (refs #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,10 @@ Optional: Screenshots von `index`, `preview`, `result` können später ergänzt 
 - Mehrere Delimiter-Profile
 - Persistente Job-Historie
 - Fehlerexport als CSV/JSON
+
+## Metadata endpoints
+
+Fuer kommende V2-Mapping-Features stellt die Anwendung zusaetzliche, read-only Metadata-Endpunkte bereit:
+
+- `/meta/tables?library=LIB`
+- `/meta/columns?library=LIB&table=TABLE`

--- a/src/main/java/com/zeus/upload/controller/MetadataController.java
+++ b/src/main/java/com/zeus/upload/controller/MetadataController.java
@@ -1,0 +1,46 @@
+package com.zeus.upload.controller;
+
+import com.zeus.upload.domain.DbColumnMeta;
+import com.zeus.upload.domain.DbTableRef;
+import com.zeus.upload.service.MetadataService;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/meta")
+public class MetadataController {
+
+    private final MetadataService metadataService;
+
+    public MetadataController(MetadataService metadataService) {
+        this.metadataService = metadataService;
+    }
+
+    @GetMapping("/tables")
+    public List<DbTableRef> listTables(@RequestParam("library") String library) {
+        if (!StringUtils.hasText(library)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "library must not be blank");
+        }
+        return metadataService.listTables(library);
+    }
+
+    @GetMapping("/columns")
+    public List<DbColumnMeta> listColumns(
+            @RequestParam("library") String library,
+            @RequestParam("table") String table
+    ) {
+        if (!StringUtils.hasText(library)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "library must not be blank");
+        }
+        if (!StringUtils.hasText(table)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "table must not be blank");
+        }
+        return metadataService.listColumns(library, table);
+    }
+}

--- a/src/main/java/com/zeus/upload/controller/UploadController.java
+++ b/src/main/java/com/zeus/upload/controller/UploadController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.util.StringUtils;
 
 @Controller
 @SessionAttributes("previewContext")
@@ -64,6 +65,8 @@ public class UploadController {
             @RequestParam("library") String library,
             @RequestParam("tableName") String tableName,
             @RequestParam(value = "dropAndRecreate", defaultValue = "false") boolean dropAndRecreate,
+            @RequestParam(value = "useExistingTable", defaultValue = "false") boolean useExistingTable,
+            @RequestParam(value = "existingTableName", required = false) String existingTableName,
             @ModelAttribute("previewContext") PreviewContext previewContext,
             Model model,
             RedirectAttributes redirectAttributes
@@ -79,6 +82,10 @@ public class UploadController {
             request.setLibrary(library);
             request.setTableName(tableName);
             request.setDropAndRecreate(dropAndRecreate);
+            request.setUseExistingTable(useExistingTable);
+            if (useExistingTable && StringUtils.hasText(existingTableName)) {
+                request.setExistingTableName(existingTableName.trim());
+            }
             request.setColumns(copyColumns(parsed.getProposals()));
 
             previewContext.setParsedCsv(parsed);

--- a/src/main/java/com/zeus/upload/domain/DbColumnMeta.java
+++ b/src/main/java/com/zeus/upload/domain/DbColumnMeta.java
@@ -1,0 +1,98 @@
+package com.zeus.upload.domain;
+
+import java.util.Objects;
+
+public class DbColumnMeta {
+
+    private final String columnName;
+    private final String typeName;
+    private final Integer jdbcType;
+    private final Integer length;
+    private final Integer precision;
+    private final Integer scale;
+    private final boolean nullable;
+    private final String defaultValue;
+    private final Integer ordinalPosition;
+
+    public DbColumnMeta(
+            String columnName,
+            String typeName,
+            Integer jdbcType,
+            Integer length,
+            Integer precision,
+            Integer scale,
+            boolean nullable,
+            String defaultValue,
+            Integer ordinalPosition
+    ) {
+        this.columnName = columnName;
+        this.typeName = typeName;
+        this.jdbcType = jdbcType;
+        this.length = length;
+        this.precision = precision;
+        this.scale = scale;
+        this.nullable = nullable;
+        this.defaultValue = defaultValue;
+        this.ordinalPosition = ordinalPosition;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public String getTypeName() {
+        return typeName;
+    }
+
+    public Integer getJdbcType() {
+        return jdbcType;
+    }
+
+    public Integer getLength() {
+        return length;
+    }
+
+    public Integer getPrecision() {
+        return precision;
+    }
+
+    public Integer getScale() {
+        return scale;
+    }
+
+    public boolean isNullable() {
+        return nullable;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public Integer getOrdinalPosition() {
+        return ordinalPosition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DbColumnMeta that)) {
+            return false;
+        }
+        return nullable == that.nullable
+                && Objects.equals(columnName, that.columnName)
+                && Objects.equals(typeName, that.typeName)
+                && Objects.equals(jdbcType, that.jdbcType)
+                && Objects.equals(length, that.length)
+                && Objects.equals(precision, that.precision)
+                && Objects.equals(scale, that.scale)
+                && Objects.equals(defaultValue, that.defaultValue)
+                && Objects.equals(ordinalPosition, that.ordinalPosition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(columnName, typeName, jdbcType, length, precision, scale, nullable, defaultValue, ordinalPosition);
+    }
+}

--- a/src/main/java/com/zeus/upload/domain/DbTableRef.java
+++ b/src/main/java/com/zeus/upload/domain/DbTableRef.java
@@ -1,0 +1,46 @@
+package com.zeus.upload.domain;
+
+import java.util.Objects;
+
+public class DbTableRef {
+
+    private final String library;
+    private final String tableName;
+
+    public DbTableRef(String library, String tableName) {
+        this.library = library;
+        this.tableName = tableName;
+    }
+
+    public String getLibrary() {
+        return library;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    @Override
+    public String toString() {
+        return "DbTableRef{"
+                + "library='" + library + '\''
+                + ", tableName='" + tableName + '\''
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DbTableRef that)) {
+            return false;
+        }
+        return Objects.equals(library, that.library) && Objects.equals(tableName, that.tableName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(library, tableName);
+    }
+}

--- a/src/main/java/com/zeus/upload/domain/ImportRequest.java
+++ b/src/main/java/com/zeus/upload/domain/ImportRequest.java
@@ -14,6 +14,8 @@ public class ImportRequest {
     private String tableName;
 
     private boolean dropAndRecreate;
+    private boolean useExistingTable;
+    private String existingTableName;
 
     @Valid
     private List<ColumnProposal> columns = new ArrayList<>();
@@ -40,6 +42,22 @@ public class ImportRequest {
 
     public void setDropAndRecreate(boolean dropAndRecreate) {
         this.dropAndRecreate = dropAndRecreate;
+    }
+
+    public boolean isUseExistingTable() {
+        return useExistingTable;
+    }
+
+    public void setUseExistingTable(boolean useExistingTable) {
+        this.useExistingTable = useExistingTable;
+    }
+
+    public String getExistingTableName() {
+        return existingTableName;
+    }
+
+    public void setExistingTableName(String existingTableName) {
+        this.existingTableName = existingTableName;
     }
 
     public List<ColumnProposal> getColumns() {

--- a/src/main/java/com/zeus/upload/service/JdbcMetadataService.java
+++ b/src/main/java/com/zeus/upload/service/JdbcMetadataService.java
@@ -1,0 +1,152 @@
+package com.zeus.upload.service;
+
+import com.zeus.upload.domain.DbColumnMeta;
+import com.zeus.upload.domain.DbTableRef;
+import com.zeus.upload.util.MetadataNormalizationUtil;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JdbcMetadataService implements MetadataService {
+
+    private static final Logger log = LoggerFactory.getLogger(JdbcMetadataService.class);
+
+    private static final Comparator<DbColumnMeta> COLUMN_COMPARATOR = Comparator
+            .comparing((DbColumnMeta c) -> c.getOrdinalPosition() == null ? Integer.MAX_VALUE : c.getOrdinalPosition())
+            .thenComparing(c -> c.getColumnName() == null ? "" : c.getColumnName());
+
+    private final DataSource dataSource;
+
+    public JdbcMetadataService(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public List<DbTableRef> listTables(String library) {
+        String normalizedLibrary = MetadataNormalizationUtil.normalizeLibrary(library);
+        if (normalizedLibrary.isEmpty()) {
+            return List.of();
+        }
+
+        try (Connection connection = dataSource.getConnection()) {
+            DatabaseMetaData metadata = connection.getMetaData();
+            List<DbTableRef> result = fetchTables(metadata, normalizedLibrary, false);
+
+            if (result.isEmpty()) {
+                result = fetchTables(metadata, normalizedLibrary, true);
+            }
+
+            if (result.isEmpty()) {
+                log.warn("No metadata tables found for library {}", normalizedLibrary);
+            }
+            return result;
+        } catch (SQLException ex) {
+            log.error("Failed to list metadata tables for library {}", normalizedLibrary, ex);
+            throw new RuntimeException("Failed to list tables for library " + normalizedLibrary, ex);
+        }
+    }
+
+    @Override
+    public List<DbColumnMeta> listColumns(String library, String tableName) {
+        String normalizedLibrary = MetadataNormalizationUtil.normalizeLibrary(library);
+        String normalizedTable = MetadataNormalizationUtil.normalizeTable(tableName);
+        if (normalizedLibrary.isEmpty() || normalizedTable.isEmpty()) {
+            return List.of();
+        }
+
+        try (Connection connection = dataSource.getConnection()) {
+            DatabaseMetaData metadata = connection.getMetaData();
+            List<DbColumnMeta> columns = new ArrayList<>();
+            try (ResultSet resultSet = metadata.getColumns(null, normalizedLibrary, normalizedTable, "%")) {
+                while (resultSet.next()) {
+                    String columnName = MetadataNormalizationUtil.normalizeTable(resultSet.getString("COLUMN_NAME"));
+                    String typeName = resultSet.getString("TYPE_NAME");
+                    Integer jdbcType = readInteger(resultSet, "DATA_TYPE");
+                    Integer length = readInteger(resultSet, "COLUMN_SIZE");
+                    Integer scale = readInteger(resultSet, "DECIMAL_DIGITS");
+                    Integer nullableValue = readInteger(resultSet, "NULLABLE");
+                    String defaultValue = resultSet.getString("COLUMN_DEF");
+                    Integer ordinalPosition = readInteger(resultSet, "ORDINAL_POSITION");
+                    boolean nullable = nullableValue == null || nullableValue != DatabaseMetaData.columnNoNulls;
+
+                    columns.add(new DbColumnMeta(
+                            columnName,
+                            typeName,
+                            jdbcType,
+                            length,
+                            length,
+                            scale,
+                            nullable,
+                            defaultValue,
+                            ordinalPosition
+                    ));
+                }
+            }
+
+            if (columns.isEmpty()) {
+                log.warn("No metadata columns found for {}.{}", normalizedLibrary, normalizedTable);
+                return List.of();
+            }
+
+            columns.sort(COLUMN_COMPARATOR);
+            return columns;
+        } catch (SQLException ex) {
+            log.error("Failed to list metadata columns for {}.{}", normalizedLibrary, normalizedTable, ex);
+            throw new RuntimeException(
+                    "Failed to list columns for " + normalizedLibrary + "." + normalizedTable,
+                    ex
+            );
+        }
+    }
+
+    static List<DbColumnMeta> sortColumnsForTest(List<DbColumnMeta> columns) {
+        List<DbColumnMeta> sorted = new ArrayList<>(columns);
+        sorted.sort(COLUMN_COMPARATOR);
+        return sorted;
+    }
+
+    private List<DbTableRef> fetchTables(DatabaseMetaData metadata, String library, boolean fallback) throws SQLException {
+        String schemaPattern = fallback ? null : library;
+        Map<String, DbTableRef> unique = new LinkedHashMap<>();
+        try (ResultSet resultSet = metadata.getTables(null, schemaPattern, "%", new String[]{"TABLE"})) {
+            while (resultSet.next()) {
+                String tableSchema = MetadataNormalizationUtil.normalizeLibrary(resultSet.getString("TABLE_SCHEM"));
+                if (fallback && !library.equals(tableSchema)) {
+                    continue;
+                }
+
+                String tableName = MetadataNormalizationUtil.normalizeTable(resultSet.getString("TABLE_NAME"));
+                if (tableName.isEmpty()) {
+                    continue;
+                }
+                unique.put(tableName, new DbTableRef(library, tableName));
+            }
+        }
+
+        List<DbTableRef> result = new ArrayList<>(unique.values());
+        result.sort(Comparator.comparing(DbTableRef::getTableName));
+        return result;
+    }
+
+    private Integer readInteger(ResultSet resultSet, String columnLabel) throws SQLException {
+        Object value = resultSet.getObject(columnLabel);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        return Integer.valueOf(String.valueOf(value));
+    }
+}

--- a/src/main/java/com/zeus/upload/service/MetadataService.java
+++ b/src/main/java/com/zeus/upload/service/MetadataService.java
@@ -1,0 +1,12 @@
+package com.zeus.upload.service;
+
+import com.zeus.upload.domain.DbColumnMeta;
+import com.zeus.upload.domain.DbTableRef;
+import java.util.List;
+
+public interface MetadataService {
+
+    List<DbTableRef> listTables(String library);
+
+    List<DbColumnMeta> listColumns(String library, String tableName);
+}

--- a/src/main/java/com/zeus/upload/util/MetadataNormalizationUtil.java
+++ b/src/main/java/com/zeus/upload/util/MetadataNormalizationUtil.java
@@ -1,0 +1,28 @@
+package com.zeus.upload.util;
+
+import java.util.Locale;
+
+public final class MetadataNormalizationUtil {
+
+    private MetadataNormalizationUtil() {
+    }
+
+    public static String normalizeLibrary(String value) {
+        return normalizeToken(value);
+    }
+
+    public static String normalizeTable(String value) {
+        return normalizeToken(value);
+    }
+
+    private static String normalizeToken(String value) {
+        if (value == null) {
+            return "";
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            return "";
+        }
+        return trimmed.toUpperCase(Locale.ROOT);
+    }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -35,6 +35,22 @@
                             <input class="form-check-input" type="checkbox" id="dropAndRecreate" name="dropAndRecreate">
                             <label class="form-check-label" for="dropAndRecreate">Drop table before create</label>
                         </div>
+                        <div class="card border-0 bg-light mb-4">
+                            <div class="card-body">
+                                <h6 class="mb-3">Existing table (optional)</h6>
+                                <div class="form-check mb-2">
+                                    <input class="form-check-input" type="checkbox" id="useExistingTable" name="useExistingTable" value="true">
+                                    <label class="form-check-label" for="useExistingTable">Use existing DB2 table metadata</label>
+                                </div>
+                                <div class="mb-2">
+                                    <label for="existingTableSelect" class="form-label">Existing table</label>
+                                    <select class="form-select" id="existingTableSelect" name="existingTableName" disabled>
+                                        <option value="">Select table...</option>
+                                    </select>
+                                </div>
+                                <div id="existingTableStatus" class="form-text"></div>
+                            </div>
+                        </div>
                         <button type="submit" class="btn btn-primary">Upload and Analyze</button>
                     </form>
                 </div>
@@ -42,5 +58,69 @@
         </div>
     </div>
 </div>
+<script>
+    (() => {
+        const libraryInput = document.getElementById("library");
+        const useExistingTable = document.getElementById("useExistingTable");
+        const existingTableSelect = document.getElementById("existingTableSelect");
+        const status = document.getElementById("existingTableStatus");
+
+        if (!libraryInput || !useExistingTable || !existingTableSelect || !status) {
+            return;
+        }
+
+        const resetSelect = (message) => {
+            existingTableSelect.innerHTML = "<option value=''>Select table...</option>";
+            existingTableSelect.disabled = true;
+            status.textContent = message || "";
+        };
+
+        const fillSelect = (tables) => {
+            existingTableSelect.innerHTML = "<option value=''>Select table...</option>";
+            tables.forEach((table) => {
+                const option = document.createElement("option");
+                option.value = table.tableName;
+                option.textContent = table.tableName;
+                existingTableSelect.appendChild(option);
+            });
+            existingTableSelect.disabled = tables.length === 0;
+            status.textContent = tables.length === 0 ? "No tables found for this library." : "";
+        };
+
+        const fetchTables = async () => {
+            if (!useExistingTable.checked) {
+                resetSelect("");
+                return;
+            }
+
+            const library = libraryInput.value.trim();
+            if (!library) {
+                resetSelect("Enter a library first.");
+                return;
+            }
+
+            status.textContent = "Loading tables...";
+            try {
+                const response = await fetch(`/meta/tables?library=${encodeURIComponent(library)}`);
+                if (!response.ok) {
+                    throw new Error("Metadata endpoint returned " + response.status);
+                }
+                const tables = await response.json();
+                fillSelect(Array.isArray(tables) ? tables : []);
+            } catch (error) {
+                resetSelect("Could not load tables.");
+            }
+        };
+
+        useExistingTable.addEventListener("change", fetchTables);
+        libraryInput.addEventListener("change", () => {
+            if (useExistingTable.checked) {
+                fetchTables();
+            }
+        });
+
+        resetSelect("");
+    })();
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/preview.html
+++ b/src/main/resources/templates/preview.html
@@ -22,6 +22,8 @@
     </div>
 
     <form th:action="@{/import}" th:object="${importRequest}" method="post">
+        <input type="hidden" th:field="*{useExistingTable}">
+        <input type="hidden" th:field="*{existingTableName}">
         <div class="card shadow-sm mb-3">
             <div class="card-body">
                 <div class="row">
@@ -109,8 +111,91 @@
             </div>
         </div>
 
+        <div class="card shadow-sm mb-3"
+             th:if="${importRequest.useExistingTable and importRequest.existingTableName != null and !#strings.isEmpty(importRequest.existingTableName)}">
+            <div class="card-header">
+                <strong>Existing Table Metadata</strong>
+                <span class="text-muted ms-2" th:text="${importRequest.library + '.' + importRequest.existingTableName}"></span>
+            </div>
+            <div class="table-responsive">
+                <table class="table table-sm table-striped mb-0">
+                    <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Column</th>
+                        <th>Type</th>
+                        <th>JDBC Type</th>
+                        <th>Length</th>
+                        <th>Scale</th>
+                        <th>Nullable</th>
+                        <th>Default</th>
+                    </tr>
+                    </thead>
+                    <tbody id="existingColumnsBody"
+                           th:attr="data-library=${importRequest.library},data-table=${importRequest.existingTableName}">
+                    <tr>
+                        <td colspan="8" class="text-muted">Loading metadata...</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
         <button type="submit" class="btn btn-success">Create Table and Import</button>
     </form>
 </div>
+<script>
+    (() => {
+        const body = document.getElementById("existingColumnsBody");
+        if (!body) {
+            return;
+        }
+
+        const library = (body.dataset.library || "").trim();
+        const table = (body.dataset.table || "").trim();
+        if (!library || !table) {
+            body.innerHTML = "<tr><td colspan='8' class='text-muted'>No existing table selected.</td></tr>";
+            return;
+        }
+
+        const renderRows = (columns) => {
+            if (!columns || columns.length === 0) {
+                body.innerHTML = "<tr><td colspan='8' class='text-muted'>No metadata columns found.</td></tr>";
+                return;
+            }
+            body.innerHTML = columns.map((column) => {
+                const ordinal = column.ordinalPosition ?? "";
+                const type = column.typeName ?? "";
+                const jdbcType = column.jdbcType ?? "";
+                const length = column.length ?? "";
+                const scale = column.scale ?? "";
+                const nullable = column.nullable ? "YES" : "NO";
+                const defaultValue = column.defaultValue ?? "";
+                return `<tr>
+                    <td>${ordinal}</td>
+                    <td>${column.columnName || ""}</td>
+                    <td>${type}</td>
+                    <td>${jdbcType}</td>
+                    <td>${length}</td>
+                    <td>${scale}</td>
+                    <td>${nullable}</td>
+                    <td>${defaultValue}</td>
+                </tr>`;
+            }).join("");
+        };
+
+        fetch(`/meta/columns?library=${encodeURIComponent(library)}&table=${encodeURIComponent(table)}`)
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error("Metadata endpoint returned " + response.status);
+                }
+                return response.json();
+            })
+            .then((columns) => renderRows(Array.isArray(columns) ? columns : []))
+            .catch(() => {
+                body.innerHTML = "<tr><td colspan='8' class='text-danger'>Could not load metadata columns.</td></tr>";
+            });
+    })();
+</script>
 </body>
 </html>

--- a/src/test/java/com/zeus/upload/service/MetadataNormalizationTest.java
+++ b/src/test/java/com/zeus/upload/service/MetadataNormalizationTest.java
@@ -1,0 +1,23 @@
+package com.zeus.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.util.MetadataNormalizationUtil;
+import org.junit.jupiter.api.Test;
+
+class MetadataNormalizationTest {
+
+    @Test
+    void shouldNormalizeLibraryAndTableToUppercase() {
+        assertThat(MetadataNormalizationUtil.normalizeLibrary(" bib ")).isEqualTo("BIB");
+        assertThat(MetadataNormalizationUtil.normalizeTable(" my_table ")).isEqualTo("MY_TABLE");
+    }
+
+    @Test
+    void shouldReturnEmptyForNullOrBlankValues() {
+        assertThat(MetadataNormalizationUtil.normalizeLibrary(null)).isEmpty();
+        assertThat(MetadataNormalizationUtil.normalizeLibrary("   ")).isEmpty();
+        assertThat(MetadataNormalizationUtil.normalizeTable(null)).isEmpty();
+        assertThat(MetadataNormalizationUtil.normalizeTable("\t")).isEmpty();
+    }
+}

--- a/src/test/java/com/zeus/upload/service/MetadataSortingTest.java
+++ b/src/test/java/com/zeus/upload/service/MetadataSortingTest.java
@@ -1,0 +1,34 @@
+package com.zeus.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.domain.DbColumnMeta;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MetadataSortingTest {
+
+    @Test
+    void shouldSortColumnsByOrdinalPositionFirst() {
+        DbColumnMeta c1 = new DbColumnMeta("C_LAST", "VARCHAR", 12, 100, 100, 0, true, null, 3);
+        DbColumnMeta c2 = new DbColumnMeta("C_FIRST", "INTEGER", 4, 10, 10, 0, false, null, 1);
+        DbColumnMeta c3 = new DbColumnMeta("C_SECOND", "DECIMAL", 3, 15, 15, 2, true, null, 2);
+
+        List<DbColumnMeta> sorted = JdbcMetadataService.sortColumnsForTest(List.of(c1, c2, c3));
+
+        assertThat(sorted).extracting(DbColumnMeta::getColumnName)
+                .containsExactly("C_FIRST", "C_SECOND", "C_LAST");
+    }
+
+    @Test
+    void shouldFallbackToColumnNameWhenOrdinalMissing() {
+        DbColumnMeta z = new DbColumnMeta("Z_COL", "VARCHAR", 12, 20, 20, 0, true, null, null);
+        DbColumnMeta a = new DbColumnMeta("A_COL", "VARCHAR", 12, 20, 20, 0, true, null, null);
+        DbColumnMeta withOrdinal = new DbColumnMeta("MID_COL", "VARCHAR", 12, 20, 20, 0, true, null, 2);
+
+        List<DbColumnMeta> sorted = JdbcMetadataService.sortColumnsForTest(List.of(z, a, withOrdinal));
+
+        assertThat(sorted).extracting(DbColumnMeta::getColumnName)
+                .containsExactly("MID_COL", "A_COL", "Z_COL");
+    }
+}


### PR DESCRIPTION
﻿## Summary
Implements the DB2/400 metadata enabler for Issue #8 in an additive way (no breaking change to current CSV -> create -> import flow).

### What was added
- `MetadataService` interface and `JdbcMetadataService` implementation based on `DatabaseMetaData`
- Domain models: `DbTableRef`, `DbColumnMeta`
- Read-only REST endpoints:
  - `GET /meta/tables?library=LIB`
  - `GET /meta/columns?library=LIB&table=TABLE`
- Optional UI hook:
  - index: "Existing table (optional)" with checkbox + table select
  - preview: read-only metadata columns view for selected existing table
- Utility: `MetadataNormalizationUtil` (trim + uppercase normalization)
- Tests:
  - `MetadataNormalizationTest`
  - `MetadataSortingTest`
- README section "Metadata endpoints"

## Behavior and safety
- Existing create/import logic remains unchanged.
- Metadata features are opt-in and read-only.
- Empty/no-result metadata lookups return empty lists (with warning logs), not crashes.
- SQL metadata errors are logged and surfaced as concise runtime messages.

## Validation done
- `mvn -q test` passed
- `mvn -q package` passed

## Acceptance checklist (#8)
- [x] `/meta/tables` and `/meta/columns` return JSON
- [x] UI can list tables when checkbox is enabled (best effort, safe if empty)
- [x] No regression of existing create/import flow
- [x] Build/test pipeline green

Refs #8
