### PR TITLE
Add explicit update and delete operations

### DIFF
--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -44,8 +44,13 @@ processing workspace with automatic mapping and precise manual control.
 ### Current implementation slice
 
 `Dry Run` is the first Phase 0 feature. It is available for create-table,
-insert-existing and upsert-existing flows and rolls back the transaction while
-returning the same affected-row count and generated SQL for review.
+insert-existing, update-existing, delete-existing and upsert-existing flows
+and rolls back the transaction while returning the affected-row count and
+generated SQL for review.
+
+The first Phase 1 operation slice is also implemented: existing-table flows
+now expose Insert, Update, Upsert/Merge and Delete. Update and Delete require
+explicit key mappings and are covered by H2 integration tests.
 
 ## Product Direction
 

--- a/src/main/java/com/zeus/upload/connector/db/DbTableTargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/db/DbTableTargetConnector.java
@@ -47,6 +47,22 @@ public class DbTableTargetConnector implements ImportResultAwareTargetConnector 
             return;
         }
 
+        if (configuration.getWriteMode() == DbTableWriteMode.UPDATE_EXISTING) {
+            result = importService.updateIntoExistingTable(
+                    configuration.getLibrary(), configuration.getTableName(), parsedCsv,
+                    configuration.getDbColumns(), configuration.getMappings(),
+                    configuration.getKeyColumns(), configuration.isDryRun());
+            return;
+        }
+
+        if (configuration.getWriteMode() == DbTableWriteMode.DELETE_EXISTING) {
+            result = importService.deleteFromExistingTable(
+                    configuration.getLibrary(), configuration.getTableName(), parsedCsv,
+                    configuration.getDbColumns(), configuration.getMappings(),
+                    configuration.getKeyColumns(), configuration.isDryRun());
+            return;
+        }
+
         result = importService.importIntoExistingTable(
                 configuration.getLibrary(),
                 configuration.getTableName(),

--- a/src/main/java/com/zeus/upload/controller/UploadController.java
+++ b/src/main/java/com/zeus/upload/controller/UploadController.java
@@ -120,6 +120,7 @@ public class UploadController {
             }
             request.setColumns(copyColumns(parsed.getProposals()));
             request.setUpsertEnabled(false);
+            request.setOperation(useExistingTable ? "INSERT" : "CREATE");
             request.setKeyColumns(List.of());
             request.setCsvDelimiter(csvDelimiter);
             request.setCsvEncoding(csvEncoding);
@@ -190,7 +191,7 @@ public class UploadController {
                     previewContext.getParsedCsv(),
                     dbColumns,
                     importRequest.getMappings(),
-                    importRequest.isUpsertEnabled(),
+                    importRequest.getOperation(),
                     importRequest.getKeyColumns()
             );
             if (!validationResult.isValid()) {

--- a/src/main/java/com/zeus/upload/domain/ImportRequest.java
+++ b/src/main/java/com/zeus/upload/domain/ImportRequest.java
@@ -17,6 +17,7 @@ public class ImportRequest {
     private boolean useExistingTable;
     private boolean upsertEnabled;
     private boolean dryRun;
+    private String operation = "INSERT";
     private String csvDelimiter;
     private String csvEncoding;
     private String csvQuote;
@@ -81,6 +82,14 @@ public class ImportRequest {
 
     public void setDryRun(boolean dryRun) {
         this.dryRun = dryRun;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public void setOperation(String operation) {
+        this.operation = operation;
     }
 
     public String getCsvDelimiter() {

--- a/src/main/java/com/zeus/upload/flow/DbTableWriteMode.java
+++ b/src/main/java/com/zeus/upload/flow/DbTableWriteMode.java
@@ -3,5 +3,7 @@ package com.zeus.upload.flow;
 public enum DbTableWriteMode {
     CREATE_TABLE,
     INSERT_EXISTING,
+    UPDATE_EXISTING,
+    DELETE_EXISTING,
     UPSERT_EXISTING
 }

--- a/src/main/java/com/zeus/upload/flow/FlowConfigurationFactory.java
+++ b/src/main/java/com/zeus/upload/flow/FlowConfigurationFactory.java
@@ -27,6 +27,21 @@ public class FlowConfigurationFactory {
         if (!importRequest.isUseExistingTable()) {
             return DbTableWriteMode.CREATE_TABLE;
         }
+        if (importRequest.getOperation() != null) {
+            try {
+                return switch (importRequest.getOperation().trim().toUpperCase()) {
+                    case "UPDATE" -> DbTableWriteMode.UPDATE_EXISTING;
+                    case "DELETE" -> DbTableWriteMode.DELETE_EXISTING;
+                    case "UPSERT" -> DbTableWriteMode.UPSERT_EXISTING;
+                    case "INSERT" -> importRequest.isUpsertEnabled()
+                            ? DbTableWriteMode.UPSERT_EXISTING
+                            : DbTableWriteMode.INSERT_EXISTING;
+                    default -> DbTableWriteMode.INSERT_EXISTING;
+                };
+            } catch (IllegalArgumentException ignored) {
+                // Fall through to the legacy upsert flag.
+            }
+        }
         if (importRequest.isUpsertEnabled()) {
             return DbTableWriteMode.UPSERT_EXISTING;
         }

--- a/src/main/java/com/zeus/upload/service/ImportService.java
+++ b/src/main/java/com/zeus/upload/service/ImportService.java
@@ -183,6 +183,187 @@ public class ImportService {
         return upsertIntoExistingTable(library, tableName, csv, dbColumns, mappings, keyColumns, false);
     }
 
+    public ImportResult updateIntoExistingTable(
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns,
+            boolean dryRun
+    ) {
+        List<ColumnMapping> effectiveMappings = determineEffectiveMappings(mappings);
+        List<String> keys = normalizeSelectedKeys(keyColumns);
+        String sql = "";
+        List<ParseError> errors = validateKeyedOperation(effectiveMappings, dbColumns, keys, "update");
+        if (!errors.isEmpty()) {
+            return ImportResult.failure("Update aborted due to invalid mapping.", sql, errors);
+        }
+
+        List<ColumnMapping> keyMappings = mappingsForKeys(effectiveMappings, keys);
+        List<ColumnMapping> updateMappings = effectiveMappings.stream()
+                .filter(mapping -> !containsNormalized(keys, mapping.getTargetColumn()))
+                .toList();
+        if (updateMappings.isEmpty()) {
+            return ImportResult.failure("Update requires at least one non-key mapped column.", sql,
+                    List.of(new ParseError(0, "", "", "Map at least one non-key column for updates.")));
+        }
+
+        sql = buildUpdateSql(library, tableName, updateMappings, keyMappings);
+        try (Connection connection = dataSource.getConnection()) {
+            connection.setAutoCommit(false);
+            int affectedRows = executeKeyedRows(connection, sql, updateMappings, keyMappings, csv.getRows(), errors);
+            if (!errors.isEmpty()) {
+                connection.rollback();
+                throw new ImportException("Import aborted due to update errors", errors);
+            }
+            if (dryRun) {
+                connection.rollback();
+                return ImportResult.success("Dry run successful; transaction rolled back", sql, affectedRows);
+            }
+            connection.commit();
+            return ImportResult.success("Update successful", sql, affectedRows);
+        } catch (ImportException ex) {
+            return ImportResult.failure(ex.getMessage(), sql, ex.getErrors());
+        } catch (Exception ex) {
+            errors.add(new ParseError(0, "", "", ex.getMessage()));
+            return ImportResult.failure("Update failed: " + ex.getMessage(), sql, errors);
+        }
+    }
+
+    public ImportResult deleteFromExistingTable(
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns,
+            boolean dryRun
+    ) {
+        List<ColumnMapping> effectiveMappings = determineEffectiveMappings(mappings);
+        List<String> keys = normalizeSelectedKeys(keyColumns);
+        String sql = "";
+        List<ParseError> errors = validateKeyedOperation(effectiveMappings, dbColumns, keys, "delete");
+        if (!errors.isEmpty()) {
+            return ImportResult.failure("Delete aborted due to invalid mapping.", sql, errors);
+        }
+
+        List<ColumnMapping> keyMappings = mappingsForKeys(effectiveMappings, keys);
+        sql = buildDeleteSql(library, tableName, keyMappings);
+        try (Connection connection = dataSource.getConnection()) {
+            connection.setAutoCommit(false);
+            int affectedRows = executeKeyedRows(connection, sql, keyMappings, List.of(), csv.getRows(), errors);
+            if (!errors.isEmpty()) {
+                connection.rollback();
+                throw new ImportException("Import aborted due to delete errors", errors);
+            }
+            if (dryRun) {
+                connection.rollback();
+                return ImportResult.success("Dry run successful; transaction rolled back", sql, affectedRows);
+            }
+            connection.commit();
+            return ImportResult.success("Delete successful", sql, affectedRows);
+        } catch (ImportException ex) {
+            return ImportResult.failure(ex.getMessage(), sql, ex.getErrors());
+        } catch (Exception ex) {
+            errors.add(new ParseError(0, "", "", ex.getMessage()));
+            return ImportResult.failure("Delete failed: " + ex.getMessage(), sql, errors);
+        }
+    }
+
+    private List<ParseError> validateKeyedOperation(
+            List<ColumnMapping> mappings,
+            List<DbColumnMeta> dbColumns,
+            List<String> keys,
+            String operation
+    ) {
+        List<ParseError> errors = new ArrayList<>();
+        Set<String> knownColumns = toNormalizedColumnSet(dbColumns);
+        Set<String> mappedColumns = mappings.stream()
+                .map(ColumnMapping::getTargetColumn)
+                .map(this::normalizeColumnName)
+                .collect(java.util.stream.Collectors.toSet());
+        for (ColumnMapping mapping : mappings) {
+            if (!knownColumns.isEmpty() && !knownColumns.contains(normalizeColumnName(mapping.getTargetColumn()))) {
+                errors.add(new ParseError(0, mapping.getTargetColumn(), "", "Mapped target column does not exist in table metadata."));
+            }
+        }
+        if (mappings.isEmpty()) {
+            errors.add(new ParseError(0, "", "", "Map at least one CSV column to a target column."));
+        }
+        if (keys.isEmpty()) {
+            errors.add(new ParseError(0, "", "", "Select at least one key column for " + operation + "."));
+        }
+        for (String key : keys) {
+            if (!knownColumns.isEmpty() && !knownColumns.contains(normalizeColumnName(key))) {
+                errors.add(new ParseError(0, key, "", "Key column does not exist in table metadata."));
+            }
+            if (!mappedColumns.contains(normalizeColumnName(key))) {
+                errors.add(new ParseError(0, key, "", "Key column must be mapped and not ignored."));
+            }
+        }
+        return errors;
+    }
+
+    private List<ColumnMapping> mappingsForKeys(List<ColumnMapping> mappings, List<String> keys) {
+        return mappings.stream().filter(mapping -> containsNormalized(keys, mapping.getTargetColumn())).toList();
+    }
+
+    private String buildUpdateSql(String library, String tableName, List<ColumnMapping> updates, List<ColumnMapping> keys) {
+        String assignments = updates.stream()
+                .map(mapping -> sqlDialect.quoteIdentifier(mapping.getTargetColumn()) + " = ?")
+                .collect(java.util.stream.Collectors.joining(", "));
+        return "UPDATE " + sqlDialect.qualifyTable(library, tableName) + " SET " + assignments
+                + " WHERE " + whereClause(keys);
+    }
+
+    private String buildDeleteSql(String library, String tableName, List<ColumnMapping> keys) {
+        return "DELETE FROM " + sqlDialect.qualifyTable(library, tableName) + " WHERE " + whereClause(keys);
+    }
+
+    private String whereClause(List<ColumnMapping> keys) {
+        return keys.stream()
+                .map(mapping -> sqlDialect.quoteIdentifier(mapping.getTargetColumn()) + " = ?")
+                .collect(java.util.stream.Collectors.joining(" AND "));
+    }
+
+    private int executeKeyedRows(
+            Connection connection,
+            String sql,
+            List<ColumnMapping> valueMappings,
+            List<ColumnMapping> keyMappings,
+            List<List<String>> rows,
+            List<ParseError> errors
+    ) throws SQLException {
+        int affectedRows = 0;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
+                try {
+                    statement.clearParameters();
+                    bindMappings(statement, valueMappings, rows.get(rowIndex), 1);
+                    bindMappings(statement, keyMappings, rows.get(rowIndex), valueMappings.size() + 1);
+                    affectedRows += statement.executeUpdate();
+                } catch (Exception ex) {
+                    errors.add(new ParseError(rowIndex + 2L, "", "", ex.getMessage()));
+                }
+            }
+        }
+        return affectedRows;
+    }
+
+    private void bindMappings(PreparedStatement statement, List<ColumnMapping> mappings, List<String> row, int startIndex)
+            throws SQLException {
+        for (int index = 0; index < mappings.size(); index++) {
+            int csvIndex = mappings.get(index).getCsvIndex();
+            String value = csvIndex < row.size() ? row.get(csvIndex) : null;
+            if (!StringUtils.hasText(value)) {
+                statement.setNull(startIndex + index, Types.VARCHAR);
+            } else {
+                statement.setString(startIndex + index, value.trim());
+            }
+        }
+    }
+
     public ImportResult upsertIntoExistingTable(
             String library,
             String tableName,

--- a/src/main/java/com/zeus/upload/service/MappingService.java
+++ b/src/main/java/com/zeus/upload/service/MappingService.java
@@ -69,12 +69,23 @@ public class MappingService {
             boolean upsertEnabled,
             List<String> keyColumns
     ) {
+        return validate(csv, dbColumns, mappings, upsertEnabled ? "UPSERT" : "INSERT", keyColumns);
+    }
+
+    public MappingValidationResult validate(
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            String operation,
+            List<String> keyColumns
+    ) {
         MappingValidationResult result = new MappingValidationResult();
         List<ColumnMapping> safeMappings = mappings == null ? List.of() : mappings;
         List<DbColumnMeta> safeDbColumns = dbColumns == null ? List.of() : dbColumns;
 
         Set<String> existingColumns = new HashSet<>();
         Map<String, DbColumnMeta> byNormalizedName = new HashMap<>();
+        boolean keyOnlyOperation = "UPDATE".equalsIgnoreCase(operation) || "DELETE".equalsIgnoreCase(operation);
         for (DbColumnMeta dbColumn : safeDbColumns) {
             if (!StringUtils.hasText(dbColumn.getColumnName())) {
                 continue;
@@ -108,7 +119,7 @@ public class MappingService {
                 continue;
             }
             String dbColumnKey = normalizeDbKey(dbColumn.getColumnName());
-            if (!dbColumn.isNullable() && !mappedDbColumns.contains(dbColumnKey) && !hasDefault(dbColumn.getDefaultValue())) {
+            if (!keyOnlyOperation && !dbColumn.isNullable() && !mappedDbColumns.contains(dbColumnKey) && !hasDefault(dbColumn.getDefaultValue())) {
                 result.getErrors().add("Required target column '" + dbColumn.getColumnName()
                         + "' is not mapped and has no default value.");
             }
@@ -143,7 +154,8 @@ public class MappingService {
             }
         }
 
-        if (upsertEnabled) {
+        if ("UPDATE".equalsIgnoreCase(operation) || "DELETE".equalsIgnoreCase(operation)
+                || "UPSERT".equalsIgnoreCase(operation)) {
             Set<String> normalizedKeys = new LinkedHashSet<>();
             List<String> safeKeyColumns = keyColumns == null ? List.of() : keyColumns;
             for (String keyColumn : safeKeyColumns) {
@@ -153,7 +165,7 @@ public class MappingService {
                 normalizedKeys.add(normalizeDbKey(keyColumn));
             }
             if (normalizedKeys.isEmpty()) {
-                result.getErrors().add("At least one key column is required for upsert mode.");
+                result.getErrors().add("At least one key column is required for " + operation.toLowerCase() + " mode.");
             } else {
                 for (String normalizedKey : normalizedKeys) {
                     if (!existingColumns.contains(normalizedKey)) {

--- a/src/main/resources/templates/preview.html
+++ b/src/main/resources/templates/preview.html
@@ -41,6 +41,7 @@
         <input type="hidden" th:field="*{csvDelimiter}">
         <input type="hidden" th:field="*{csvEncoding}">
         <input type="hidden" th:field="*{csvQuote}">
+        <input type="hidden" th:field="*{operation}" id="operationValue">
 
         <div class="card shadow-sm mb-3">
             <div class="card-body">
@@ -69,8 +70,14 @@
                 <div class="row" th:if="${importRequest.useExistingTable}">
                     <div class="col-md-4 mb-3">
                         <div class="form-check mt-1">
-                            <input class="form-check-input" type="checkbox" th:field="*{upsertEnabled}">
-                            <label class="form-check-label">Upsert (MERGE) instead of INSERT</label>
+                            <label class="form-label" for="operationSelect">Operation</label>
+                            <select class="form-select" id="operationSelect">
+                                <option value="INSERT">Insert new rows</option>
+                                <option value="UPDATE">Update existing rows</option>
+                                <option value="UPSERT">Upsert / Merge</option>
+                                <option value="DELETE">Delete matching rows</option>
+                            </select>
+                            <div class="form-text">Update und Delete benötigen Schlüsselspalten.</div>
                         </div>
                     </div>
                     <div class="col-md-8 mb-3">
@@ -241,9 +248,20 @@
         </div>
 
         <button th:if="${!importRequest.useExistingTable}" type="submit" class="btn btn-success">Create Table and Import</button>
-        <button th:if="${importRequest.useExistingTable}" type="submit" class="btn btn-success"
-                th:text="${importRequest.upsertEnabled} ? 'Upsert Into Existing Table' : 'Import Into Existing Table'">Import Into Existing Table</button>
+        <button th:if="${importRequest.useExistingTable}" type="submit" class="btn btn-success">Execute Operation</button>
     </form>
 </div>
+<script th:if="${importRequest.useExistingTable}">
+    (() => {
+        const select = document.getElementById('operationSelect');
+        const hidden = document.getElementById('operationValue');
+        if (!select || !hidden) return;
+        select.value = hidden.value || 'INSERT';
+        select.addEventListener('change', () => {
+            hidden.value = select.value;
+        });
+        hidden.value = select.value;
+    })();
+</script>
 </body>
 </html>

--- a/src/test/java/com/zeus/upload/it/H2ImportIntegrationTest.java
+++ b/src/test/java/com/zeus/upload/it/H2ImportIntegrationTest.java
@@ -136,6 +136,41 @@ class H2ImportIntegrationTest {
     }
 
     @Test
+    void shouldUpdateAndDeleteExistingRowsBySelectedKeys() {
+        jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS \"TESTLIB\"");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS \"TESTLIB\".\"H2_UPDATE_DELETE_IT\"");
+        jdbcTemplate.execute("CREATE TABLE \"TESTLIB\".\"H2_UPDATE_DELETE_IT\" (\"ID\" INTEGER PRIMARY KEY, \"NAME\" VARCHAR(128) NOT NULL)");
+        jdbcTemplate.update("INSERT INTO \"TESTLIB\".\"H2_UPDATE_DELETE_IT\" VALUES (?, ?)", 1, "Old Alice");
+        jdbcTemplate.update("INSERT INTO \"TESTLIB\".\"H2_UPDATE_DELETE_IT\" VALUES (?, ?)", 2, "Bob");
+
+        ParsedCsv updateCsv = rowsCsv(List.of("id", "name"), List.of(List.of("1", "New Alice")));
+        List<DbColumnMeta> dbColumns = List.of(
+                new DbColumnMeta("ID", "INTEGER", java.sql.Types.INTEGER, 10, 10, 0, false, null, 1),
+                new DbColumnMeta("NAME", "VARCHAR", java.sql.Types.VARCHAR, 128, 128, 0, false, null, 2)
+        );
+        List<ColumnMapping> updateMappings = List.of(
+                mapping(0, "id", "ID", false),
+                mapping(1, "name", "NAME", false)
+        );
+
+        assertThat(mappingService.validate(updateCsv, dbColumns, updateMappings, "UPDATE", List.of("ID")).isValid())
+                .isTrue();
+        ImportResult updateResult = importService.updateIntoExistingTable(
+                LIBRARY, "H2_UPDATE_DELETE_IT", updateCsv, dbColumns, updateMappings, List.of("ID"), false);
+        assertThat(updateResult.isSuccess()).isTrue();
+        assertThat(jdbcTemplate.queryForObject("SELECT \"NAME\" FROM \"TESTLIB\".\"H2_UPDATE_DELETE_IT\" WHERE \"ID\" = 1", String.class))
+                .isEqualTo("New Alice");
+
+        ParsedCsv deleteCsv = rowsCsv(List.of("id"), List.of(List.of("2")));
+        List<ColumnMapping> deleteMappings = List.of(mapping(0, "id", "ID", false));
+        ImportResult deleteResult = importService.deleteFromExistingTable(
+                LIBRARY, "H2_UPDATE_DELETE_IT", deleteCsv, dbColumns, deleteMappings, List.of("ID"), false);
+        assertThat(deleteResult.isSuccess()).isTrue();
+        assertThat(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM \"TESTLIB\".\"H2_UPDATE_DELETE_IT\"", Integer.class))
+                .isEqualTo(1);
+    }
+
+    @Test
     @Disabled("H2 MODE=DB2 does not reliably support DB2 for i MERGE ... USING (VALUES ...) syntax.")
     void shouldExecuteDb2StyleMergeSqlAgainstH2() {
         jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS \"TESTLIB\"");
@@ -200,6 +235,13 @@ class H2ImportIntegrationTest {
             mappings.add(mapping(i, header, target, false));
         }
         return mappings;
+    }
+
+    private ParsedCsv rowsCsv(List<String> headers, List<List<String>> rows) {
+        ParsedCsv csv = new ParsedCsv();
+        csv.getOriginalHeaders().addAll(headers);
+        csv.getRows().addAll(rows);
+        return csv;
     }
 
     private ColumnMapping mapping(int csvIndex, String csvColumn, String targetColumn, boolean ignored) {


### PR DESCRIPTION
## What changed\n- introduce an explicit operation model for existing-table flows\n- add safe key-based UPDATE and DELETE execution\n- keep legacy upsertEnabled behavior compatible\n- add operation selection to the preview UI\n- add H2 integration coverage for update and delete\n\n## Validation\n- Maven test: 45 tests, 0 failures, 1 skipped\n- GitHub Actions CI runs the same Maven suite\n