### PR TITLE
feat: DB2/400 MERGE upsert for existing-table imports (closes #4)

### DIFF
--- a/src/main/java/com/zeus/upload/controller/UploadController.java
+++ b/src/main/java/com/zeus/upload/controller/UploadController.java
@@ -105,6 +105,8 @@ public class UploadController {
                 }
             }
             request.setColumns(copyColumns(parsed.getProposals()));
+            request.setUpsertEnabled(false);
+            request.setKeyColumns(List.of());
 
             if (useExistingTable && StringUtils.hasText(existingTableName)) {
                 List<DbColumnMeta> dbColumns = metadataService.listColumns(library, existingTableName);
@@ -114,14 +116,18 @@ public class UploadController {
                 previewContext.setMappings(copyMappings(mappings));
                 previewContext.setUseExistingTable(true);
                 previewContext.setExistingTableName(existingTableName.trim());
+                previewContext.setUpsertEnabled(false);
+                previewContext.setKeyColumns(List.of());
                 model.addAttribute("dbColumns", dbColumns);
                 model.addAttribute("mappings", mappings);
             } else {
                 request.setUseExistingTable(false);
                 previewContext.setUseExistingTable(false);
                 previewContext.setExistingTableName(null);
+                previewContext.setUpsertEnabled(false);
                 previewContext.setDbColumns(List.of());
                 previewContext.setMappings(List.of());
+                previewContext.setKeyColumns(List.of());
             }
 
             previewContext.setParsedCsv(parsed);
@@ -166,7 +172,9 @@ public class UploadController {
             MappingValidationResult validationResult = mappingService.validate(
                     previewContext.getParsedCsv(),
                     dbColumns,
-                    importRequest.getMappings()
+                    importRequest.getMappings(),
+                    importRequest.isUpsertEnabled(),
+                    importRequest.getKeyColumns()
             );
             if (!validationResult.isValid()) {
                 model.addAttribute("supportedTypes", SUPPORTED_TYPES);
@@ -178,13 +186,24 @@ public class UploadController {
                 return "preview";
             }
             model.addAttribute("mappingWarnings", validationResult.getWarnings());
-            result = importService.importIntoExistingTable(
-                    importRequest.getLibrary(),
-                    importRequest.getExistingTableName(),
-                    previewContext.getParsedCsv(),
-                    dbColumns,
-                    importRequest.getMappings()
-            );
+            if (importRequest.isUpsertEnabled()) {
+                result = importService.upsertIntoExistingTable(
+                        importRequest.getLibrary(),
+                        importRequest.getExistingTableName(),
+                        previewContext.getParsedCsv(),
+                        dbColumns,
+                        importRequest.getMappings(),
+                        importRequest.getKeyColumns()
+                );
+            } else {
+                result = importService.importIntoExistingTable(
+                        importRequest.getLibrary(),
+                        importRequest.getExistingTableName(),
+                        previewContext.getParsedCsv(),
+                        dbColumns,
+                        importRequest.getMappings()
+                );
+            }
         } else {
             result = importService.importCsv(importRequest, previewContext.getParsedCsv());
         }

--- a/src/main/java/com/zeus/upload/domain/ImportRequest.java
+++ b/src/main/java/com/zeus/upload/domain/ImportRequest.java
@@ -15,7 +15,9 @@ public class ImportRequest {
 
     private boolean dropAndRecreate;
     private boolean useExistingTable;
+    private boolean upsertEnabled;
     private String existingTableName;
+    private List<String> keyColumns = new ArrayList<>();
 
     @Valid
     private List<ColumnProposal> columns = new ArrayList<>();
@@ -59,6 +61,22 @@ public class ImportRequest {
 
     public void setExistingTableName(String existingTableName) {
         this.existingTableName = existingTableName;
+    }
+
+    public boolean isUpsertEnabled() {
+        return upsertEnabled;
+    }
+
+    public void setUpsertEnabled(boolean upsertEnabled) {
+        this.upsertEnabled = upsertEnabled;
+    }
+
+    public List<String> getKeyColumns() {
+        return keyColumns;
+    }
+
+    public void setKeyColumns(List<String> keyColumns) {
+        this.keyColumns = keyColumns == null ? new ArrayList<>() : new ArrayList<>(keyColumns);
     }
 
     public List<ColumnProposal> getColumns() {

--- a/src/main/java/com/zeus/upload/domain/PreviewContext.java
+++ b/src/main/java/com/zeus/upload/domain/PreviewContext.java
@@ -8,9 +8,11 @@ public class PreviewContext {
     private ParsedCsv parsedCsv;
     private String originalFilename;
     private boolean useExistingTable;
+    private boolean upsertEnabled;
     private String existingTableName;
     private List<DbColumnMeta> dbColumns = new ArrayList<>();
     private List<ColumnMapping> mappings = new ArrayList<>();
+    private List<String> keyColumns = new ArrayList<>();
 
     public ParsedCsv getParsedCsv() {
         return parsedCsv;
@@ -44,6 +46,14 @@ public class PreviewContext {
         this.existingTableName = existingTableName;
     }
 
+    public boolean isUpsertEnabled() {
+        return upsertEnabled;
+    }
+
+    public void setUpsertEnabled(boolean upsertEnabled) {
+        this.upsertEnabled = upsertEnabled;
+    }
+
     public List<DbColumnMeta> getDbColumns() {
         return dbColumns;
     }
@@ -58,5 +68,13 @@ public class PreviewContext {
 
     public void setMappings(List<ColumnMapping> mappings) {
         this.mappings = mappings;
+    }
+
+    public List<String> getKeyColumns() {
+        return keyColumns;
+    }
+
+    public void setKeyColumns(List<String> keyColumns) {
+        this.keyColumns = keyColumns == null ? new ArrayList<>() : new ArrayList<>(keyColumns);
     }
 }

--- a/src/main/java/com/zeus/upload/service/ImportService.java
+++ b/src/main/java/com/zeus/upload/service/ImportService.java
@@ -8,6 +8,7 @@ import com.zeus.upload.domain.ImportRequest;
 import com.zeus.upload.domain.ImportResult;
 import com.zeus.upload.domain.ParseError;
 import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.sql.MergeSqlBuilder;
 import com.zeus.upload.sql.SqlDialect;
 import java.math.BigDecimal;
 import java.sql.BatchUpdateException;
@@ -22,8 +23,10 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
@@ -41,6 +44,7 @@ public class ImportService {
     private final TypeInferenceService typeInferenceService;
     private final AppProperties appProperties;
     private final SqlDialect sqlDialect;
+    private final MergeSqlBuilder mergeSqlBuilder;
 
     public ImportService(
             DataSource dataSource,
@@ -54,6 +58,7 @@ public class ImportService {
         this.typeInferenceService = typeInferenceService;
         this.appProperties = appProperties;
         this.sqlDialect = sqlDialect;
+        this.mergeSqlBuilder = new MergeSqlBuilder(sqlDialect);
     }
 
     public ImportResult importCsv(ImportRequest request, ParsedCsv parsedCsv) {
@@ -141,6 +146,99 @@ public class ImportService {
         } catch (Exception ex) {
             errors.add(new ParseError(0, "", "", ex.getMessage()));
             return ImportResult.failure("Import failed: " + ex.getMessage(), insertSql, errors);
+        }
+    }
+
+    public ImportResult upsertIntoExistingTable(
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns
+    ) {
+        List<ParseError> errors = new ArrayList<>();
+        List<ColumnMapping> effectiveMappings = determineEffectiveMappings(mappings);
+        Set<String> knownColumns = toNormalizedColumnSet(dbColumns);
+        for (ColumnMapping mapping : effectiveMappings) {
+            String targetColumn = mapping.getTargetColumn();
+            if (!knownColumns.isEmpty() && !knownColumns.contains(normalizeColumnName(targetColumn))) {
+                errors.add(new ParseError(
+                        0,
+                        targetColumn,
+                        "",
+                        "Mapped target column does not exist in table metadata."
+                ));
+            }
+        }
+        if (effectiveMappings.isEmpty()) {
+            return ImportResult.failure(
+                    "No mapped columns selected for import.",
+                    "",
+                    List.of(new ParseError(0, "", "", "Map at least one CSV column to a target column."))
+            );
+        }
+
+        List<String> insertColumns = effectiveMappings.stream()
+                .map(ColumnMapping::getTargetColumn)
+                .toList();
+        List<String> effectiveKeys = normalizeSelectedKeys(keyColumns);
+        if (effectiveKeys.isEmpty()) {
+            return ImportResult.failure(
+                    "Upsert requires at least one key column.",
+                    "",
+                    List.of(new ParseError(0, "", "", "Select one or more key columns for MERGE upsert."))
+            );
+        }
+
+        Set<String> insertSet = toNormalizedStringColumnSet(insertColumns);
+        for (String key : effectiveKeys) {
+            if (!insertSet.contains(normalizeColumnName(key))) {
+                errors.add(new ParseError(
+                        0,
+                        key,
+                        "",
+                        "Key column must be mapped and not ignored for upsert."
+                ));
+            }
+        }
+        if (!errors.isEmpty()) {
+            return ImportResult.failure("Import aborted due to invalid upsert mapping.", "", errors);
+        }
+
+        List<String> updateColumns = insertColumns.stream()
+                .filter(column -> !containsNormalized(effectiveKeys, column))
+                .toList();
+        if (updateColumns.isEmpty()) {
+            return ImportResult.failure(
+                    "Upsert requires at least one non-key mapped column for update.",
+                    "",
+                    List.of(new ParseError(0, "", "", "Map at least one non-key column for upsert updates."))
+            );
+        }
+
+        String mergeSql;
+        try {
+            mergeSql = mergeSqlBuilder.buildDb2MergeSql(library, tableName, insertColumns, updateColumns, effectiveKeys);
+        } catch (IllegalArgumentException ex) {
+            return ImportResult.failure("Import aborted due to invalid upsert configuration.", "",
+                    List.of(new ParseError(0, "", "", ex.getMessage())));
+        }
+
+        try (Connection connection = dataSource.getConnection()) {
+            connection.setAutoCommit(false);
+            int processedRows = executeMergeRows(connection, mergeSql, effectiveMappings, insertColumns, csv.getRows(), errors);
+            if (!errors.isEmpty()) {
+                connection.rollback();
+                throw new ImportException("Import aborted due to upsert errors", errors);
+            }
+            connection.commit();
+            return ImportResult.success("Upsert successful", mergeSql, processedRows);
+        } catch (ImportException ex) {
+            return ImportResult.failure(ex.getMessage(), mergeSql, ex.getErrors());
+        } catch (Exception ex) {
+            errors.add(new ParseError(0, "", "", ex.getMessage()));
+            return ImportResult.failure("Import failed: " + ex.getMessage(), mergeSql, errors);
         }
     }
 
@@ -282,6 +380,38 @@ public class ImportService {
         return inserted;
     }
 
+    private int executeMergeRows(
+            Connection connection,
+            String mergeSql,
+            List<ColumnMapping> mappings,
+            List<String> insertColumns,
+            List<List<String>> rows,
+            List<ParseError> errors
+    ) throws SQLException {
+        int processedRows = 0;
+        Map<String, Integer> csvIndexesByColumn = csvIndexByTargetColumn(mappings);
+        String firstTarget = insertColumns.isEmpty() ? "" : insertColumns.get(0);
+
+        try (PreparedStatement statement = connection.prepareStatement(mergeSql)) {
+            for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
+                List<String> row = rows.get(rowIndex);
+                try {
+                    bindMergeRow(statement, insertColumns, csvIndexesByColumn, row);
+                    statement.executeUpdate();
+                    processedRows++;
+                } catch (Exception ex) {
+                    errors.add(new ParseError(
+                            rowIndex + 2L,
+                            firstTarget,
+                            "",
+                            ex.getMessage()
+                    ));
+                }
+            }
+        }
+        return processedRows;
+    }
+
     private void bindMappedRow(PreparedStatement statement, List<ColumnMapping> mappings, List<String> row) throws SQLException {
         statement.clearParameters();
         for (int mappingIndex = 0; mappingIndex < mappings.size(); mappingIndex++) {
@@ -293,6 +423,26 @@ public class ImportService {
                 statement.setNull(mappingIndex + 1, Types.VARCHAR);
             } else {
                 statement.setString(mappingIndex + 1, trimmed);
+            }
+        }
+    }
+
+    private void bindMergeRow(
+            PreparedStatement statement,
+            List<String> insertColumns,
+            Map<String, Integer> csvIndexesByColumn,
+            List<String> row
+    ) throws SQLException {
+        statement.clearParameters();
+        for (int parameterIndex = 0; parameterIndex < insertColumns.size(); parameterIndex++) {
+            String insertColumn = insertColumns.get(parameterIndex);
+            Integer csvIndex = csvIndexesByColumn.get(normalizeColumnName(insertColumn));
+            String value = (csvIndex == null || csvIndex >= row.size()) ? null : row.get(csvIndex);
+            String trimmed = value == null ? null : value.trim();
+            if (!StringUtils.hasText(trimmed)) {
+                statement.setNull(parameterIndex + 1, Types.VARCHAR);
+            } else {
+                statement.setString(parameterIndex + 1, trimmed);
             }
         }
     }
@@ -310,6 +460,35 @@ public class ImportService {
         }
         effective.sort(Comparator.comparingInt(ColumnMapping::getCsvIndex));
         return effective;
+    }
+
+    private List<String> normalizeSelectedKeys(List<String> keyColumns) {
+        List<String> normalized = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        if (keyColumns == null) {
+            return normalized;
+        }
+        for (String key : keyColumns) {
+            if (!StringUtils.hasText(key)) {
+                continue;
+            }
+            String trimmed = key.trim();
+            String normalizedName = normalizeColumnName(trimmed);
+            if (seen.add(normalizedName)) {
+                normalized.add(trimmed);
+            }
+        }
+        return normalized;
+    }
+
+    private boolean containsNormalized(List<String> values, String candidate) {
+        String normalizedCandidate = normalizeColumnName(candidate);
+        for (String value : values) {
+            if (normalizeColumnName(value).equals(normalizedCandidate)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void bindValue(PreparedStatement statement, int parameterIndex, ColumnProposal column, String rawValue)
@@ -368,6 +547,31 @@ public class ImportService {
             }
         }
         return names;
+    }
+
+    private Set<String> toNormalizedStringColumnSet(List<String> columns) {
+        Set<String> names = new HashSet<>();
+        if (columns == null) {
+            return names;
+        }
+        for (String column : columns) {
+            if (StringUtils.hasText(column)) {
+                names.add(normalizeColumnName(column));
+            }
+        }
+        return names;
+    }
+
+    private Map<String, Integer> csvIndexByTargetColumn(List<ColumnMapping> mappings) {
+        Map<String, Integer> mappingByColumn = new LinkedHashMap<>();
+        for (ColumnMapping mapping : mappings) {
+            String targetColumn = mapping.getTargetColumn();
+            if (!StringUtils.hasText(targetColumn)) {
+                continue;
+            }
+            mappingByColumn.put(normalizeColumnName(targetColumn), mapping.getCsvIndex());
+        }
+        return mappingByColumn;
     }
 
     private String normalizeColumnName(String value) {

--- a/src/main/java/com/zeus/upload/service/MappingService.java
+++ b/src/main/java/com/zeus/upload/service/MappingService.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -58,17 +59,29 @@ public class MappingService {
     }
 
     public MappingValidationResult validate(ParsedCsv csv, List<DbColumnMeta> dbColumns, List<ColumnMapping> mappings) {
+        return validate(csv, dbColumns, mappings, false, List.of());
+    }
+
+    public MappingValidationResult validate(
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            boolean upsertEnabled,
+            List<String> keyColumns
+    ) {
         MappingValidationResult result = new MappingValidationResult();
         List<ColumnMapping> safeMappings = mappings == null ? List.of() : mappings;
         List<DbColumnMeta> safeDbColumns = dbColumns == null ? List.of() : dbColumns;
 
         Set<String> existingColumns = new HashSet<>();
+        Map<String, DbColumnMeta> byNormalizedName = new HashMap<>();
         for (DbColumnMeta dbColumn : safeDbColumns) {
             if (!StringUtils.hasText(dbColumn.getColumnName())) {
                 continue;
             }
             String key = normalizeDbKey(dbColumn.getColumnName());
             existingColumns.add(key);
+            byNormalizedName.put(key, dbColumn);
         }
 
         Set<String> mappedDbColumns = new HashSet<>();
@@ -127,6 +140,37 @@ public class MappingService {
         for (int i = 0; i < headers.size(); i++) {
             if (!mappedCsvIndexes.contains(i) && !ignoredCsvIndexes.contains(i) && !warnedUnmappedCsvIndexes.contains(i)) {
                 result.getWarnings().add("CSV column '" + headers.get(i) + "' is unmapped.");
+            }
+        }
+
+        if (upsertEnabled) {
+            Set<String> normalizedKeys = new LinkedHashSet<>();
+            List<String> safeKeyColumns = keyColumns == null ? List.of() : keyColumns;
+            for (String keyColumn : safeKeyColumns) {
+                if (!StringUtils.hasText(keyColumn)) {
+                    continue;
+                }
+                normalizedKeys.add(normalizeDbKey(keyColumn));
+            }
+            if (normalizedKeys.isEmpty()) {
+                result.getErrors().add("At least one key column is required for upsert mode.");
+            } else {
+                for (String normalizedKey : normalizedKeys) {
+                    if (!existingColumns.contains(normalizedKey)) {
+                        result.getErrors().add("Key column '" + normalizedKey + "' does not exist in table metadata.");
+                        continue;
+                    }
+                    if (!mappedDbColumns.contains(normalizedKey)) {
+                        result.getErrors().add("Key column '" + normalizedKey + "' must be mapped and not ignored.");
+                        continue;
+                    }
+                    DbColumnMeta keyMeta = byNormalizedName.get(normalizedKey);
+                    if (keyMeta != null && keyMeta.isNullable()) {
+                        result.getWarnings().add(
+                                "Key column '" + keyMeta.getColumnName() + "' is nullable; NOT NULL keys are recommended."
+                        );
+                    }
+                }
             }
         }
 

--- a/src/main/java/com/zeus/upload/sql/MergeSqlBuilder.java
+++ b/src/main/java/com/zeus/upload/sql/MergeSqlBuilder.java
@@ -1,0 +1,85 @@
+package com.zeus.upload.sql;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.util.StringUtils;
+
+public class MergeSqlBuilder {
+
+    private final SqlDialect sqlDialect;
+
+    public MergeSqlBuilder(SqlDialect sqlDialect) {
+        this.sqlDialect = sqlDialect;
+    }
+
+    public String buildDb2MergeSql(
+            String library,
+            String table,
+            List<String> insertColumns,
+            List<String> updateColumns,
+            List<String> keyColumns
+    ) {
+        List<String> safeInsertColumns = normalizeColumns(insertColumns);
+        List<String> safeUpdateColumns = normalizeColumns(updateColumns);
+        List<String> safeKeyColumns = normalizeColumns(keyColumns);
+
+        if (!StringUtils.hasText(library) || !StringUtils.hasText(table)) {
+            throw new IllegalArgumentException("Library and table are required for MERGE.");
+        }
+        if (safeInsertColumns.isEmpty()) {
+            throw new IllegalArgumentException("At least one insert column is required for MERGE.");
+        }
+        if (safeKeyColumns.isEmpty()) {
+            throw new IllegalArgumentException("At least one key column is required for MERGE.");
+        }
+        if (safeUpdateColumns.isEmpty()) {
+            throw new IllegalArgumentException("At least one non-key update column is required for MERGE.");
+        }
+
+        Set<String> insertColumnSet = new LinkedHashSet<>(safeInsertColumns);
+        if (insertColumnSet.size() != safeInsertColumns.size()) {
+            throw new IllegalArgumentException("Insert columns must be unique.");
+        }
+        if (!insertColumnSet.containsAll(safeKeyColumns)) {
+            throw new IllegalArgumentException("All key columns must be part of insert columns.");
+        }
+        if (!insertColumnSet.containsAll(safeUpdateColumns)) {
+            throw new IllegalArgumentException("All update columns must be part of insert columns.");
+        }
+
+        String qualifiedTable = sqlDialect.qualifyTable(library, table);
+        String valuePlaceholders = String.join(", ", safeInsertColumns.stream().map(c -> "?").toList());
+        String sourceColumns = String.join(", ", safeInsertColumns.stream().map(sqlDialect::quoteIdentifier).toList());
+        String onClause = String.join(" AND ", safeKeyColumns.stream()
+                .map(column -> "T." + sqlDialect.quoteIdentifier(column) + " = S." + sqlDialect.quoteIdentifier(column))
+                .toList());
+        String updateClause = String.join(", ", safeUpdateColumns.stream()
+                .map(column -> "T." + sqlDialect.quoteIdentifier(column) + " = S." + sqlDialect.quoteIdentifier(column))
+                .toList());
+        String insertColumnsClause = String.join(", ", safeInsertColumns.stream().map(sqlDialect::quoteIdentifier).toList());
+        String insertValuesClause = String.join(", ", safeInsertColumns.stream()
+                .map(column -> "S." + sqlDialect.quoteIdentifier(column))
+                .toList());
+
+        return "MERGE INTO " + qualifiedTable + " AS T "
+                + "USING (VALUES (" + valuePlaceholders + ")) AS S(" + sourceColumns + ") "
+                + "ON (" + onClause + ") "
+                + "WHEN MATCHED THEN UPDATE SET " + updateClause + " "
+                + "WHEN NOT MATCHED THEN INSERT (" + insertColumnsClause + ") VALUES (" + insertValuesClause + ")";
+    }
+
+    private List<String> normalizeColumns(List<String> columns) {
+        List<String> normalized = new ArrayList<>();
+        if (columns == null) {
+            return normalized;
+        }
+        for (String column : columns) {
+            if (StringUtils.hasText(column)) {
+                normalized.add(column.trim());
+            }
+        }
+        return normalized;
+    }
+}

--- a/src/main/resources/templates/preview.html
+++ b/src/main/resources/templates/preview.html
@@ -63,6 +63,24 @@
                         </div>
                     </div>
                 </div>
+                <div class="row" th:if="${importRequest.useExistingTable}">
+                    <div class="col-md-4 mb-3">
+                        <div class="form-check mt-1">
+                            <input class="form-check-input" type="checkbox" th:field="*{upsertEnabled}">
+                            <label class="form-check-label">Upsert (MERGE) instead of INSERT</label>
+                        </div>
+                    </div>
+                    <div class="col-md-8 mb-3">
+                        <label class="form-label">Key Columns</label>
+                        <input type="hidden" name="keyColumns" value="">
+                        <select class="form-select" th:field="*{keyColumns}" multiple size="6">
+                            <option th:each="dbColumn : ${dbColumns}"
+                                    th:value="${dbColumn.columnName}"
+                                    th:text="${dbColumn.columnName + (dbColumn.nullable ? ' (nullable)' : '')}"></option>
+                        </select>
+                        <div class="form-text">Keys must uniquely identify a row.</div>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -215,7 +233,8 @@
         </div>
 
         <button th:if="${!importRequest.useExistingTable}" type="submit" class="btn btn-success">Create Table and Import</button>
-        <button th:if="${importRequest.useExistingTable}" type="submit" class="btn btn-success">Import Into Existing Table</button>
+        <button th:if="${importRequest.useExistingTable}" type="submit" class="btn btn-success"
+                th:text="${importRequest.upsertEnabled} ? 'Upsert Into Existing Table' : 'Import Into Existing Table'">Import Into Existing Table</button>
     </form>
 </div>
 </body>

--- a/src/test/java/com/zeus/upload/it/H2ImportIntegrationTest.java
+++ b/src/test/java/com/zeus/upload/it/H2ImportIntegrationTest.java
@@ -14,6 +14,7 @@ import com.zeus.upload.service.MappingService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -132,6 +133,46 @@ class H2ImportIntegrationTest {
 
         assertThat(validationResult.isValid()).isFalse();
         assertThat(validationResult.getErrors()).anyMatch(error -> error.contains("REQUIRED_NO_DEFAULT"));
+    }
+
+    @Test
+    @Disabled("H2 MODE=DB2 does not reliably support DB2 for i MERGE ... USING (VALUES ...) syntax.")
+    void shouldExecuteDb2StyleMergeSqlAgainstH2() {
+        jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS \"TESTLIB\"");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS \"TESTLIB\".\"H2_MERGE_IT\"");
+        jdbcTemplate.execute("""
+                CREATE TABLE "TESTLIB"."H2_MERGE_IT" (
+                  "ID" INTEGER NOT NULL PRIMARY KEY,
+                  "NAME" VARCHAR(128) NOT NULL
+                )
+                """);
+        jdbcTemplate.execute("INSERT INTO \"TESTLIB\".\"H2_MERGE_IT\" (\"ID\", \"NAME\") VALUES (1, 'Old')");
+
+        jdbcTemplate.update("""
+                MERGE INTO "TESTLIB"."H2_MERGE_IT" AS T
+                USING (VALUES (?, ?)) AS S("ID", "NAME")
+                ON (T."ID" = S."ID")
+                WHEN MATCHED THEN UPDATE SET T."NAME" = S."NAME"
+                WHEN NOT MATCHED THEN INSERT ("ID", "NAME") VALUES (S."ID", S."NAME")
+                """, 1, "Updated");
+        jdbcTemplate.update("""
+                MERGE INTO "TESTLIB"."H2_MERGE_IT" AS T
+                USING (VALUES (?, ?)) AS S("ID", "NAME")
+                ON (T."ID" = S."ID")
+                WHEN MATCHED THEN UPDATE SET T."NAME" = S."NAME"
+                WHEN NOT MATCHED THEN INSERT ("ID", "NAME") VALUES (S."ID", S."NAME")
+                """, 2, "Inserted");
+
+        Integer rowCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM \"TESTLIB\".\"H2_MERGE_IT\"",
+                Integer.class
+        );
+        String updatedName = jdbcTemplate.queryForObject(
+                "SELECT \"NAME\" FROM \"TESTLIB\".\"H2_MERGE_IT\" WHERE \"ID\" = 1",
+                String.class
+        );
+        assertThat(rowCount).isEqualTo(2);
+        assertThat(updatedName).isEqualTo("Updated");
     }
 
     private ParsedCsv parseSampleCsv() throws IOException {

--- a/src/test/java/com/zeus/upload/service/MappingServiceTest.java
+++ b/src/test/java/com/zeus/upload/service/MappingServiceTest.java
@@ -95,6 +95,42 @@ class MappingServiceTest {
         assertThat(result.getWarnings()).anyMatch(warning -> warning.contains("CSV column 'first' is unmapped"));
     }
 
+    @Test
+    void shouldFailUpsertValidationWhenNoKeyColumnsProvided() {
+        ParsedCsv csv = parsedCsvWithHeaders("id", "name");
+        List<DbColumnMeta> dbColumns = List.of(
+                dbColumn("ID", false, null),
+                dbColumn("NAME", true, null)
+        );
+        List<ColumnMapping> mappings = List.of(
+                mapping(0, "id", "ID", false),
+                mapping(1, "name", "NAME", false)
+        );
+
+        MappingValidationResult result = service.validate(csv, dbColumns, mappings, true, List.of());
+
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getErrors()).anyMatch(error -> error.contains("At least one key column"));
+    }
+
+    @Test
+    void shouldFailUpsertValidationWhenKeyColumnIsNotMapped() {
+        ParsedCsv csv = parsedCsvWithHeaders("id", "name");
+        List<DbColumnMeta> dbColumns = List.of(
+                dbColumn("ID", false, null),
+                dbColumn("NAME", true, null)
+        );
+        List<ColumnMapping> mappings = List.of(
+                mapping(0, "id", "", false),
+                mapping(1, "name", "NAME", false)
+        );
+
+        MappingValidationResult result = service.validate(csv, dbColumns, mappings, true, List.of("ID"));
+
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getErrors()).anyMatch(error -> error.contains("must be mapped"));
+    }
+
     private ParsedCsv parsedCsvWithHeaders(String... headers) {
         ParsedCsv csv = new ParsedCsv();
         csv.getOriginalHeaders().addAll(List.of(headers));

--- a/src/test/java/com/zeus/upload/sql/MergeSqlBuilderTest.java
+++ b/src/test/java/com/zeus/upload/sql/MergeSqlBuilderTest.java
@@ -1,0 +1,61 @@
+package com.zeus.upload.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MergeSqlBuilderTest {
+
+    @Test
+    void shouldBuildDeterministicDb2MergeSql() {
+        MergeSqlBuilder builder = new MergeSqlBuilder(new Db2iDialect());
+
+        String sql = builder.buildDb2MergeSql(
+                "bib",
+                "orders",
+                List.of("ID", "NAME", "AMOUNT"),
+                List.of("NAME", "AMOUNT"),
+                List.of("ID")
+        );
+
+        assertThat(sql).isEqualTo(
+                "MERGE INTO \"BIB\".\"ORDERS\" AS T "
+                        + "USING (VALUES (?, ?, ?)) AS S(\"ID\", \"NAME\", \"AMOUNT\") "
+                        + "ON (T.\"ID\" = S.\"ID\") "
+                        + "WHEN MATCHED THEN UPDATE SET T.\"NAME\" = S.\"NAME\", T.\"AMOUNT\" = S.\"AMOUNT\" "
+                        + "WHEN NOT MATCHED THEN INSERT (\"ID\", \"NAME\", \"AMOUNT\") VALUES (S.\"ID\", S.\"NAME\", S.\"AMOUNT\")"
+        );
+    }
+
+    @Test
+    void shouldUseAllKeyColumnsInOnClause() {
+        MergeSqlBuilder builder = new MergeSqlBuilder(new Db2iDialect());
+
+        String sql = builder.buildDb2MergeSql(
+                "bib",
+                "orders",
+                List.of("ID", "TENANT", "NAME"),
+                List.of("NAME"),
+                List.of("ID", "TENANT")
+        );
+
+        assertThat(sql).contains("ON (T.\"ID\" = S.\"ID\" AND T.\"TENANT\" = S.\"TENANT\")");
+        assertThat(sql).contains("UPDATE SET T.\"NAME\" = S.\"NAME\"");
+    }
+
+    @Test
+    void shouldRejectMergeWithoutUpdateColumns() {
+        MergeSqlBuilder builder = new MergeSqlBuilder(new Db2iDialect());
+
+        assertThatThrownBy(() -> builder.buildDb2MergeSql(
+                "bib",
+                "orders",
+                List.of("ID"),
+                List.of(),
+                List.of("ID")
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("non-key update column");
+    }
+}


### PR DESCRIPTION
Adds optional upsert mode for existing-table imports using DB2/400 MERGE with user-selected key columns. Includes MergeSqlBuilder tests and validation updates.

Closes #4