### PR TITLE
Add GitHub Actions Maven CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Build and test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Maven test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Run tests
+        run: mvn --batch-mode --no-transfer-progress test


### PR DESCRIPTION
## What changed\n- add GitHub Actions CI for pushes and pull requests targeting main\n- run the existing Maven test suite on Java 17\n- enable Maven dependency caching\n\n## Validation\n- local Maven test: 44 tests, 0 failures, 1 skipped\n