### PR TITLE
feat: introduce connector architecture foundation and update roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# zeus-easy-upload
+﻿# zeus-easy-upload
 
 Spring-Boot-Webanwendung zum Import beliebiger CSV-Dateien in IBM i DB2/400 Tabellen.
 
@@ -13,9 +13,41 @@ Version 1 Fokus:
 
 - `controller`: Web-Flow (`/`, `/upload`, `/import`)
 - `service`: CSV-Parsing, Typinferenz, DDL und Import
+- `connector`: Source-/Target-Adapter fuer Datenfluesse
+- `flow`: neutrales Record- und Flow-Modell
 - `domain`: Request/Result/Fehlermodelle
-- `util`: Identifier- und Spaltensanitizing für AS400-Regeln
+- `util`: Identifier- und Spaltensanitizing fÃ¼r AS400-Regeln
 - `config`: Konfigurationseigenschaften (`app.*`)
+
+## Connector Architecture
+
+`zeus-easy-upload` entwickelt sich schrittweise von einem CSV->DB Tool zu einem allgemeinen Datenfluss-Werkzeug mit mehreren Connectoren.
+
+Aktueller First-Class-Flow:
+
+- CSV -> DB table
+
+Minimale Architektur in der aktuellen Iteration:
+
+- `SourceConnector -> DataFlow -> TargetConnector`
+- `CsvSourceConnector` liest das bereits bewaehrte `ParsedCsv`
+- `DbTableTargetConnector` delegiert weiterhin an die bestehende `ImportService`-Logik
+
+Wichtig:
+
+- die bestehende CSV->DB Funktionalitaet bleibt erhalten
+- vorhandene Services fuer Parsing, Mapping, Metadata und Import bleiben das Rueckgrat der Implementierung
+- die Connector-Abstraktion ist bewusst inkrementell und noch kein Plugin-System
+
+Geplante naechste Connector-Richtungen:
+
+- DB source
+- CSV export / target
+- FTP
+- SFTP
+- REST
+- filesystem
+- cloud/object storage
 
 ## Voraussetzungen
 
@@ -54,9 +86,9 @@ app:
 
 - Schema entspricht `Library`.
 - SQL arbeitet mit `LIB.TABLE`.
-- Identifier werden in Großbuchstaben normalisiert.
+- Identifier werden in GroÃŸbuchstaben normalisiert.
 - Spaltennamen werden auf `A-Z0-9_` reduziert.
-- Spaltenlänge wird auf 10 Zeichen begrenzt (Trunkierung + Hash-Suffix).
+- SpaltenlÃ¤nge wird auf 10 Zeichen begrenzt (Trunkierung + Hash-Suffix).
 - Leere Strings werden als `NULL` gespeichert.
 
 ## Starten
@@ -71,7 +103,7 @@ Anwendung: `http://localhost:8080`
 ## Nutzung
 
 1. CSV hochladen, Library und Tabellenname eingeben.
-2. Vorschau prüfen und Typen/Parameter bei Bedarf anpassen.
+2. Vorschau prÃ¼fen und Typen/Parameter bei Bedarf anpassen.
 3. Import starten.
 4. Ergebnisseite zeigt DDL, Anzahl Zeilen und detaillierte Fehlerliste.
 
@@ -86,10 +118,10 @@ Erkannte Zieltypen:
 - `VARCHAR(n)`
 
 Regeln:
-- Analyse über maximal `app.sample-rows` Zeilen (Default: 200)
+- Analyse Ã¼ber maximal `app.sample-rows` Zeilen (Default: 200)
 - Datum: `yyyy-MM-dd`, `dd.MM.yyyy`, `dd/MM/yyyy`
 - Timestamp: `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd'T'HH:mm:ss`
-- `VARCHAR(n)`: Max-Länge + 10%, Minimum 32, Maximum 4000
+- `VARCHAR(n)`: Max-LÃ¤nge + 10%, Minimum 32, Maximum 4000
 
 ## Beispiel-CSV
 
@@ -103,7 +135,7 @@ Enthaltene Unit-Tests:
 - `DecimalDetectionTest`
 - `DateParsingTest`
 
-Ausführen:
+AusfÃ¼hren:
 
 ```bash
 mvn test
@@ -111,7 +143,7 @@ mvn test
 
 ## Screenshots
 
-Optional: Screenshots von `index`, `preview`, `result` können später ergänzt werden.
+Optional: Screenshots von `index`, `preview`, `result` kÃ¶nnen spÃ¤ter ergÃ¤nzt werden.
 
 ## Erweiterbarkeit (Future)
 
@@ -126,3 +158,4 @@ Fuer kommende V2-Mapping-Features stellt die Anwendung zusaetzliche, read-only M
 
 - `/meta/tables?library=LIB`
 - `/meta/columns?library=LIB&table=TABLE`
+

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Aktueller First-Class-Flow:
 Minimale Architektur in der aktuellen Iteration:
 
 - `SourceConnector -> DataFlow -> TargetConnector`
+- `FlowConfiguration` beschreibt den aktuellen Source-/Target-Aufbau neutral
 - `CsvSourceConnector` liest das bereits bewaehrte `ParsedCsv`
 - `DbTableTargetConnector` delegiert weiterhin an die bestehende `ImportService`-Logik
 

--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -46,6 +46,7 @@ The active architecture priority is to add a minimal connector seam without brea
 - CSV source connector
 - DB target connector
 - Adapt current CSV -> DB execution to `DataFlow`
+- Connector configuration model (`#44`)
 
 ### Planned: Multi-connector roadmap
 
@@ -70,9 +71,9 @@ This track is intentionally ahead of broader platform features because it create
 
 ### Proposed work items
 
-- `#42` Connector architecture foundation (SourceConnector/TargetConnector)
-- `#43` Neutral record model + flow execution seam
-- `#44` Connector configuration model
+- `#42` Connector architecture foundation (SourceConnector/TargetConnector) - implemented on this branch
+- `#43` Neutral record model + flow execution seam - implemented on this branch
+- `#44` Connector configuration model - implemented on this branch
 - `#45` DB source connector
 - `#46` CSV target/export connector
 - `#47` Protocol connector foundations (FTP/SFTP/REST/filesystem)

--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -1,286 +1,158 @@
 # V2 Roadmap
 
-`gh` is not available in this environment. Create GitHub issues manually from the definitions below.
+## Product Direction
 
-## Epic (P1)
+`zeus-easy-upload` is no longer just a CSV-to-DB prototype. The current application already supports:
 
-### Title
-V2: Produktiv-Workflow (Mapping + Upsert + Async + API + Profiles)
+- Spring Boot UI flow
+- CSV parsing and preview
+- create-table import into DB2/400
+- existing-table imports with auto-mapping
+- DB metadata lookup
+- MERGE-based upsert
+- H2-backed integration testing with minimal SQL-dialect groundwork
 
-### Labels
-`epic`, `enhancement`, `import`, `priority:P1`
+The next step is not a rewrite. The next step is to introduce a connector architecture foundation so the product can evolve from a CSV import tool into a multi-connector data transfer toolkit.
 
-### Description
-Goal:
-- Enable production-grade CSV import workflows: mapping to existing tables, upsert, async progress, REST API, reusable profiles.
+Current first-class supported flow:
 
-Scope (In):
-- Auto-map CSV columns to existing DB2/400 table columns
-- Upsert via DB2/400 MERGE based on selectable key columns
-- Save/load import profiles (mapping + settings)
-- Async imports with progress tracking and UI progress bar
-- REST API endpoints mirroring the GUI workflow
+- CSV -> DB table
 
-Scope (Out):
-- AuthN/AuthZ beyond minimal/basic protection
-- Complex transformations (derive columns, joins)
-- CSV validation rules engine (beyond type parsing + required columns)
+Target architecture:
 
-Work items (Issues):
-- [ ] Feature: Auto-Mapping auf bestehende Tabellen
-- [ ] Feature: Upsert via MERGE (DB2/400)
-- [ ] Feature: Import-Profile speichern & laden
-- [ ] Feature: Async Import mit Progress-Bar (UI)
-- [ ] Feature: REST API zusätzlich zur GUI
-- [ ] Tech: DB2/400 Metadata Service kapseln (DatabaseMetaData)
-- [ ] Tech: Import Job Tracking + Progress Persistence
-- [ ] Tech: Fehlerreport Export (CSV/JSON Download)
-- [ ] Tech: Integrations-Test-Setup (Profile "it") + Doku IBM i
-- [ ] Feature/Tech: CSV Settings Optionen (Encoding/Delimiter/Quote)
+- `SourceConnector -> DataFlow -> TargetConnector`
 
-Epic acceptance criteria:
-- [ ] All listed work items are implemented and documented
-- [ ] A full end-to-end run is possible: upload -> preview/mapping -> async import -> progress -> result/errors via UI and API
-- [ ] Upsert mode updates existing keys and inserts new ones correctly
-- [ ] Profiles can be saved and reused to repeat the same import setup
+## Status Overview
 
-## Issue Backlog
+### Done: CSV-to-DB foundation
 
-### 1) Auto-Mapping auf bestehende Tabellen (Feature, P1)
-Labels: `enhancement`, `db2`, `import`, `ui`, `priority:P1`
-Part of: `#<EPIC>`
+- `#3` Auto-Mapping auf bestehende Tabellen
+- `#4` Upsert via MERGE (DB2/400)
+- `#8` DB2/400 Metadata Service kapseln (DatabaseMetaData)
+- `#38` Test infra: H2 in-memory integration tests + minimal SQL dialect scaffold
 
-Problem / Value:
-- Users need to import into existing DB2/400 tables without recreating them, while ensuring correct column mapping and type compatibility.
+These items stay done. They are enabling work for the connector direction and should not be reopened.
 
-Scope (In):
-- UI option: "Use existing table" (instead of "Create new table")
-- List tables by library/schema using DatabaseMetaData
-- Read columns (name, type, length, precision, scale, nullable)
-- Mapping UI: CSV column -> DB column dropdown; allow "ignore"
-- Preflight validation: required (non-null) columns must be mapped; no duplicate target mapping
+### In Progress: Architecture evolution
 
-Scope (Out):
-- Automatic schema migrations / altering existing columns
-- Advanced transformations (concats, computed columns)
+The active architecture priority is to add a minimal connector seam without breaking the existing workflow.
 
-Acceptance criteria:
-- [ ] UI allows selecting an existing table from a library/schema
-- [ ] UI shows DB columns and allows mapping each CSV column to exactly one DB column (or ignore)
-- [ ] Validation prevents start if any NOT NULL DB columns are unmapped and have no default
-- [ ] Import uses mapping to insert/update correct target columns
-- [ ] A sample import into an existing table completes with correct values
+- Analysis of current implementation and migration path
+- Connector architecture foundation
+- Neutral record model
+- Source connector abstraction
+- Target connector abstraction
+- Flow execution model
+- CSV source connector
+- DB target connector
+- Adapt current CSV -> DB execution to `DataFlow`
 
-Notes:
-- Implement metadata access via a dedicated MetadataService.
+### Planned: Multi-connector roadmap
 
-### 2) Upsert via MERGE (DB2/400) (Feature, P1)
-Labels: `enhancement`, `db2`, `import`, `api`, `ui`, `priority:P1`
-Part of: `#<EPIC>`
+After the minimal connector seam is in place, planned expansion areas are:
 
-Problem / Value:
-- Insert-only is not enough for recurring imports. Need UPSERT based on key columns.
+- connector configuration model
+- DB source connector
+- CSV target/export connector
+- filesystem connector
+- FTP connector foundation
+- SFTP connector foundation
+- REST connector foundation
+- cloud/object storage connector foundation
 
-Scope (In):
-- UI/REST option: Mode INSERT_ONLY vs UPSERT
-- User selects one or more key columns (DB columns) for match condition
-- Implement MERGE INTO <LIB>.<TABLE> ... ON (keys) WHEN MATCHED THEN UPDATE ... WHEN NOT MATCHED THEN INSERT ...
-- Batch approach or per-row MERGE (choose pragmatic for v1): correctness first
+## Track A: Connector Architecture
 
-Scope (Out):
-- Complex conflict resolution policies
-- Partial updates based on changed fields only (optional later)
+This track is intentionally ahead of broader platform features because it creates the seam needed for future source/target combinations.
 
-Acceptance criteria:
-- [ ] In UPSERT mode, rows with existing keys are updated, new keys inserted
-- [ ] Keys selection supports 1..n columns
-- [ ] Transaction rollback on failure, with clear error message including row/column
-- [ ] Works via both GUI flow and REST API
-- [ ] Document DB2/400 MERGE limitations/assumptions in README
+### Epic
 
-### 3) Import-Profile speichern & laden (Feature, P2)
-Labels: `enhancement`, `import`, `ui`, `priority:P2`
-Part of: `#<EPIC>`
+- `#41` Connector Architecture: Multi-connector flow foundation
 
-Problem / Value:
-- Repeated imports require redoing mapping/settings each time; profiles make workflows repeatable.
+### Proposed work items
 
-Scope (In):
-- Profile contains: targetLibrary, tableName, mode (insert/upsert), key columns, CSV settings (delimiter/quote/encoding), mapping (csv->db), type overrides (when create mode)
-- UI: Save profile, Load profile, Delete profile
-- Storage: start with DB table (preferred) OR JSON files under a configurable folder
+- `#42` Connector architecture foundation (SourceConnector/TargetConnector)
+- `#43` Neutral record model + flow execution seam
+- `#44` Connector configuration model
+- `#45` DB source connector
+- `#46` CSV target/export connector
+- `#47` Protocol connector foundations (FTP/SFTP/REST/filesystem)
 
-Scope (Out):
-- Multi-user permission model
-- Versioned profile migrations (beyond minimal)
+### Acceptance direction
 
-Acceptance criteria:
-- [ ] User can save a profile with a name
-- [ ] User can load the profile and UI rehydrates mapping + settings
-- [ ] User can delete a profile
-- [ ] Profile persistence is documented (where stored, how to backup)
+- Existing CSV -> DB behavior still works exactly as before
+- Current implementation uses connector orchestration internally
+- New source/target combinations can be added without reworking the controller flow again
+- Existing services remain reusable implementation backbones rather than being replaced
 
-### 4) Async Import mit Progress-Bar (UI) (Feature, P2)
-Labels: `enhancement`, `ui`, `import`, `priority:P2`
-Part of: `#<EPIC>`
+## Track B: Production Workflow Backlog
 
-Problem / Value:
-- Large CSV imports should not block HTTP requests or time out; users need progress visibility.
+The existing V2 epic remains relevant, but it is no longer the only organizing track.
 
-Scope (In):
-- Start import returns a jobId
-- Background job executes import
-- Progress tracking: totalRows, processedRows, inserted, updated (if upsert), failed, status (QUEUED/RUNNING/DONE/FAILED/CANCELLED)
-- UI shows progress bar and live updates (polling acceptable)
-- Result page shows summary and errors
+### Existing Epic
 
-Scope (Out):
-- WebSockets (polling is fine for v1)
-- Distributed job queue
+- `#2` V2: Produktiv-Workflow (Mapping + Upsert + Async + API + Profiles)
 
-Acceptance criteria:
-- [ ] Import runs in background without request timeout
-- [ ] UI displays progress and updates at least every 1-2 seconds (polling)
-- [ ] On completion, UI shows final counts + errors
-- [ ] Cancel is optional; if implemented, must stop the job cleanly
+### Still open from the V2 backlog
 
-### 5) REST API zusätzlich zur GUI (Feature, P2)
-Labels: `enhancement`, `api`, `import`, `priority:P2`
-Part of: `#<EPIC>`
+- `#5` Import-Profile speichern & laden
+- `#6` Async Import mit Progress-Bar (UI)
+- `#7` REST API zusÃ¤tzlich zur GUI
+- `#9` Import Job Tracking + Progress Persistence
+- `#10` Fehlerreport Export (CSV/JSON Download)
+- `#11` Integrations-Test-Setup (Profile "it") + Doku IBM i
+- `#12` CSV Settings Optionen (Encoding/Delimiter/Quote + UI)
 
-Problem / Value:
-- Automation / integrations require a stable REST API in addition to the UI.
+### Reordering guidance
 
-Scope (In):
-- Endpoints (example):
-  - POST /api/uploads -> upload CSV, returns uploadId + inferred schema
-  - POST /api/imports -> start import, returns jobId
-  - GET /api/imports/{id} -> status/progress
-  - GET /api/imports/{id}/errors -> error report
-- JSON models align with existing domain models
-- API docs: minimal README section (OpenAPI optional)
+These items remain valid, but architecture work should happen before major expansion in:
 
-Scope (Out):
-- OAuth/JWT (optional later)
-- Multi-tenant separation
+- generic REST/API exposure
+- reusable connector configuration
+- async multi-flow execution
+- export-oriented workflows
 
-Acceptance criteria:
-- [ ] API can perform full flow: upload -> start import -> poll status -> read errors
-- [ ] API supports insert-only and upsert mode
-- [ ] Validation errors return 4xx with meaningful messages
+## Incremental Migration Path
 
-### 6) DB2/400 Metadata Service kapseln (DatabaseMetaData) (Enabler, P1)
-Labels: `tech-debt`, `db2`, `import`, `priority:P1`
-Part of: `#<EPIC>`
+### Phase 1
 
-Context:
-- Multiple features depend on robust introspection: existing tables, columns, types, nullable, defaults.
+Introduce the connector seam with minimal additive types:
 
-Scope (In):
-- Create MetadataService with methods:
-  - listLibraries/schemas (if possible)
-  - listTables(library)
-  - getColumns(library, table) -> name/type/length/precision/scale/nullable/default
-- Centralize DB2 type normalization (map JDBC types to internal representation)
+- `DataRecord`
+- `SourceConnector`
+- `TargetConnector`
+- `DataFlow`
 
-Scope (Out):
-- Caching layers (optional later)
+### Phase 2
 
-Acceptance criteria:
-- [ ] MetadataService returns correct tables/columns for a given library
-- [ ] Results are used by mapping UI and/or validation
-- [ ] Unit tests cover type normalization logic
+Wrap existing implementations instead of moving them:
 
-### 7) Import Job Tracking + Progress Persistence (Enabler, P2)
-Labels: `tech-debt`, `import`, `priority:P2`
-Part of: `#<EPIC>`
+- `CsvParsingService` stays the CSV ingestion backbone
+- `ImportService` stays the DB write backbone
+- `MappingService` and `MetadataService` stay unchanged
 
-Context:
-- Async import requires reliable progress tracking, and ideally persistence across restarts.
+### Phase 3
 
-Scope (In):
-- Define ImportJob entity with status + counters + timestamps
-- Provide InMemory implementation first, plus optional DB persistence toggle
-- Provide JobService: createJob, updateProgress, complete, fail
+Refactor only orchestration so the current flow becomes:
 
-Scope (Out):
-- Distributed lock/queue
+- CSV upload and preview
+- mapping/validation
+- `CsvSourceConnector`
+- `DataFlow`
+- `DbTableTargetConnector`
 
-Acceptance criteria:
-- [ ] Job progress is queryable via service and API
-- [ ] UI polling reads consistent progress
-- [ ] On failure, job status is FAILED with error summary
+### Phase 4
 
-### 8) Fehlerreport Export (CSV/JSON Download) (Enabler, P2)
-Labels: `enhancement`, `ui`, `api`, `import`, `priority:P2`
-Part of: `#<EPIC>`
+Add additional connectors incrementally after the seam is proven:
 
-Problem / Value:
-- Users need to download error details for troubleshooting and rework.
+- DB source
+- CSV export
+- filesystem
+- FTP/SFTP
+- REST
 
-Scope (In):
-- Provide downloadable error report:
-  - JSON (full detail)
-  - CSV (flattened: row, column, value, message)
-- UI buttons on result page
-- API endpoint for error export
+## Notes
 
-Scope (Out):
-- Pretty HTML reports
-
-Acceptance criteria:
-- [ ] After a failed import (or partial errors), user can download JSON and CSV report
-- [ ] API provides the same reports
-- [ ] Report includes jobId, timestamp, and error list
-
-### 9) Integrations-Test-Setup (Profile "it") + Doku IBM i (Enabler, P3)
-Labels: `tech-debt`, `db2`, `priority:P3`
-Part of: `#<EPIC>`
-
-Context:
-- Critical DB2/400 behaviors (MERGE, identifier limits, data types) should be verified against a real IBM i.
-
-Scope (In):
-- Add Maven profile "it" that can run integration tests when env vars are provided:
-  - IT_DB_URL, IT_DB_USER, IT_DB_PASS
-- Provide one or two smoke tests:
-  - create table (temp name)
-  - insert
-  - merge/upsert (when implemented)
-- Document in README how to run and required permissions
-
-Scope (Out):
-- CI pipeline automation (optional later)
-
-Acceptance criteria:
-- [ ] `mvn -Pit test` runs integration tests when env vars exist
-- [ ] Tests are skipped gracefully when env vars are missing
-- [ ] README contains clear instructions
-
-### 10) CSV Settings Optionen (Encoding/Delimiter/Quote + UI) (Feature/Enabler, P3)
-Labels: `enhancement`, `ui`, `import`, `priority:P3`
-Part of: `#<EPIC>`
-
-Problem / Value:
-- Real-world CSV varies widely (Excel exports). Users need control over delimiter/quote/encoding.
-
-Scope (In):
-- UI options:
-  - delimiter (comma, semicolon, tab)
-  - quote char (", ')
-  - encoding (UTF-8 default; optional ISO-8859-1, Windows-1252)
-- Optional auto-detect heuristic (nice-to-have)
-- Persist in import profile
-
-Scope (Out):
-- Full RFC edge cases (multi-line quoted fields are already handled by parser)
-
-Acceptance criteria:
-- [ ] User can set delimiter/quote/encoding before parsing
-- [ ] Parsing reflects these settings and preview matches expected
-- [ ] Settings are saved/loaded with profiles
-
-## Manual creation order
-1. Create the Epic issue first.
-2. Create issues 1-10 and set `Part of: #<EPIC_NUMBER>` in each body.
-3. Add labels exactly as listed for each issue.
+- No plugin system is planned in this phase
+- No generic runtime connector registry is planned in this phase
+- The current UI and current import behavior must remain intact
+- Existing logic should be wrapped first and only extracted further when a second real connector pair justifies it

--- a/docs/architecture/connector-architecture-analysis.md
+++ b/docs/architecture/connector-architecture-analysis.md
@@ -1,0 +1,183 @@
+# Connector Architecture Analysis
+
+## Current-State Assessment
+
+The current implementation already contains the core building blocks of a future source-to-target platform, even though the application is still presented as a CSV-to-DB import tool.
+
+### What already resembles source/target behavior
+
+- `CsvParsingService` is effectively the current source-side ingestion component. It parses uploaded CSV files into `ParsedCsv`, preserving header order, raw rows, preview rows, delimiter detection, parse errors, and inferred column proposals.
+- `ImportService` is effectively the current target-side execution component. It owns create-table import, existing-table insert, and MERGE-based upsert behavior.
+- `MetadataService` and `MappingService` already provide target preparation concerns that are reusable for future connectors:
+  - table/column discovery
+  - auto-mapping
+  - preflight validation
+- `UploadController` already acts as a flow orchestrator. It performs source parsing, target preparation, validation, and final execution.
+
+### Backbone services that should remain in place
+
+The following services should remain the implementation backbone for the next iteration:
+
+- `CsvParsingService`: keep as the proven CSV ingestion/parsing implementation
+- `ImportService`: keep as the proven DB write/import implementation
+- `MappingService`: keep existing-table mapping and validation logic intact
+- `MetadataService`: keep metadata lookup intact
+- `DdlService` and `SqlDialect`: keep SQL generation and dialect handling intact
+
+These services already separate parsing, metadata, mapping, and SQL execution well enough that a connector seam can be added above them with low risk.
+
+### Where the code is tightly coupled to CSV -> DB today
+
+- `UploadController` directly orchestrates the full CSV -> DB workflow and branches between:
+  - create-new-table import
+  - existing-table insert
+  - existing-table upsert
+- `ImportService` accepts `ParsedCsv` and internally depends on row lists (`List<List<String>>`) rather than a neutral record abstraction.
+- Existing mapping logic is expressed in CSV-column terms (`csvColumn`, `csvIndex`) and is therefore still tied to CSV-originated data.
+- `ImportResult` and the controller flow are import-specific; there is no neutral flow result model yet.
+
+### Lowest-risk connector insertion point
+
+The safest place to introduce the connector abstraction is between:
+
+- parsed source data (`ParsedCsv`)
+- and execution against the DB target (`ImportService`)
+
+That allows the application to add:
+
+- a neutral `DataRecord`
+- `SourceConnector`
+- `TargetConnector`
+- a minimal `DataFlow`
+
+without rewriting parsing, validation, metadata, SQL generation, or DB execution.
+
+### Wrap vs. move
+
+For this iteration, existing logic should be wrapped, not moved.
+
+Recommended approach:
+
+- Wrap `ParsedCsv` with a CSV source connector
+- Wrap `ImportService` with a DB table target connector
+- Keep validation and preview preparation in the current controller/service flow
+- Defer deeper extraction from `ImportService` until there is a second real source or target implementation
+
+This keeps the migration additive and preserves current behavior.
+
+## Recommended Incremental Migration Path
+
+### Step 1: Add a minimal neutral flow seam
+
+Introduce:
+
+- `DataRecord`
+- `SourceConnector`
+- `TargetConnector`
+- `DataFlow`
+
+Keep them intentionally small and framework-neutral.
+
+### Step 2: Wrap current CSV parsing output
+
+Implement a CSV source connector that converts existing `ParsedCsv` rows into ordered `DataRecord` instances.
+
+Important detail:
+
+- column order should be preserved via insertion order in the record map
+- duplicate CSV headers should not force a redesign now; the connector should favor stable ordered output over deep normalization changes
+
+### Step 3: Wrap current DB import execution
+
+Implement a DB table target connector that:
+
+- accepts `Stream<DataRecord>`
+- reconstructs the row-oriented structure needed by `ImportService`
+- delegates to the existing create/import/upsert methods
+
+This preserves all current SQL, batching, rollback, and error behavior.
+
+### Step 4: Refactor orchestration only
+
+Adapt the current CSV -> DB execution path so the controller uses:
+
+- `CsvSourceConnector`
+- `DbTableTargetConnector`
+- `DataFlow`
+
+Keep these parts unchanged:
+
+- UI
+- request/preview flow
+- mapping validation
+- metadata lookup
+- existing import SQL behavior
+
+### Step 5: Defer broader connector evolution
+
+After the seam is proven, follow with:
+
+- neutral flow configuration
+- DB source connector
+- CSV target/export connector
+- filesystem connector
+- FTP/SFTP connector foundation
+- REST connector foundation
+
+At that point deeper extraction from `ImportService` becomes justified.
+
+## Roadmap Impact
+
+### Existing roadmap items affected
+
+Closed work that now becomes foundation for the connector direction:
+
+- `#3` Auto-mapping on existing tables
+- `#4` Upsert via MERGE
+- `#8` Metadata service extraction
+- `#38` H2 integration tests and minimal SQL dialect groundwork
+
+These should remain marked as done and be referenced as enabling work, not reopened.
+
+Open work that remains valid but should be clarified by the new direction:
+
+- `#5` Import profiles
+- `#6` Async import
+- `#7` REST API
+- `#9` Job tracking
+- `#10` Error export
+- `#11` IBM i integration-test profile
+- `#12` CSV settings
+
+### Recommended roadmap changes
+
+The roadmap should be both extended and reordered.
+
+- Extend it with an explicit connector architecture track
+- Reorder it so connector foundation work happens before broader API/profile/async expansion
+- Clarify that the current product is still CSV -> DB first, but is now evolving toward multi-connector flows
+- Split new architecture work into dedicated issues instead of burying it inside the existing V2 epic
+
+### Recommended new roadmap track
+
+Add an architecture track covering:
+
+- connector architecture foundation
+- neutral record model
+- source connector abstraction
+- target connector abstraction
+- flow execution model
+- connector configuration model
+- DB source connector
+- CSV target/export connector
+- protocol connector foundations (FTP, SFTP, REST, filesystem)
+
+### Recommendation on issues
+
+Create a new connector-architecture epic plus focused follow-up issues.
+
+Reason:
+
+- the current V2 epic is centered on the production CSV import workflow
+- the connector direction is broader than that scope
+- a separate epic makes dependencies and future expansion clearer without discarding the existing roadmap

--- a/src/main/java/com/zeus/upload/connector/ConnectorFactory.java
+++ b/src/main/java/com/zeus/upload/connector/ConnectorFactory.java
@@ -1,0 +1,34 @@
+package com.zeus.upload.connector;
+
+import com.zeus.upload.connector.db.DbTableTargetConnector;
+import com.zeus.upload.connector.file.CsvSourceConnector;
+import com.zeus.upload.flow.CsvSourceConfiguration;
+import com.zeus.upload.flow.DbTableTargetConfiguration;
+import com.zeus.upload.flow.SourceConfiguration;
+import com.zeus.upload.flow.TargetConfiguration;
+import com.zeus.upload.service.ImportService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConnectorFactory {
+
+    private final ImportService importService;
+
+    public ConnectorFactory(ImportService importService) {
+        this.importService = importService;
+    }
+
+    public SourceConnector createSource(SourceConfiguration configuration) {
+        if (configuration instanceof CsvSourceConfiguration csvSourceConfiguration) {
+            return new CsvSourceConnector(csvSourceConfiguration.getParsedCsv());
+        }
+        throw new IllegalArgumentException("Unsupported source configuration: " + configuration.getClass().getName());
+    }
+
+    public TargetConnector createTarget(TargetConfiguration configuration) {
+        if (configuration instanceof DbTableTargetConfiguration dbTableTargetConfiguration) {
+            return new DbTableTargetConnector(importService, dbTableTargetConfiguration);
+        }
+        throw new IllegalArgumentException("Unsupported target configuration: " + configuration.getClass().getName());
+    }
+}

--- a/src/main/java/com/zeus/upload/connector/ImportResultAwareTargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/ImportResultAwareTargetConnector.java
@@ -1,0 +1,8 @@
+package com.zeus.upload.connector;
+
+import com.zeus.upload.domain.ImportResult;
+
+public interface ImportResultAwareTargetConnector extends TargetConnector {
+
+    ImportResult getImportResult();
+}

--- a/src/main/java/com/zeus/upload/connector/SourceConnector.java
+++ b/src/main/java/com/zeus/upload/connector/SourceConnector.java
@@ -1,0 +1,9 @@
+package com.zeus.upload.connector;
+
+import com.zeus.upload.flow.DataRecord;
+import java.util.stream.Stream;
+
+public interface SourceConnector {
+
+    Stream<DataRecord> read();
+}

--- a/src/main/java/com/zeus/upload/connector/TargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/TargetConnector.java
@@ -1,0 +1,9 @@
+package com.zeus.upload.connector;
+
+import com.zeus.upload.flow.DataRecord;
+import java.util.stream.Stream;
+
+public interface TargetConnector {
+
+    void write(Stream<DataRecord> records);
+}

--- a/src/main/java/com/zeus/upload/connector/db/DbTableTargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/db/DbTableTargetConnector.java
@@ -1,28 +1,27 @@
 package com.zeus.upload.connector.db;
 
-import com.zeus.upload.connector.TargetConnector;
-import com.zeus.upload.domain.DbColumnMeta;
+import com.zeus.upload.connector.ImportResultAwareTargetConnector;
 import com.zeus.upload.domain.ImportRequest;
 import com.zeus.upload.domain.ImportResult;
 import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.flow.DbTableTargetConfiguration;
+import com.zeus.upload.flow.DbTableWriteMode;
 import com.zeus.upload.flow.DataRecord;
 import com.zeus.upload.service.ImportService;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-public class DbTableTargetConnector implements TargetConnector {
+public class DbTableTargetConnector implements ImportResultAwareTargetConnector {
 
     private final ImportService importService;
-    private final ImportRequest importRequest;
-    private final List<DbColumnMeta> dbColumns;
+    private final DbTableTargetConfiguration configuration;
 
     private ImportResult result;
 
-    public DbTableTargetConnector(ImportService importService, ImportRequest importRequest, List<DbColumnMeta> dbColumns) {
+    public DbTableTargetConnector(ImportService importService, DbTableTargetConfiguration configuration) {
         this.importService = Objects.requireNonNull(importService, "importService must not be null");
-        this.importRequest = Objects.requireNonNull(importRequest, "importRequest must not be null");
-        this.dbColumns = dbColumns == null ? List.of() : List.copyOf(dbColumns);
+        this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
     }
 
     @Override
@@ -30,39 +29,53 @@ public class DbTableTargetConnector implements TargetConnector {
         ParsedCsv parsedCsv = new ParsedCsv();
         records.map(this::toRow).forEach(parsedCsv.getRows()::add);
 
-        if (!importRequest.isUseExistingTable()) {
-            result = importService.importCsv(importRequest, parsedCsv);
+        if (configuration.getWriteMode() == DbTableWriteMode.CREATE_TABLE) {
+            result = importService.importCsv(createImportRequest(), parsedCsv);
             return;
         }
 
-        if (importRequest.isUpsertEnabled()) {
+        if (configuration.getWriteMode() == DbTableWriteMode.UPSERT_EXISTING) {
             result = importService.upsertIntoExistingTable(
-                    importRequest.getLibrary(),
-                    importRequest.getExistingTableName(),
+                    configuration.getLibrary(),
+                    configuration.getTableName(),
                     parsedCsv,
-                    dbColumns,
-                    importRequest.getMappings(),
-                    importRequest.getKeyColumns()
+                    configuration.getDbColumns(),
+                    configuration.getMappings(),
+                    configuration.getKeyColumns()
             );
             return;
         }
 
         result = importService.importIntoExistingTable(
-                importRequest.getLibrary(),
-                importRequest.getExistingTableName(),
+                configuration.getLibrary(),
+                configuration.getTableName(),
                 parsedCsv,
-                dbColumns,
-                importRequest.getMappings()
+                configuration.getDbColumns(),
+                configuration.getMappings()
         );
     }
 
-    public ImportResult getResult() {
+    @Override
+    public ImportResult getImportResult() {
         return result;
+    }
+
+    public ImportResult getResult() {
+        return getImportResult();
     }
 
     private List<String> toRow(DataRecord record) {
         return record.asMap().values().stream()
                 .map(value -> value == null ? null : String.valueOf(value))
                 .toList();
+    }
+
+    private ImportRequest createImportRequest() {
+        ImportRequest importRequest = new ImportRequest();
+        importRequest.setLibrary(configuration.getLibrary());
+        importRequest.setTableName(configuration.getTableName());
+        importRequest.setDropAndRecreate(configuration.isDropAndRecreate());
+        importRequest.setColumns(configuration.getColumns());
+        return importRequest;
     }
 }

--- a/src/main/java/com/zeus/upload/connector/db/DbTableTargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/db/DbTableTargetConnector.java
@@ -1,0 +1,68 @@
+package com.zeus.upload.connector.db;
+
+import com.zeus.upload.connector.TargetConnector;
+import com.zeus.upload.domain.DbColumnMeta;
+import com.zeus.upload.domain.ImportRequest;
+import com.zeus.upload.domain.ImportResult;
+import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.flow.DataRecord;
+import com.zeus.upload.service.ImportService;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class DbTableTargetConnector implements TargetConnector {
+
+    private final ImportService importService;
+    private final ImportRequest importRequest;
+    private final List<DbColumnMeta> dbColumns;
+
+    private ImportResult result;
+
+    public DbTableTargetConnector(ImportService importService, ImportRequest importRequest, List<DbColumnMeta> dbColumns) {
+        this.importService = Objects.requireNonNull(importService, "importService must not be null");
+        this.importRequest = Objects.requireNonNull(importRequest, "importRequest must not be null");
+        this.dbColumns = dbColumns == null ? List.of() : List.copyOf(dbColumns);
+    }
+
+    @Override
+    public void write(Stream<DataRecord> records) {
+        ParsedCsv parsedCsv = new ParsedCsv();
+        records.map(this::toRow).forEach(parsedCsv.getRows()::add);
+
+        if (!importRequest.isUseExistingTable()) {
+            result = importService.importCsv(importRequest, parsedCsv);
+            return;
+        }
+
+        if (importRequest.isUpsertEnabled()) {
+            result = importService.upsertIntoExistingTable(
+                    importRequest.getLibrary(),
+                    importRequest.getExistingTableName(),
+                    parsedCsv,
+                    dbColumns,
+                    importRequest.getMappings(),
+                    importRequest.getKeyColumns()
+            );
+            return;
+        }
+
+        result = importService.importIntoExistingTable(
+                importRequest.getLibrary(),
+                importRequest.getExistingTableName(),
+                parsedCsv,
+                dbColumns,
+                importRequest.getMappings()
+        );
+    }
+
+    public ImportResult getResult() {
+        return result;
+    }
+
+    private List<String> toRow(DataRecord record) {
+        return record.asMap().values().stream()
+                .map(value -> value == null ? null : String.valueOf(value))
+                .toList();
+    }
+}

--- a/src/main/java/com/zeus/upload/connector/file/CsvSourceConnector.java
+++ b/src/main/java/com/zeus/upload/connector/file/CsvSourceConnector.java
@@ -1,0 +1,57 @@
+package com.zeus.upload.connector.file;
+
+import com.zeus.upload.connector.SourceConnector;
+import com.zeus.upload.domain.ColumnProposal;
+import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.flow.DataRecord;
+import java.util.List;
+
+public class CsvSourceConnector implements SourceConnector {
+
+    private final ParsedCsv parsedCsv;
+    private final List<String> recordKeys;
+
+    public CsvSourceConnector(ParsedCsv parsedCsv) {
+        this.parsedCsv = parsedCsv;
+        this.recordKeys = buildRecordKeys(parsedCsv);
+    }
+
+    @Override
+    public java.util.stream.Stream<DataRecord> read() {
+        return parsedCsv.getRows().stream().map(this::toRecord);
+    }
+
+    private DataRecord toRecord(List<String> row) {
+        DataRecord record = new DataRecord();
+        for (int index = 0; index < recordKeys.size(); index++) {
+            String value = index < row.size() ? row.get(index) : null;
+            record.set(recordKeys.get(index), value);
+        }
+        return record;
+    }
+
+    private List<String> buildRecordKeys(ParsedCsv csv) {
+        if (csv.getProposals().isEmpty()) {
+            return csv.getOriginalHeaders().stream()
+                    .map(header -> header == null ? "" : header)
+                    .toList();
+        }
+
+        return csv.getProposals().stream()
+                .map(this::resolveRecordKey)
+                .toList();
+    }
+
+    private String resolveRecordKey(ColumnProposal proposal) {
+        if (proposal.getFinalName() != null && !proposal.getFinalName().isBlank()) {
+            return proposal.getFinalName();
+        }
+        if (proposal.getSanitizedName() != null && !proposal.getSanitizedName().isBlank()) {
+            return proposal.getSanitizedName();
+        }
+        if (proposal.getOriginalName() != null && !proposal.getOriginalName().isBlank()) {
+            return proposal.getOriginalName();
+        }
+        return "COLUMN_" + proposal.getIndex();
+    }
+}

--- a/src/main/java/com/zeus/upload/controller/UploadController.java
+++ b/src/main/java/com/zeus/upload/controller/UploadController.java
@@ -1,5 +1,7 @@
 package com.zeus.upload.controller;
 
+import com.zeus.upload.connector.db.DbTableTargetConnector;
+import com.zeus.upload.connector.file.CsvSourceConnector;
 import com.zeus.upload.domain.ColumnMapping;
 import com.zeus.upload.config.AppProperties;
 import com.zeus.upload.domain.ColumnProposal;
@@ -8,6 +10,7 @@ import com.zeus.upload.domain.ImportRequest;
 import com.zeus.upload.domain.ImportResult;
 import com.zeus.upload.domain.MappingValidationResult;
 import com.zeus.upload.domain.PreviewContext;
+import com.zeus.upload.flow.DataFlow;
 import com.zeus.upload.service.CsvParsingService;
 import com.zeus.upload.service.ImportService;
 import com.zeus.upload.service.MappingService;
@@ -186,30 +189,24 @@ public class UploadController {
                 return "preview";
             }
             model.addAttribute("mappingWarnings", validationResult.getWarnings());
-            if (importRequest.isUpsertEnabled()) {
-                result = importService.upsertIntoExistingTable(
-                        importRequest.getLibrary(),
-                        importRequest.getExistingTableName(),
-                        previewContext.getParsedCsv(),
-                        dbColumns,
-                        importRequest.getMappings(),
-                        importRequest.getKeyColumns()
-                );
-            } else {
-                result = importService.importIntoExistingTable(
-                        importRequest.getLibrary(),
-                        importRequest.getExistingTableName(),
-                        previewContext.getParsedCsv(),
-                        dbColumns,
-                        importRequest.getMappings()
-                );
-            }
+            result = executeConnectorFlow(importRequest, previewContext, dbColumns);
         } else {
-            result = importService.importCsv(importRequest, previewContext.getParsedCsv());
+            result = executeConnectorFlow(importRequest, previewContext, List.of());
         }
         model.addAttribute("result", result);
         sessionStatus.setComplete();
         return "result";
+    }
+
+    private ImportResult executeConnectorFlow(
+            ImportRequest importRequest,
+            PreviewContext previewContext,
+            List<DbColumnMeta> dbColumns
+    ) {
+        CsvSourceConnector source = new CsvSourceConnector(previewContext.getParsedCsv());
+        DbTableTargetConnector target = new DbTableTargetConnector(importService, importRequest, dbColumns);
+        new DataFlow(source, target).execute();
+        return target.getResult();
     }
 
     private List<ColumnProposal> copyColumns(List<ColumnProposal> source) {

--- a/src/main/java/com/zeus/upload/controller/UploadController.java
+++ b/src/main/java/com/zeus/upload/controller/UploadController.java
@@ -1,7 +1,5 @@
 package com.zeus.upload.controller;
 
-import com.zeus.upload.connector.db.DbTableTargetConnector;
-import com.zeus.upload.connector.file.CsvSourceConnector;
 import com.zeus.upload.domain.ColumnMapping;
 import com.zeus.upload.config.AppProperties;
 import com.zeus.upload.domain.ColumnProposal;
@@ -10,9 +8,9 @@ import com.zeus.upload.domain.ImportRequest;
 import com.zeus.upload.domain.ImportResult;
 import com.zeus.upload.domain.MappingValidationResult;
 import com.zeus.upload.domain.PreviewContext;
-import com.zeus.upload.flow.DataFlow;
+import com.zeus.upload.flow.FlowConfigurationFactory;
+import com.zeus.upload.flow.FlowExecutionService;
 import com.zeus.upload.service.CsvParsingService;
-import com.zeus.upload.service.ImportService;
 import com.zeus.upload.service.MappingService;
 import com.zeus.upload.service.MetadataService;
 import jakarta.validation.Valid;
@@ -42,23 +40,26 @@ public class UploadController {
     private static final List<String> SUPPORTED_TYPES = List.of("INTEGER", "BIGINT", "DECIMAL", "DATE", "TIMESTAMP", "VARCHAR");
 
     private final CsvParsingService csvParsingService;
-    private final ImportService importService;
     private final MetadataService metadataService;
     private final MappingService mappingService;
     private final AppProperties appProperties;
+    private final FlowConfigurationFactory flowConfigurationFactory;
+    private final FlowExecutionService flowExecutionService;
 
     public UploadController(
             CsvParsingService csvParsingService,
-            ImportService importService,
             MetadataService metadataService,
             MappingService mappingService,
-            AppProperties appProperties
+            AppProperties appProperties,
+            FlowConfigurationFactory flowConfigurationFactory,
+            FlowExecutionService flowExecutionService
     ) {
         this.csvParsingService = csvParsingService;
-        this.importService = importService;
         this.metadataService = metadataService;
         this.mappingService = mappingService;
         this.appProperties = appProperties;
+        this.flowConfigurationFactory = flowConfigurationFactory;
+        this.flowExecutionService = flowExecutionService;
     }
 
     @ModelAttribute("previewContext")
@@ -189,24 +190,17 @@ public class UploadController {
                 return "preview";
             }
             model.addAttribute("mappingWarnings", validationResult.getWarnings());
-            result = executeConnectorFlow(importRequest, previewContext, dbColumns);
+            result = executeConfiguredFlow(importRequest, previewContext);
         } else {
-            result = executeConnectorFlow(importRequest, previewContext, List.of());
+            result = executeConfiguredFlow(importRequest, previewContext);
         }
         model.addAttribute("result", result);
         sessionStatus.setComplete();
         return "result";
     }
 
-    private ImportResult executeConnectorFlow(
-            ImportRequest importRequest,
-            PreviewContext previewContext,
-            List<DbColumnMeta> dbColumns
-    ) {
-        CsvSourceConnector source = new CsvSourceConnector(previewContext.getParsedCsv());
-        DbTableTargetConnector target = new DbTableTargetConnector(importService, importRequest, dbColumns);
-        new DataFlow(source, target).execute();
-        return target.getResult();
+    private ImportResult executeConfiguredFlow(ImportRequest importRequest, PreviewContext previewContext) {
+        return flowExecutionService.execute(flowConfigurationFactory.fromImportContext(importRequest, previewContext));
     }
 
     private List<ColumnProposal> copyColumns(List<ColumnProposal> source) {

--- a/src/main/java/com/zeus/upload/flow/CsvSourceConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/CsvSourceConfiguration.java
@@ -1,0 +1,17 @@
+package com.zeus.upload.flow;
+
+import com.zeus.upload.domain.ParsedCsv;
+import java.util.Objects;
+
+public class CsvSourceConfiguration implements SourceConfiguration {
+
+    private final ParsedCsv parsedCsv;
+
+    public CsvSourceConfiguration(ParsedCsv parsedCsv) {
+        this.parsedCsv = Objects.requireNonNull(parsedCsv, "parsedCsv must not be null");
+    }
+
+    public ParsedCsv getParsedCsv() {
+        return parsedCsv;
+    }
+}

--- a/src/main/java/com/zeus/upload/flow/DataFlow.java
+++ b/src/main/java/com/zeus/upload/flow/DataFlow.java
@@ -1,0 +1,23 @@
+package com.zeus.upload.flow;
+
+import com.zeus.upload.connector.SourceConnector;
+import com.zeus.upload.connector.TargetConnector;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class DataFlow {
+
+    private final SourceConnector source;
+    private final TargetConnector target;
+
+    public DataFlow(SourceConnector source, TargetConnector target) {
+        this.source = Objects.requireNonNull(source, "source must not be null");
+        this.target = Objects.requireNonNull(target, "target must not be null");
+    }
+
+    public void execute() {
+        try (Stream<DataRecord> records = source.read()) {
+            target.write(records);
+        }
+    }
+}

--- a/src/main/java/com/zeus/upload/flow/DataRecord.java
+++ b/src/main/java/com/zeus/upload/flow/DataRecord.java
@@ -1,0 +1,21 @@
+package com.zeus.upload.flow;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class DataRecord {
+
+    private final Map<String, Object> values = new LinkedHashMap<>();
+
+    public Object get(String key) {
+        return values.get(key);
+    }
+
+    public void set(String key, Object value) {
+        values.put(key, value);
+    }
+
+    public Map<String, Object> asMap() {
+        return values;
+    }
+}

--- a/src/main/java/com/zeus/upload/flow/DbTableTargetConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/DbTableTargetConfiguration.java
@@ -1,0 +1,72 @@
+package com.zeus.upload.flow;
+
+import com.zeus.upload.domain.ColumnMapping;
+import com.zeus.upload.domain.ColumnProposal;
+import com.zeus.upload.domain.DbColumnMeta;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class DbTableTargetConfiguration implements TargetConfiguration {
+
+    private final String library;
+    private final String tableName;
+    private final DbTableWriteMode writeMode;
+    private final boolean dropAndRecreate;
+    private final List<ColumnProposal> columns;
+    private final List<ColumnMapping> mappings;
+    private final List<String> keyColumns;
+    private final List<DbColumnMeta> dbColumns;
+
+    public DbTableTargetConfiguration(
+            String library,
+            String tableName,
+            DbTableWriteMode writeMode,
+            boolean dropAndRecreate,
+            List<ColumnProposal> columns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns,
+            List<DbColumnMeta> dbColumns
+    ) {
+        this.library = Objects.requireNonNull(library, "library must not be null");
+        this.tableName = Objects.requireNonNull(tableName, "tableName must not be null");
+        this.writeMode = Objects.requireNonNull(writeMode, "writeMode must not be null");
+        this.dropAndRecreate = dropAndRecreate;
+        this.columns = columns == null ? List.of() : List.copyOf(new ArrayList<>(columns));
+        this.mappings = mappings == null ? List.of() : List.copyOf(new ArrayList<>(mappings));
+        this.keyColumns = keyColumns == null ? List.of() : List.copyOf(new ArrayList<>(keyColumns));
+        this.dbColumns = dbColumns == null ? List.of() : List.copyOf(new ArrayList<>(dbColumns));
+    }
+
+    public String getLibrary() {
+        return library;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public DbTableWriteMode getWriteMode() {
+        return writeMode;
+    }
+
+    public boolean isDropAndRecreate() {
+        return dropAndRecreate;
+    }
+
+    public List<ColumnProposal> getColumns() {
+        return columns;
+    }
+
+    public List<ColumnMapping> getMappings() {
+        return mappings;
+    }
+
+    public List<String> getKeyColumns() {
+        return keyColumns;
+    }
+
+    public List<DbColumnMeta> getDbColumns() {
+        return dbColumns;
+    }
+}

--- a/src/main/java/com/zeus/upload/flow/DbTableWriteMode.java
+++ b/src/main/java/com/zeus/upload/flow/DbTableWriteMode.java
@@ -1,0 +1,7 @@
+package com.zeus.upload.flow;
+
+public enum DbTableWriteMode {
+    CREATE_TABLE,
+    INSERT_EXISTING,
+    UPSERT_EXISTING
+}

--- a/src/main/java/com/zeus/upload/flow/FlowConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/FlowConfiguration.java
@@ -1,0 +1,22 @@
+package com.zeus.upload.flow;
+
+import java.util.Objects;
+
+public class FlowConfiguration {
+
+    private final SourceConfiguration source;
+    private final TargetConfiguration target;
+
+    public FlowConfiguration(SourceConfiguration source, TargetConfiguration target) {
+        this.source = Objects.requireNonNull(source, "source must not be null");
+        this.target = Objects.requireNonNull(target, "target must not be null");
+    }
+
+    public SourceConfiguration getSource() {
+        return source;
+    }
+
+    public TargetConfiguration getTarget() {
+        return target;
+    }
+}

--- a/src/main/java/com/zeus/upload/flow/FlowConfigurationFactory.java
+++ b/src/main/java/com/zeus/upload/flow/FlowConfigurationFactory.java
@@ -1,0 +1,42 @@
+package com.zeus.upload.flow;
+
+import com.zeus.upload.domain.ImportRequest;
+import com.zeus.upload.domain.PreviewContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FlowConfigurationFactory {
+
+    public FlowConfiguration fromImportContext(ImportRequest importRequest, PreviewContext previewContext) {
+        CsvSourceConfiguration source = new CsvSourceConfiguration(previewContext.getParsedCsv());
+        DbTableTargetConfiguration target = new DbTableTargetConfiguration(
+                importRequest.getLibrary(),
+                resolveTargetTable(importRequest),
+                resolveWriteMode(importRequest),
+                importRequest.isDropAndRecreate(),
+                importRequest.getColumns(),
+                importRequest.getMappings(),
+                importRequest.getKeyColumns(),
+                previewContext.getDbColumns()
+        );
+        return new FlowConfiguration(source, target);
+    }
+
+    private DbTableWriteMode resolveWriteMode(ImportRequest importRequest) {
+        if (!importRequest.isUseExistingTable()) {
+            return DbTableWriteMode.CREATE_TABLE;
+        }
+        if (importRequest.isUpsertEnabled()) {
+            return DbTableWriteMode.UPSERT_EXISTING;
+        }
+        return DbTableWriteMode.INSERT_EXISTING;
+    }
+
+    private String resolveTargetTable(ImportRequest importRequest) {
+        if (importRequest.isUseExistingTable() && importRequest.getExistingTableName() != null
+                && !importRequest.getExistingTableName().isBlank()) {
+            return importRequest.getExistingTableName();
+        }
+        return importRequest.getTableName();
+    }
+}

--- a/src/main/java/com/zeus/upload/flow/FlowExecutionService.java
+++ b/src/main/java/com/zeus/upload/flow/FlowExecutionService.java
@@ -1,0 +1,29 @@
+package com.zeus.upload.flow;
+
+import com.zeus.upload.connector.ConnectorFactory;
+import com.zeus.upload.connector.ImportResultAwareTargetConnector;
+import com.zeus.upload.connector.SourceConnector;
+import com.zeus.upload.connector.TargetConnector;
+import com.zeus.upload.domain.ImportResult;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FlowExecutionService {
+
+    private final ConnectorFactory connectorFactory;
+
+    public FlowExecutionService(ConnectorFactory connectorFactory) {
+        this.connectorFactory = connectorFactory;
+    }
+
+    public ImportResult execute(FlowConfiguration configuration) {
+        SourceConnector source = connectorFactory.createSource(configuration.getSource());
+        TargetConnector target = connectorFactory.createTarget(configuration.getTarget());
+        new DataFlow(source, target).execute();
+
+        if (target instanceof ImportResultAwareTargetConnector resultAwareTarget) {
+            return resultAwareTarget.getImportResult();
+        }
+        throw new IllegalStateException("Configured target does not provide an ImportResult.");
+    }
+}

--- a/src/main/java/com/zeus/upload/flow/SourceConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/SourceConfiguration.java
@@ -1,0 +1,4 @@
+package com.zeus.upload.flow;
+
+public interface SourceConfiguration {
+}

--- a/src/main/java/com/zeus/upload/flow/TargetConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/TargetConfiguration.java
@@ -1,0 +1,4 @@
+package com.zeus.upload.flow;
+
+public interface TargetConfiguration {
+}

--- a/src/test/java/com/zeus/upload/connector/ConnectorFactoryTest.java
+++ b/src/test/java/com/zeus/upload/connector/ConnectorFactoryTest.java
@@ -1,0 +1,57 @@
+package com.zeus.upload.connector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.zeus.upload.connector.db.DbTableTargetConnector;
+import com.zeus.upload.connector.file.CsvSourceConnector;
+import com.zeus.upload.domain.ColumnProposal;
+import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.flow.CsvSourceConfiguration;
+import com.zeus.upload.flow.DbTableTargetConfiguration;
+import com.zeus.upload.flow.DbTableWriteMode;
+import com.zeus.upload.service.ImportService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ConnectorFactoryTest {
+
+    @Test
+    void shouldCreateCsvSourceConnector() {
+        ConnectorFactory factory = new ConnectorFactory(mock(ImportService.class));
+        ParsedCsv parsedCsv = new ParsedCsv();
+
+        SourceConnector connector = factory.createSource(new CsvSourceConfiguration(parsedCsv));
+
+        assertThat(connector).isInstanceOf(CsvSourceConnector.class);
+    }
+
+    @Test
+    void shouldCreateDbTableTargetConnector() {
+        ConnectorFactory factory = new ConnectorFactory(mock(ImportService.class));
+        DbTableTargetConfiguration configuration = new DbTableTargetConfiguration(
+                "TESTLIB",
+                "ORDERS",
+                DbTableWriteMode.CREATE_TABLE,
+                false,
+                List.of(column()),
+                List.of(),
+                List.of(),
+                List.of()
+        );
+
+        TargetConnector connector = factory.createTarget(configuration);
+
+        assertThat(connector).isInstanceOf(DbTableTargetConnector.class);
+    }
+
+    private ColumnProposal column() {
+        ColumnProposal proposal = new ColumnProposal();
+        proposal.setIndex(0);
+        proposal.setOriginalName("ID");
+        proposal.setSanitizedName("ID");
+        proposal.setFinalName("ID");
+        proposal.setSqlType("INTEGER");
+        return proposal;
+    }
+}

--- a/src/test/java/com/zeus/upload/connector/db/DbTableTargetConnectorIntegrationTest.java
+++ b/src/test/java/com/zeus/upload/connector/db/DbTableTargetConnectorIntegrationTest.java
@@ -5,10 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.zeus.upload.connector.file.CsvSourceConnector;
 import com.zeus.upload.domain.ColumnMapping;
 import com.zeus.upload.domain.DbColumnMeta;
-import com.zeus.upload.domain.ImportRequest;
 import com.zeus.upload.domain.ImportResult;
 import com.zeus.upload.domain.ParsedCsv;
 import com.zeus.upload.flow.DataFlow;
+import com.zeus.upload.flow.DbTableTargetConfiguration;
+import com.zeus.upload.flow.DbTableWriteMode;
 import com.zeus.upload.service.CsvParsingService;
 import com.zeus.upload.service.ImportService;
 import java.io.IOException;
@@ -50,20 +51,23 @@ class DbTableTargetConnectorIntegrationTest {
                 """);
 
         ParsedCsv parsedCsv = parseSampleCsv();
-        ImportRequest request = new ImportRequest();
-        request.setLibrary(LIBRARY);
-        request.setTableName("H2_CONNECTOR_IMPORT_IT");
-        request.setUseExistingTable(true);
-        request.setExistingTableName("H2_CONNECTOR_IMPORT_IT");
-        request.setMappings(mappingsForHeaders(parsedCsv.getOriginalHeaders()));
-
         List<DbColumnMeta> dbColumns = List.of(
                 new DbColumnMeta("ID", "INTEGER", java.sql.Types.INTEGER, 10, 10, 0, false, null, 1),
                 new DbColumnMeta("NAME", "VARCHAR", java.sql.Types.VARCHAR, 128, 128, 0, false, null, 2),
                 new DbColumnMeta("SOURCE", "VARCHAR", java.sql.Types.VARCHAR, 20, 20, 0, false, "'CSV'", 3)
         );
+        DbTableTargetConfiguration configuration = new DbTableTargetConfiguration(
+                LIBRARY,
+                "H2_CONNECTOR_IMPORT_IT",
+                DbTableWriteMode.INSERT_EXISTING,
+                false,
+                List.of(),
+                mappingsForHeaders(parsedCsv.getOriginalHeaders()),
+                List.of(),
+                dbColumns
+        );
 
-        DbTableTargetConnector target = new DbTableTargetConnector(importService, request, dbColumns);
+        DbTableTargetConnector target = new DbTableTargetConnector(importService, configuration);
         new DataFlow(new CsvSourceConnector(parsedCsv), target).execute();
         ImportResult result = target.getResult();
 

--- a/src/test/java/com/zeus/upload/connector/db/DbTableTargetConnectorIntegrationTest.java
+++ b/src/test/java/com/zeus/upload/connector/db/DbTableTargetConnectorIntegrationTest.java
@@ -1,0 +1,117 @@
+package com.zeus.upload.connector.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.connector.file.CsvSourceConnector;
+import com.zeus.upload.domain.ColumnMapping;
+import com.zeus.upload.domain.DbColumnMeta;
+import com.zeus.upload.domain.ImportRequest;
+import com.zeus.upload.domain.ImportResult;
+import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.flow.DataFlow;
+import com.zeus.upload.service.CsvParsingService;
+import com.zeus.upload.service.ImportService;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class DbTableTargetConnectorIntegrationTest {
+
+    private static final String LIBRARY = "TESTLIB";
+
+    @Autowired
+    private CsvParsingService csvParsingService;
+
+    @Autowired
+    private ImportService importService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void shouldWriteExistingTableFlowThroughConnectorAdapter() throws IOException {
+        jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS \"TESTLIB\"");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS \"TESTLIB\".\"H2_CONNECTOR_IMPORT_IT\"");
+        jdbcTemplate.execute("""
+                CREATE TABLE "TESTLIB"."H2_CONNECTOR_IMPORT_IT" (
+                  "ID" INTEGER NOT NULL,
+                  "NAME" VARCHAR(128) NOT NULL,
+                  "SOURCE" VARCHAR(20) NOT NULL DEFAULT 'CSV'
+                )
+                """);
+
+        ParsedCsv parsedCsv = parseSampleCsv();
+        ImportRequest request = new ImportRequest();
+        request.setLibrary(LIBRARY);
+        request.setTableName("H2_CONNECTOR_IMPORT_IT");
+        request.setUseExistingTable(true);
+        request.setExistingTableName("H2_CONNECTOR_IMPORT_IT");
+        request.setMappings(mappingsForHeaders(parsedCsv.getOriginalHeaders()));
+
+        List<DbColumnMeta> dbColumns = List.of(
+                new DbColumnMeta("ID", "INTEGER", java.sql.Types.INTEGER, 10, 10, 0, false, null, 1),
+                new DbColumnMeta("NAME", "VARCHAR", java.sql.Types.VARCHAR, 128, 128, 0, false, null, 2),
+                new DbColumnMeta("SOURCE", "VARCHAR", java.sql.Types.VARCHAR, 20, 20, 0, false, "'CSV'", 3)
+        );
+
+        DbTableTargetConnector target = new DbTableTargetConnector(importService, request, dbColumns);
+        new DataFlow(new CsvSourceConnector(parsedCsv), target).execute();
+        ImportResult result = target.getResult();
+
+        assertThat(result).isNotNull();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getInsertedRows()).isEqualTo(3);
+
+        Integer rowCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM \"TESTLIB\".\"H2_CONNECTOR_IMPORT_IT\"",
+                Integer.class
+        );
+        String source = jdbcTemplate.queryForObject(
+                "SELECT \"SOURCE\" FROM \"TESTLIB\".\"H2_CONNECTOR_IMPORT_IT\" WHERE \"ID\" = 1",
+                String.class
+        );
+        assertThat(rowCount).isEqualTo(3);
+        assertThat(source).isEqualTo("CSV");
+    }
+
+    private ParsedCsv parseSampleCsv() throws IOException {
+        ClassPathResource resource = new ClassPathResource("examples/sample.csv");
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "sample.csv",
+                "text/csv",
+                resource.getInputStream()
+        );
+        return csvParsingService.parse(file);
+    }
+
+    private List<ColumnMapping> mappingsForHeaders(List<String> headers) {
+        List<ColumnMapping> mappings = new ArrayList<>();
+        for (int i = 0; i < headers.size(); i++) {
+            String header = headers.get(i);
+            String target = null;
+            if ("id".equalsIgnoreCase(header)) {
+                target = "ID";
+            }
+            if ("name".equalsIgnoreCase(header)) {
+                target = "NAME";
+            }
+            ColumnMapping mapping = new ColumnMapping();
+            mapping.setCsvIndex(i);
+            mapping.setCsvColumn(header);
+            mapping.setTargetColumn(target);
+            mapping.setIgnored(false);
+            mappings.add(mapping);
+        }
+        return mappings;
+    }
+}

--- a/src/test/java/com/zeus/upload/connector/file/CsvSourceConnectorTest.java
+++ b/src/test/java/com/zeus/upload/connector/file/CsvSourceConnectorTest.java
@@ -1,0 +1,45 @@
+package com.zeus.upload.connector.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.config.AppProperties;
+import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.service.CsvParsingService;
+import com.zeus.upload.service.TypeInferenceService;
+import com.zeus.upload.util.ColumnNameSanitizer;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mock.web.MockMultipartFile;
+
+class CsvSourceConnectorTest {
+
+    @Test
+    void shouldEmitOrderedRecordsFromParsedCsv() throws IOException {
+        CsvParsingService csvParsingService = new CsvParsingService(
+                new TypeInferenceService(),
+                new ColumnNameSanitizer(),
+                new AppProperties()
+        );
+        ParsedCsv parsedCsv = csvParsingService.parse(sampleCsv());
+
+        List<com.zeus.upload.flow.DataRecord> records = new CsvSourceConnector(parsedCsv).read().toList();
+
+        assertThat(records).hasSize(3);
+        assertThat(List.copyOf(records.get(0).asMap().keySet()))
+                .containsExactlyElementsOf(parsedCsv.getProposals().stream().map(p -> p.getFinalName()).toList());
+        assertThat(List.copyOf(records.get(0).asMap().values()))
+                .containsExactly("1", "Alice", "123.45", "2025-01-20", "2025-01-20 10:15:30");
+    }
+
+    private MockMultipartFile sampleCsv() throws IOException {
+        ClassPathResource resource = new ClassPathResource("examples/sample.csv");
+        return new MockMultipartFile(
+                "file",
+                "sample.csv",
+                "text/csv",
+                resource.getInputStream()
+        );
+    }
+}

--- a/src/test/java/com/zeus/upload/controller/UploadControllerExistingTableTest.java
+++ b/src/test/java/com/zeus/upload/controller/UploadControllerExistingTableTest.java
@@ -13,8 +13,9 @@ import com.zeus.upload.domain.ColumnMapping;
 import com.zeus.upload.domain.ColumnProposal;
 import com.zeus.upload.domain.DbColumnMeta;
 import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.flow.FlowConfigurationFactory;
+import com.zeus.upload.flow.FlowExecutionService;
 import com.zeus.upload.service.CsvParsingService;
-import com.zeus.upload.service.ImportService;
 import com.zeus.upload.service.MappingService;
 import com.zeus.upload.service.MetadataService;
 import java.util.List;
@@ -35,9 +36,6 @@ class UploadControllerExistingTableTest {
     private CsvParsingService csvParsingService;
 
     @MockBean
-    private ImportService importService;
-
-    @MockBean
     private MetadataService metadataService;
 
     @MockBean
@@ -45,6 +43,12 @@ class UploadControllerExistingTableTest {
 
     @MockBean
     private AppProperties appProperties;
+
+    @MockBean
+    private FlowConfigurationFactory flowConfigurationFactory;
+
+    @MockBean
+    private FlowExecutionService flowExecutionService;
 
     @Test
     void uploadShouldRenderPreviewWithMappingsForExistingTableMode() throws Exception {

--- a/src/test/java/com/zeus/upload/flow/DataFlowTest.java
+++ b/src/test/java/com/zeus/upload/flow/DataFlowTest.java
@@ -1,0 +1,29 @@
+package com.zeus.upload.flow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.connector.SourceConnector;
+import com.zeus.upload.connector.TargetConnector;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class DataFlowTest {
+
+    @Test
+    void shouldPassSourceRecordsToTarget() {
+        DataRecord first = new DataRecord();
+        first.set("ID", 1);
+        DataRecord second = new DataRecord();
+        second.set("ID", 2);
+
+        SourceConnector source = () -> Stream.of(first, second);
+        List<DataRecord> written = new ArrayList<>();
+        TargetConnector target = records -> records.forEach(written::add);
+
+        new DataFlow(source, target).execute();
+
+        assertThat(written).containsExactly(first, second);
+    }
+}

--- a/src/test/java/com/zeus/upload/flow/DataRecordTest.java
+++ b/src/test/java/com/zeus/upload/flow/DataRecordTest.java
@@ -1,0 +1,21 @@
+package com.zeus.upload.flow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DataRecordTest {
+
+    @Test
+    void shouldStoreAndExposeValuesInInsertionOrder() {
+        DataRecord record = new DataRecord();
+
+        record.set("ID", 1);
+        record.set("NAME", "Alice");
+
+        assertThat(record.get("ID")).isEqualTo(1);
+        assertThat(record.get("NAME")).isEqualTo("Alice");
+        assertThat(List.copyOf(record.asMap().keySet())).containsExactly("ID", "NAME");
+    }
+}

--- a/src/test/java/com/zeus/upload/flow/FlowConfigurationFactoryTest.java
+++ b/src/test/java/com/zeus/upload/flow/FlowConfigurationFactoryTest.java
@@ -1,0 +1,90 @@
+package com.zeus.upload.flow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.domain.ColumnMapping;
+import com.zeus.upload.domain.ColumnProposal;
+import com.zeus.upload.domain.DbColumnMeta;
+import com.zeus.upload.domain.ImportRequest;
+import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.domain.PreviewContext;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class FlowConfigurationFactoryTest {
+
+    private final FlowConfigurationFactory factory = new FlowConfigurationFactory();
+
+    @Test
+    void shouldCreateCreateTableFlowConfiguration() {
+        ImportRequest request = new ImportRequest();
+        request.setLibrary("TESTLIB");
+        request.setTableName("NEW_TABLE");
+        request.setDropAndRecreate(true);
+        request.setColumns(List.of(column("ID")));
+
+        PreviewContext previewContext = new PreviewContext();
+        ParsedCsv parsedCsv = new ParsedCsv();
+        parsedCsv.getOriginalHeaders().add("id");
+        previewContext.setParsedCsv(parsedCsv);
+
+        FlowConfiguration configuration = factory.fromImportContext(request, previewContext);
+
+        assertThat(configuration.getSource()).isInstanceOf(CsvSourceConfiguration.class);
+        assertThat(configuration.getTarget()).isInstanceOf(DbTableTargetConfiguration.class);
+
+        DbTableTargetConfiguration target = (DbTableTargetConfiguration) configuration.getTarget();
+        assertThat(target.getLibrary()).isEqualTo("TESTLIB");
+        assertThat(target.getTableName()).isEqualTo("NEW_TABLE");
+        assertThat(target.getWriteMode()).isEqualTo(DbTableWriteMode.CREATE_TABLE);
+        assertThat(target.isDropAndRecreate()).isTrue();
+        assertThat(target.getColumns()).hasSize(1);
+    }
+
+    @Test
+    void shouldCreateExistingTableUpsertFlowConfiguration() {
+        ImportRequest request = new ImportRequest();
+        request.setLibrary("TESTLIB");
+        request.setTableName("TMP_TABLE");
+        request.setUseExistingTable(true);
+        request.setExistingTableName("PERSON");
+        request.setUpsertEnabled(true);
+        request.setMappings(List.of(mapping("id", 0, "ID")));
+        request.setKeyColumns(List.of("ID"));
+
+        PreviewContext previewContext = new PreviewContext();
+        ParsedCsv parsedCsv = new ParsedCsv();
+        parsedCsv.getOriginalHeaders().add("id");
+        previewContext.setParsedCsv(parsedCsv);
+        previewContext.setDbColumns(List.of(
+                new DbColumnMeta("ID", "INTEGER", java.sql.Types.INTEGER, 10, 10, 0, false, null, 1)
+        ));
+
+        FlowConfiguration configuration = factory.fromImportContext(request, previewContext);
+
+        DbTableTargetConfiguration target = (DbTableTargetConfiguration) configuration.getTarget();
+        assertThat(target.getTableName()).isEqualTo("PERSON");
+        assertThat(target.getWriteMode()).isEqualTo(DbTableWriteMode.UPSERT_EXISTING);
+        assertThat(target.getMappings()).hasSize(1);
+        assertThat(target.getKeyColumns()).containsExactly("ID");
+        assertThat(target.getDbColumns()).hasSize(1);
+    }
+
+    private ColumnProposal column(String finalName) {
+        ColumnProposal proposal = new ColumnProposal();
+        proposal.setIndex(0);
+        proposal.setOriginalName(finalName);
+        proposal.setSanitizedName(finalName);
+        proposal.setFinalName(finalName);
+        proposal.setSqlType("INTEGER");
+        return proposal;
+    }
+
+    private ColumnMapping mapping(String csvColumn, int csvIndex, String targetColumn) {
+        ColumnMapping mapping = new ColumnMapping();
+        mapping.setCsvColumn(csvColumn);
+        mapping.setCsvIndex(csvIndex);
+        mapping.setTargetColumn(targetColumn);
+        return mapping;
+    }
+}

--- a/src/test/java/com/zeus/upload/flow/FlowExecutionServiceTest.java
+++ b/src/test/java/com/zeus/upload/flow/FlowExecutionServiceTest.java
@@ -1,0 +1,71 @@
+package com.zeus.upload.flow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.connector.ConnectorFactory;
+import com.zeus.upload.connector.ImportResultAwareTargetConnector;
+import com.zeus.upload.connector.SourceConnector;
+import com.zeus.upload.connector.TargetConnector;
+import com.zeus.upload.domain.ImportResult;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class FlowExecutionServiceTest {
+
+    @Test
+    void shouldExecuteConfiguredFlowAndReturnTargetResult() {
+        ImportResult expected = ImportResult.success("ok", "", 1);
+        ConnectorFactory connectorFactory = new StubConnectorFactory(expected);
+        FlowExecutionService service = new FlowExecutionService(connectorFactory);
+        FlowConfiguration configuration = new FlowConfiguration(new StubSourceConfiguration(), new StubTargetConfiguration());
+
+        ImportResult result = service.execute(configuration);
+
+        assertThat(result).isSameAs(expected);
+    }
+
+    private static class StubConnectorFactory extends ConnectorFactory {
+
+        private final ImportResult result;
+
+        private StubConnectorFactory(ImportResult result) {
+            super(null);
+            this.result = result;
+        }
+
+        @Override
+        public SourceConnector createSource(SourceConfiguration configuration) {
+            return Stream::empty;
+        }
+
+        @Override
+        public TargetConnector createTarget(TargetConfiguration configuration) {
+            return new StubTargetConnector(result);
+        }
+    }
+
+    private record StubSourceConfiguration() implements SourceConfiguration {
+    }
+
+    private record StubTargetConfiguration() implements TargetConfiguration {
+    }
+
+    private static class StubTargetConnector implements ImportResultAwareTargetConnector {
+
+        private final ImportResult result;
+
+        private StubTargetConnector(ImportResult result) {
+            this.result = result;
+        }
+
+        @Override
+        public void write(Stream<com.zeus.upload.flow.DataRecord> records) {
+            records.count();
+        }
+
+        @Override
+        public ImportResult getImportResult() {
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- analyzes the current implementation and documents the migration path in docs/architecture/connector-architecture-analysis.md
- introduces a minimal connector abstraction with DataRecord, SourceConnector, TargetConnector, and DataFlow
- adds a connector configuration model with FlowConfiguration, typed source/target configs, a configuration factory, and connector factory/execution services
- wraps the existing CSV->DB behavior in CsvSourceConnector and DbTableTargetConnector while removing concrete connector wiring from the controller
- updates V2_ROADMAP.md and README.md for the multi-connector direction
- keeps current functionality intact while reusing the existing parsing, mapping, metadata, and import services

## Verification
- mvn -q test
- mvn -q package

Refs #41
Closes #42
Closes #43
Closes #44