### PR TITLE
Add safe import controls and CSV settings

### DIFF
--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -1,5 +1,52 @@
 # V2 Roadmap
 
+## tiny-tool.de Product Roadmap (2026-08-04)
+
+Product goal: turn the current CSV-to-DB flow into a safe, comfortable mass-data
+processing workspace with automatic mapping and precise manual control.
+
+### Phase 0 — Safe foundation (current)
+
+- Preserve the existing CSV -> DB2/400 workflow.
+- Make every write operation previewable via a transaction-backed dry run.
+- Expose a neutral operation model in the flow configuration.
+- Keep validation, mapping and execution results explicit and testable.
+
+### Phase 1 — Mass-data MVP
+
+- CSV and Excel upload with encoding, delimiter and quote options.
+- Insert, update, upsert/merge and delete operations.
+- Automatic mapping with confidence indicators and manual overrides.
+- Key-column selection, transformations and null/empty-value policies.
+- Preview of affected rows, validation errors and conflict handling.
+
+### Phase 2 — Repeatable workflows
+
+- Save and load import profiles.
+- Background jobs with progress, cancellation and retry.
+- Job history, downloadable error reports and audit trail.
+- API endpoints for starting and inspecting jobs.
+
+### Phase 3 — Connectors and automation
+
+- Database sources and targets beyond the initial DB2/400 connector.
+- REST, filesystem, FTP/SFTP and object-storage connectors.
+- Scheduled synchronizations and reusable multi-step flows.
+- Tenant isolation, roles, secrets management and usage limits for tiny-tool.de.
+
+### Product guardrails
+
+- Destructive operations require an explicit preview and confirmation.
+- Dry runs must use the same validation and SQL path as real executions.
+- Existing successful CSV -> DB behavior remains backwards compatible.
+- Large imports run in batches and never require loading the complete file into the UI.
+
+### Current implementation slice
+
+`Dry Run` is the first Phase 0 feature. It is available for create-table,
+insert-existing and upsert-existing flows and rolls back the transaction while
+returning the same affected-row count and generated SQL for review.
+
 ## Product Direction
 
 `zeus-easy-upload` is no longer just a CSV-to-DB prototype. The current application already supports:

--- a/src/main/java/com/zeus/upload/connector/db/DbTableTargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/db/DbTableTargetConnector.java
@@ -41,7 +41,8 @@ public class DbTableTargetConnector implements ImportResultAwareTargetConnector 
                     parsedCsv,
                     configuration.getDbColumns(),
                     configuration.getMappings(),
-                    configuration.getKeyColumns()
+                    configuration.getKeyColumns(),
+                    configuration.isDryRun()
             );
             return;
         }
@@ -51,7 +52,8 @@ public class DbTableTargetConnector implements ImportResultAwareTargetConnector 
                 configuration.getTableName(),
                 parsedCsv,
                 configuration.getDbColumns(),
-                configuration.getMappings()
+                configuration.getMappings(),
+                configuration.isDryRun()
         );
     }
 
@@ -75,6 +77,7 @@ public class DbTableTargetConnector implements ImportResultAwareTargetConnector 
         importRequest.setLibrary(configuration.getLibrary());
         importRequest.setTableName(configuration.getTableName());
         importRequest.setDropAndRecreate(configuration.isDropAndRecreate());
+        importRequest.setDryRun(configuration.isDryRun());
         importRequest.setColumns(configuration.getColumns());
         return importRequest;
     }

--- a/src/main/java/com/zeus/upload/controller/UploadController.java
+++ b/src/main/java/com/zeus/upload/controller/UploadController.java
@@ -3,6 +3,7 @@ package com.zeus.upload.controller;
 import com.zeus.upload.domain.ColumnMapping;
 import com.zeus.upload.config.AppProperties;
 import com.zeus.upload.domain.ColumnProposal;
+import com.zeus.upload.domain.CsvImportOptions;
 import com.zeus.upload.domain.DbColumnMeta;
 import com.zeus.upload.domain.ImportRequest;
 import com.zeus.upload.domain.ImportResult;
@@ -86,6 +87,9 @@ public class UploadController {
             @RequestParam(value = "dropAndRecreate", defaultValue = "false") boolean dropAndRecreate,
             @RequestParam(value = "useExistingTable", defaultValue = "false") boolean useExistingTable,
             @RequestParam(value = "existingTableName", required = false) String existingTableName,
+            @RequestParam(value = "csvDelimiter", required = false) String csvDelimiter,
+            @RequestParam(value = "csvEncoding", required = false) String csvEncoding,
+            @RequestParam(value = "csvQuote", required = false) String csvQuote,
             @ModelAttribute("previewContext") PreviewContext previewContext,
             Model model,
             RedirectAttributes redirectAttributes
@@ -96,7 +100,13 @@ public class UploadController {
         }
 
         try {
-            var parsed = csvParsingService.parse(file);
+            CsvImportOptions csvOptions = new CsvImportOptions();
+            csvOptions.setDelimiter(csvDelimiter);
+            csvOptions.setEncoding(csvEncoding);
+            csvOptions.setQuote(csvQuote);
+            var parsed = isDefaultCsvOptions(csvOptions)
+                    ? csvParsingService.parse(file)
+                    : csvParsingService.parse(file, csvOptions);
             ImportRequest request = new ImportRequest();
             request.setLibrary(library);
             request.setTableName(tableName);
@@ -111,6 +121,9 @@ public class UploadController {
             request.setColumns(copyColumns(parsed.getProposals()));
             request.setUpsertEnabled(false);
             request.setKeyColumns(List.of());
+            request.setCsvDelimiter(csvDelimiter);
+            request.setCsvEncoding(csvEncoding);
+            request.setCsvQuote(csvQuote);
 
             if (useExistingTable && StringUtils.hasText(existingTableName)) {
                 List<DbColumnMeta> dbColumns = metadataService.listColumns(library, existingTableName);
@@ -221,6 +234,12 @@ public class UploadController {
             copy.add(c);
         }
         return copy;
+    }
+
+    private boolean isDefaultCsvOptions(CsvImportOptions options) {
+        return !StringUtils.hasText(options.getDelimiter())
+                && (!StringUtils.hasText(options.getEncoding()) || "UTF-8".equalsIgnoreCase(options.getEncoding()))
+                && (!StringUtils.hasText(options.getQuote()) || "\"".equals(options.getQuote()));
     }
 
     private List<ColumnMapping> copyMappings(List<ColumnMapping> source) {

--- a/src/main/java/com/zeus/upload/domain/CsvImportOptions.java
+++ b/src/main/java/com/zeus/upload/domain/CsvImportOptions.java
@@ -1,0 +1,51 @@
+package com.zeus.upload.domain;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class CsvImportOptions {
+
+    private String delimiter;
+    private String encoding = StandardCharsets.UTF_8.name();
+    private String quote = "\"";
+
+    public static CsvImportOptions defaults() {
+        return new CsvImportOptions();
+    }
+
+    public char delimiterOr(char fallback) {
+        return delimiter == null || delimiter.isBlank() ? fallback : delimiter.charAt(0);
+    }
+
+    public char quoteOr(char fallback) {
+        return quote == null || quote.isBlank() ? fallback : quote.charAt(0);
+    }
+
+    public Charset charset() {
+        return Charset.forName(encoding == null || encoding.isBlank() ? StandardCharsets.UTF_8.name() : encoding);
+    }
+
+    public String getDelimiter() {
+        return delimiter;
+    }
+
+    public void setDelimiter(String delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
+    }
+
+    public String getQuote() {
+        return quote;
+    }
+
+    public void setQuote(String quote) {
+        this.quote = quote;
+    }
+}

--- a/src/main/java/com/zeus/upload/domain/ImportRequest.java
+++ b/src/main/java/com/zeus/upload/domain/ImportRequest.java
@@ -16,6 +16,10 @@ public class ImportRequest {
     private boolean dropAndRecreate;
     private boolean useExistingTable;
     private boolean upsertEnabled;
+    private boolean dryRun;
+    private String csvDelimiter;
+    private String csvEncoding;
+    private String csvQuote;
     private String existingTableName;
     private List<String> keyColumns = new ArrayList<>();
 
@@ -69,6 +73,38 @@ public class ImportRequest {
 
     public void setUpsertEnabled(boolean upsertEnabled) {
         this.upsertEnabled = upsertEnabled;
+    }
+
+    public boolean isDryRun() {
+        return dryRun;
+    }
+
+    public void setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
+    }
+
+    public String getCsvDelimiter() {
+        return csvDelimiter;
+    }
+
+    public void setCsvDelimiter(String csvDelimiter) {
+        this.csvDelimiter = csvDelimiter;
+    }
+
+    public String getCsvEncoding() {
+        return csvEncoding;
+    }
+
+    public void setCsvEncoding(String csvEncoding) {
+        this.csvEncoding = csvEncoding;
+    }
+
+    public String getCsvQuote() {
+        return csvQuote;
+    }
+
+    public void setCsvQuote(String csvQuote) {
+        this.csvQuote = csvQuote;
     }
 
     public List<String> getKeyColumns() {

--- a/src/main/java/com/zeus/upload/flow/DbTableTargetConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/DbTableTargetConfiguration.java
@@ -13,6 +13,7 @@ public class DbTableTargetConfiguration implements TargetConfiguration {
     private final String tableName;
     private final DbTableWriteMode writeMode;
     private final boolean dropAndRecreate;
+    private final boolean dryRun;
     private final List<ColumnProposal> columns;
     private final List<ColumnMapping> mappings;
     private final List<String> keyColumns;
@@ -28,10 +29,25 @@ public class DbTableTargetConfiguration implements TargetConfiguration {
             List<String> keyColumns,
             List<DbColumnMeta> dbColumns
     ) {
+        this(library, tableName, writeMode, dropAndRecreate, false, columns, mappings, keyColumns, dbColumns);
+    }
+
+    public DbTableTargetConfiguration(
+            String library,
+            String tableName,
+            DbTableWriteMode writeMode,
+            boolean dropAndRecreate,
+            boolean dryRun,
+            List<ColumnProposal> columns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns,
+            List<DbColumnMeta> dbColumns
+    ) {
         this.library = Objects.requireNonNull(library, "library must not be null");
         this.tableName = Objects.requireNonNull(tableName, "tableName must not be null");
         this.writeMode = Objects.requireNonNull(writeMode, "writeMode must not be null");
         this.dropAndRecreate = dropAndRecreate;
+        this.dryRun = dryRun;
         this.columns = columns == null ? List.of() : List.copyOf(new ArrayList<>(columns));
         this.mappings = mappings == null ? List.of() : List.copyOf(new ArrayList<>(mappings));
         this.keyColumns = keyColumns == null ? List.of() : List.copyOf(new ArrayList<>(keyColumns));
@@ -52,6 +68,10 @@ public class DbTableTargetConfiguration implements TargetConfiguration {
 
     public boolean isDropAndRecreate() {
         return dropAndRecreate;
+    }
+
+    public boolean isDryRun() {
+        return dryRun;
     }
 
     public List<ColumnProposal> getColumns() {

--- a/src/main/java/com/zeus/upload/flow/FlowConfigurationFactory.java
+++ b/src/main/java/com/zeus/upload/flow/FlowConfigurationFactory.java
@@ -14,6 +14,7 @@ public class FlowConfigurationFactory {
                 resolveTargetTable(importRequest),
                 resolveWriteMode(importRequest),
                 importRequest.isDropAndRecreate(),
+                importRequest.isDryRun(),
                 importRequest.getColumns(),
                 importRequest.getMappings(),
                 importRequest.getKeyColumns(),

--- a/src/main/java/com/zeus/upload/service/CsvParsingService.java
+++ b/src/main/java/com/zeus/upload/service/CsvParsingService.java
@@ -2,6 +2,7 @@ package com.zeus.upload.service;
 
 import com.zeus.upload.config.AppProperties;
 import com.zeus.upload.domain.ColumnProposal;
+import com.zeus.upload.domain.CsvImportOptions;
 import com.zeus.upload.domain.ParseError;
 import com.zeus.upload.domain.ParsedCsv;
 import com.zeus.upload.util.ColumnNameSanitizer;
@@ -40,10 +41,16 @@ public class CsvParsingService {
     }
 
     public ParsedCsv parse(MultipartFile file) throws IOException {
-        String content = new String(file.getBytes(), StandardCharsets.UTF_8);
-        char delimiter = detectDelimiter(content);
+        return parse(file, CsvImportOptions.defaults());
+    }
+
+    public ParsedCsv parse(MultipartFile file, CsvImportOptions options) throws IOException {
+        CsvImportOptions effectiveOptions = options == null ? CsvImportOptions.defaults() : options;
+        String content = new String(file.getBytes(), effectiveOptions.charset());
+        char delimiter = effectiveOptions.delimiterOr(detectDelimiter(content));
         CSVFormat format = CSVFormat.DEFAULT.builder()
                 .setDelimiter(delimiter)
+                .setQuote(effectiveOptions.quoteOr('"'))
                 .setHeader()
                 .setSkipHeaderRecord(true)
                 .setIgnoreEmptyLines(true)

--- a/src/main/java/com/zeus/upload/service/ImportService.java
+++ b/src/main/java/com/zeus/upload/service/ImportService.java
@@ -62,6 +62,10 @@ public class ImportService {
     }
 
     public ImportResult importCsv(ImportRequest request, ParsedCsv parsedCsv) {
+        return importCsv(request, parsedCsv, request.isDryRun());
+    }
+
+    private ImportResult importCsv(ImportRequest request, ParsedCsv parsedCsv, boolean dryRun) {
         List<ParseError> errors = new ArrayList<>();
         String createSql = ddlService.createTableSql(request.getLibrary(), request.getTableName(), request.getColumns());
         String insertSql = ddlService.insertSql(request.getLibrary(), request.getTableName(), request.getColumns());
@@ -88,6 +92,10 @@ public class ImportService {
                 throw new ImportException("Import aborted due to conversion errors", errors);
             }
 
+            if (dryRun) {
+                connection.rollback();
+                return ImportResult.success("Dry run successful; transaction rolled back", createSql, insertedRows);
+            }
             connection.commit();
             return ImportResult.success("Import successful", createSql, insertedRows);
         } catch (ImportException ex) {
@@ -104,6 +112,17 @@ public class ImportService {
             ParsedCsv csv,
             List<DbColumnMeta> dbColumns,
             List<ColumnMapping> mappings
+    ) {
+        return importIntoExistingTable(library, tableName, csv, dbColumns, mappings, false);
+    }
+
+    public ImportResult importIntoExistingTable(
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            boolean dryRun
     ) {
         List<ParseError> errors = new ArrayList<>();
         List<ColumnMapping> effectiveMappings = determineEffectiveMappings(mappings);
@@ -139,6 +158,10 @@ public class ImportService {
                 connection.rollback();
                 throw new ImportException("Import aborted due to insert errors", errors);
             }
+            if (dryRun) {
+                connection.rollback();
+                return ImportResult.success("Dry run successful; transaction rolled back", insertSql, insertedRows);
+            }
             connection.commit();
             return ImportResult.success("Import successful", insertSql, insertedRows);
         } catch (ImportException ex) {
@@ -156,6 +179,18 @@ public class ImportService {
             List<DbColumnMeta> dbColumns,
             List<ColumnMapping> mappings,
             List<String> keyColumns
+    ) {
+        return upsertIntoExistingTable(library, tableName, csv, dbColumns, mappings, keyColumns, false);
+    }
+
+    public ImportResult upsertIntoExistingTable(
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns,
+            boolean dryRun
     ) {
         List<ParseError> errors = new ArrayList<>();
         List<ColumnMapping> effectiveMappings = determineEffectiveMappings(mappings);
@@ -231,6 +266,10 @@ public class ImportService {
             if (!errors.isEmpty()) {
                 connection.rollback();
                 throw new ImportException("Import aborted due to upsert errors", errors);
+            }
+            if (dryRun) {
+                connection.rollback();
+                return ImportResult.success("Dry run successful; transaction rolled back", mergeSql, processedRows);
             }
             connection.commit();
             return ImportResult.success("Upsert successful", mergeSql, processedRows);

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -21,6 +21,35 @@
                             <label for="file" class="form-label">CSV File</label>
                             <input class="form-control" id="file" name="file" type="file" accept=".csv,text/csv" required>
                         </div>
+                        <div class="card border-0 bg-light mb-4">
+                            <div class="card-body">
+                                <h6 class="mb-3">CSV Settings</h6>
+                                <div class="row">
+                                    <div class="col-md-4 mb-2">
+                                        <label for="csvDelimiter" class="form-label">Delimiter</label>
+                                        <select class="form-select" id="csvDelimiter" name="csvDelimiter">
+                                            <option value="">Auto-detect</option>
+                                            <option value=",">Comma (,)</option>
+                                            <option value=";">Semicolon (;)</option>
+                                            <option value="|">Pipe (|)</option>
+                                            <option value="&#9;">Tab</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-md-4 mb-2">
+                                        <label for="csvEncoding" class="form-label">Encoding</label>
+                                        <select class="form-select" id="csvEncoding" name="csvEncoding">
+                                            <option value="UTF-8" selected>UTF-8</option>
+                                            <option value="windows-1252">Windows-1252</option>
+                                            <option value="ISO-8859-1">ISO-8859-1</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-md-4 mb-2">
+                                        <label for="csvQuote" class="form-label">Quote</label>
+                                        <input class="form-control" id="csvQuote" name="csvQuote" value="&quot;" maxlength="1">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                         <div class="row">
                             <div class="col-md-6 mb-3">
                                 <label for="library" class="form-label">Library (Schema)</label>

--- a/src/main/resources/templates/preview.html
+++ b/src/main/resources/templates/preview.html
@@ -38,6 +38,9 @@
     <form th:action="@{/import}" th:object="${importRequest}" method="post">
         <input type="hidden" th:field="*{useExistingTable}">
         <input type="hidden" th:field="*{existingTableName}">
+        <input type="hidden" th:field="*{csvDelimiter}">
+        <input type="hidden" th:field="*{csvEncoding}">
+        <input type="hidden" th:field="*{csvQuote}">
 
         <div class="card shadow-sm mb-3">
             <div class="card-body">
@@ -80,6 +83,11 @@
                         </select>
                         <div class="form-text">Keys must uniquely identify a row.</div>
                     </div>
+                </div>
+                <div class="form-check form-switch mt-2">
+                    <input class="form-check-input" type="checkbox" th:field="*{dryRun}" id="dryRun">
+                    <label class="form-check-label" for="dryRun">Dry Run — prüfen, aber nichts dauerhaft schreiben</label>
+                    <div class="form-text">Die echte Transaktion wird ausgeführt und anschließend vollständig zurückgerollt.</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## What changed\n- add transaction-backed dry runs for create, insert and upsert flows\n- add configurable CSV delimiter, encoding and quote settings\n- preserve the existing default parser path for compatibility\n- document the tiny-tool.de product roadmap and guardrails\n\n## Validation\n- Maven test suite: 44 tests, 0 failures, 1 skipped\n- build successful\n