### PR TITLE
test: H2 integration tests + minimal dialect scaffold (refs #38)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/zeus/upload/config/SqlDialectConfiguration.java
+++ b/src/main/java/com/zeus/upload/config/SqlDialectConfiguration.java
@@ -1,0 +1,24 @@
+package com.zeus.upload.config;
+
+import com.zeus.upload.sql.Db2iDialect;
+import com.zeus.upload.sql.H2Dialect;
+import com.zeus.upload.sql.SqlDialect;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+public class SqlDialectConfiguration {
+
+    @Bean
+    @Profile("!test")
+    public SqlDialect db2iDialect() {
+        return new Db2iDialect();
+    }
+
+    @Bean
+    @Profile("test")
+    public SqlDialect h2Dialect() {
+        return new H2Dialect();
+    }
+}

--- a/src/main/java/com/zeus/upload/service/DdlService.java
+++ b/src/main/java/com/zeus/upload/service/DdlService.java
@@ -1,8 +1,8 @@
 package com.zeus.upload.service;
 
 import com.zeus.upload.domain.ColumnProposal;
+import com.zeus.upload.sql.SqlDialect;
 import com.zeus.upload.util.ColumnNameSanitizer;
-import com.zeus.upload.util.Db2IdentifierUtil;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -13,14 +13,14 @@ import org.springframework.stereotype.Service;
 public class DdlService {
 
     private final ColumnNameSanitizer columnNameSanitizer;
+    private final SqlDialect sqlDialect;
 
-    public DdlService(ColumnNameSanitizer columnNameSanitizer) {
+    public DdlService(ColumnNameSanitizer columnNameSanitizer, SqlDialect sqlDialect) {
         this.columnNameSanitizer = columnNameSanitizer;
+        this.sqlDialect = sqlDialect;
     }
 
     public String createTableSql(String library, String table, List<ColumnProposal> columns) {
-        String lib = Db2IdentifierUtil.sanitizeIdentifier(library);
-        String tbl = Db2IdentifierUtil.sanitizeIdentifier(table);
         List<String> definitions = new ArrayList<>();
         Set<String> used = new HashSet<>();
 
@@ -31,24 +31,26 @@ public class DdlService {
                     ColumnNameSanitizer.MAX_COLUMN_LENGTH
             );
             column.setFinalName(finalName);
-            definitions.add(finalName + " " + resolveTypeDefinition(column) + (column.isNullable() ? "" : " NOT NULL"));
+            definitions.add(sqlDialect.quoteIdentifier(finalName) + " "
+                    + resolveTypeDefinition(column)
+                    + (column.isNullable() ? "" : " NOT NULL"));
         }
 
-        return "CREATE TABLE " + lib + "." + tbl + " (" + String.join(", ", definitions) + ")";
+        return "CREATE TABLE " + sqlDialect.qualifyTable(library, table) + " (" + String.join(", ", definitions) + ")";
     }
 
     public String dropTableSql(String library, String table) {
-        String lib = Db2IdentifierUtil.sanitizeIdentifier(library);
-        String tbl = Db2IdentifierUtil.sanitizeIdentifier(table);
-        return "DROP TABLE " + lib + "." + tbl;
+        return "DROP TABLE " + sqlDialect.qualifyTable(library, table);
     }
 
     public String insertSql(String library, String table, List<ColumnProposal> columns) {
-        String lib = Db2IdentifierUtil.sanitizeIdentifier(library);
-        String tbl = Db2IdentifierUtil.sanitizeIdentifier(table);
-        List<String> names = columns.stream().map(ColumnProposal::getFinalName).toList();
+        List<String> names = columns.stream()
+                .map(ColumnProposal::getFinalName)
+                .map(sqlDialect::quoteIdentifier)
+                .toList();
         String placeholders = String.join(", ", columns.stream().map(c -> "?").toList());
-        return "INSERT INTO " + lib + "." + tbl + " (" + String.join(", ", names) + ") VALUES (" + placeholders + ")";
+        return "INSERT INTO " + sqlDialect.qualifyTable(library, table)
+                + " (" + String.join(", ", names) + ") VALUES (" + placeholders + ")";
     }
 
     private String resolveTypeDefinition(ColumnProposal column) {

--- a/src/main/java/com/zeus/upload/service/ImportService.java
+++ b/src/main/java/com/zeus/upload/service/ImportService.java
@@ -8,7 +8,7 @@ import com.zeus.upload.domain.ImportRequest;
 import com.zeus.upload.domain.ImportResult;
 import com.zeus.upload.domain.ParseError;
 import com.zeus.upload.domain.ParsedCsv;
-import com.zeus.upload.util.Db2IdentifierUtil;
+import com.zeus.upload.sql.SqlDialect;
 import java.math.BigDecimal;
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
@@ -40,17 +40,20 @@ public class ImportService {
     private final DdlService ddlService;
     private final TypeInferenceService typeInferenceService;
     private final AppProperties appProperties;
+    private final SqlDialect sqlDialect;
 
     public ImportService(
             DataSource dataSource,
             DdlService ddlService,
             TypeInferenceService typeInferenceService,
-            AppProperties appProperties
+            AppProperties appProperties,
+            SqlDialect sqlDialect
     ) {
         this.dataSource = dataSource;
         this.ddlService = ddlService;
         this.typeInferenceService = typeInferenceService;
         this.appProperties = appProperties;
+        this.sqlDialect = sqlDialect;
     }
 
     public ImportResult importCsv(ImportRequest request, ParsedCsv parsedCsv) {
@@ -142,14 +145,12 @@ public class ImportService {
     }
 
     String buildInsertSql(String library, String tableName, List<ColumnMapping> mappings) {
-        String lib = Db2IdentifierUtil.sanitizeIdentifier(library);
-        String tbl = Db2IdentifierUtil.sanitizeIdentifier(tableName);
         List<String> targetColumns = mappings.stream()
                 .map(ColumnMapping::getTargetColumn)
-                .map(Db2IdentifierUtil::sanitizeIdentifier)
+                .map(sqlDialect::quoteIdentifier)
                 .toList();
         String placeholders = String.join(", ", mappings.stream().map(m -> "?").toList());
-        return "INSERT INTO " + lib + "." + tbl
+        return "INSERT INTO " + sqlDialect.qualifyTable(library, tableName)
                 + " (" + String.join(", ", targetColumns) + ") VALUES (" + placeholders + ")";
     }
 

--- a/src/main/java/com/zeus/upload/sql/Db2iDialect.java
+++ b/src/main/java/com/zeus/upload/sql/Db2iDialect.java
@@ -1,0 +1,17 @@
+package com.zeus.upload.sql;
+
+import com.zeus.upload.util.Db2IdentifierUtil;
+
+public class Db2iDialect implements SqlDialect {
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        String sanitized = Db2IdentifierUtil.sanitizeIdentifier(identifier);
+        return "\"" + sanitized.replace("\"", "\"\"") + "\"";
+    }
+
+    @Override
+    public String qualifyTable(String libraryOrSchema, String table) {
+        return quoteIdentifier(libraryOrSchema) + "." + quoteIdentifier(table);
+    }
+}

--- a/src/main/java/com/zeus/upload/sql/H2Dialect.java
+++ b/src/main/java/com/zeus/upload/sql/H2Dialect.java
@@ -1,0 +1,17 @@
+package com.zeus.upload.sql;
+
+import com.zeus.upload.util.Db2IdentifierUtil;
+
+public class H2Dialect implements SqlDialect {
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        String sanitized = Db2IdentifierUtil.sanitizeIdentifier(identifier);
+        return "\"" + sanitized.replace("\"", "\"\"") + "\"";
+    }
+
+    @Override
+    public String qualifyTable(String libraryOrSchema, String table) {
+        return quoteIdentifier(libraryOrSchema) + "." + quoteIdentifier(table);
+    }
+}

--- a/src/main/java/com/zeus/upload/sql/SqlDialect.java
+++ b/src/main/java/com/zeus/upload/sql/SqlDialect.java
@@ -1,0 +1,8 @@
+package com.zeus.upload.sql;
+
+public interface SqlDialect {
+
+    String quoteIdentifier(String identifier);
+
+    String qualifyTable(String libraryOrSchema, String table);
+}

--- a/src/test/java/com/zeus/upload/it/H2ImportIntegrationTest.java
+++ b/src/test/java/com/zeus/upload/it/H2ImportIntegrationTest.java
@@ -1,0 +1,172 @@
+package com.zeus.upload.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.domain.ColumnMapping;
+import com.zeus.upload.domain.DbColumnMeta;
+import com.zeus.upload.domain.ImportRequest;
+import com.zeus.upload.domain.ImportResult;
+import com.zeus.upload.domain.MappingValidationResult;
+import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.service.CsvParsingService;
+import com.zeus.upload.service.ImportService;
+import com.zeus.upload.service.MappingService;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class H2ImportIntegrationTest {
+
+    private static final String LIBRARY = "TESTLIB";
+
+    @Autowired
+    private CsvParsingService csvParsingService;
+
+    @Autowired
+    private ImportService importService;
+
+    @Autowired
+    private MappingService mappingService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void shouldImportCsvByCreatingTableRoundTrip() throws IOException {
+        jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS \"TESTLIB\"");
+        ParsedCsv parsedCsv = parseSampleCsv();
+
+        ImportRequest request = new ImportRequest();
+        request.setLibrary(LIBRARY);
+        request.setTableName("H2_CREATE_IMPORT_IT");
+        request.setColumns(new ArrayList<>(parsedCsv.getProposals()));
+
+        ImportResult result = importService.importCsv(request, parsedCsv);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getInsertedRows()).isEqualTo(parsedCsv.getRows().size());
+
+        Integer rowCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM \"TESTLIB\".\"H2_CREATE_IMPORT_IT\"",
+                Integer.class
+        );
+        String name = jdbcTemplate.queryForObject(
+                "SELECT \"NAME\" FROM \"TESTLIB\".\"H2_CREATE_IMPORT_IT\" WHERE \"ID\" = 1",
+                String.class
+        );
+        assertThat(rowCount).isEqualTo(3);
+        assertThat(name).isEqualTo("Alice");
+    }
+
+    @Test
+    void shouldImportIntoExistingTableUsingMappingsRoundTrip() throws IOException {
+        jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS \"TESTLIB\"");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS \"TESTLIB\".\"H2_EXISTING_IMPORT_IT\"");
+        jdbcTemplate.execute("""
+                CREATE TABLE "TESTLIB"."H2_EXISTING_IMPORT_IT" (
+                  "ID" INTEGER NOT NULL,
+                  "NAME" VARCHAR(128) NOT NULL,
+                  "SOURCE" VARCHAR(20) NOT NULL DEFAULT 'CSV'
+                )
+                """);
+
+        ParsedCsv parsedCsv = parseSampleCsv();
+        List<DbColumnMeta> dbColumns = List.of(
+                new DbColumnMeta("ID", "INTEGER", java.sql.Types.INTEGER, 10, 10, 0, false, null, 1),
+                new DbColumnMeta("NAME", "VARCHAR", java.sql.Types.VARCHAR, 128, 128, 0, false, null, 2),
+                new DbColumnMeta("SOURCE", "VARCHAR", java.sql.Types.VARCHAR, 20, 20, 0, false, "'CSV'", 3)
+        );
+
+        List<ColumnMapping> mappings = mappingsForHeaders(parsedCsv.getOriginalHeaders());
+        MappingValidationResult validationResult = mappingService.validate(parsedCsv, dbColumns, mappings);
+        assertThat(validationResult.isValid()).isTrue();
+
+        ImportResult result = importService.importIntoExistingTable(
+                LIBRARY,
+                "H2_EXISTING_IMPORT_IT",
+                parsedCsv,
+                dbColumns,
+                mappings
+        );
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getInsertedRows()).isEqualTo(3);
+
+        Integer rowCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM \"TESTLIB\".\"H2_EXISTING_IMPORT_IT\"",
+                Integer.class
+        );
+        String source = jdbcTemplate.queryForObject(
+                "SELECT \"SOURCE\" FROM \"TESTLIB\".\"H2_EXISTING_IMPORT_IT\" WHERE \"ID\" = 1",
+                String.class
+        );
+        assertThat(rowCount).isEqualTo(3);
+        assertThat(source).isEqualTo("CSV");
+    }
+
+    @Test
+    void shouldFailValidationWhenRequiredColumnWithoutDefaultIsNotMapped() {
+        ParsedCsv parsedCsv = new ParsedCsv();
+        parsedCsv.getOriginalHeaders().addAll(List.of("id", "name"));
+
+        List<DbColumnMeta> dbColumns = List.of(
+                new DbColumnMeta("ID", "INTEGER", java.sql.Types.INTEGER, 10, 10, 0, false, null, 1),
+                new DbColumnMeta("NAME", "VARCHAR", java.sql.Types.VARCHAR, 100, 100, 0, false, null, 2),
+                new DbColumnMeta("REQUIRED_NO_DEFAULT", "VARCHAR", java.sql.Types.VARCHAR, 100, 100, 0, false, null, 3)
+        );
+        List<ColumnMapping> mappings = List.of(
+                mapping(0, "id", "ID", false),
+                mapping(1, "name", "NAME", false)
+        );
+
+        MappingValidationResult validationResult = mappingService.validate(parsedCsv, dbColumns, mappings);
+
+        assertThat(validationResult.isValid()).isFalse();
+        assertThat(validationResult.getErrors()).anyMatch(error -> error.contains("REQUIRED_NO_DEFAULT"));
+    }
+
+    private ParsedCsv parseSampleCsv() throws IOException {
+        ClassPathResource resource = new ClassPathResource("examples/sample.csv");
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "sample.csv",
+                "text/csv",
+                resource.getInputStream()
+        );
+        return csvParsingService.parse(file);
+    }
+
+    private List<ColumnMapping> mappingsForHeaders(List<String> headers) {
+        List<ColumnMapping> mappings = new ArrayList<>();
+        for (int i = 0; i < headers.size(); i++) {
+            String header = headers.get(i);
+            String target = null;
+            if ("id".equalsIgnoreCase(header)) {
+                target = "ID";
+            }
+            if ("name".equalsIgnoreCase(header)) {
+                target = "NAME";
+            }
+            mappings.add(mapping(i, header, target, false));
+        }
+        return mappings;
+    }
+
+    private ColumnMapping mapping(int csvIndex, String csvColumn, String targetColumn, boolean ignored) {
+        ColumnMapping mapping = new ColumnMapping();
+        mapping.setCsvIndex(csvIndex);
+        mapping.setCsvColumn(csvColumn);
+        mapping.setTargetColumn(targetColumn);
+        mapping.setIgnored(ignored);
+        return mapping;
+    }
+}

--- a/src/test/java/com/zeus/upload/service/ExistingTableImportSqlTest.java
+++ b/src/test/java/com/zeus/upload/service/ExistingTableImportSqlTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 
 import com.zeus.upload.config.AppProperties;
 import com.zeus.upload.domain.ColumnMapping;
+import com.zeus.upload.sql.Db2iDialect;
 import java.util.List;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
@@ -15,7 +16,7 @@ class ExistingTableImportSqlTest {
     void shouldBuildInsertSqlWithMappedColumnOrder() {
         AppProperties properties = new AppProperties();
         DataSource dataSource = mock(DataSource.class);
-        ImportService importService = new ImportService(dataSource, null, null, properties);
+        ImportService importService = new ImportService(dataSource, null, null, properties, new Db2iDialect());
         List<ColumnMapping> mappings = List.of(
                 mapping(2, "amount", "AMOUNT"),
                 mapping(0, "id", "ID"),
@@ -24,7 +25,7 @@ class ExistingTableImportSqlTest {
 
         String sql = importService.buildInsertSql("bib", "orders", mappings);
 
-        assertThat(sql).isEqualTo("INSERT INTO BIB.ORDERS (AMOUNT, ID, CREATED_AT) VALUES (?, ?, ?)");
+        assertThat(sql).isEqualTo("INSERT INTO \"BIB\".\"ORDERS\" (\"AMOUNT\", \"ID\", \"CREATED_AT\") VALUES (?, ?, ?)");
     }
 
     private ColumnMapping mapping(int csvIndex, String csvColumn, String targetColumn) {

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:zeus_easy_upload_test;MODE=DB2;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=true
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  sql:
+    init:
+      mode: never


### PR DESCRIPTION
Adds H2 in-memory integration tests (create-table + existing-table import) and introduces a minimal SqlDialect abstraction for quoting/qualifying identifiers. Keeps DB2/400 production behavior unchanged.

Refs #38