### PR TITLE
Add CSV and JSON error report downloads

### DIFF
--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -76,6 +76,15 @@ Target architecture:
 
 ## Status Overview
 
+### GitHub issue alignment (checked 2026-08-06)
+
+The closed issues confirm the completed foundation: #3, #4, #8, #38 and
+#42-#44 are reflected in the current connector, metadata, mapping and test
+architecture. Issue #12 (CSV encoding/delimiter/quote settings) was completed
+by PR #49 and is ready to be closed. Issue #10 (CSV/JSON error reports) is the
+current implementation slice. The remaining open issues are tracked below by
+their product package rather than treated as separate rewrites.
+
 ### Done: CSV-to-DB foundation
 
 - `#3` Auto-Mapping auf bestehende Tabellen

--- a/src/main/java/com/zeus/upload/controller/ErrorReportController.java
+++ b/src/main/java/com/zeus/upload/controller/ErrorReportController.java
@@ -1,0 +1,52 @@
+package com.zeus.upload.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zeus.upload.domain.ImportResult;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+@Controller
+public class ErrorReportController {
+
+    private final ObjectMapper objectMapper;
+
+    public ErrorReportController(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @GetMapping("/result/errors.csv")
+    public ResponseEntity<byte[]> csv(@SessionAttribute("lastImportResult") ImportResult result) {
+        StringBuilder csv = new StringBuilder("row,column,value,message\r\n");
+        result.getErrors().forEach(error -> csv.append(String.join(",",
+                escape(String.valueOf(error.getRowNumber())),
+                escape(error.getColumnName()),
+                escape(error.getRawValue()),
+                escape(error.getMessage()))).append("\r\n"));
+        return download(csv.toString(), "import-errors.csv", "text/csv");
+    }
+
+    @GetMapping("/result/errors.json")
+    public ResponseEntity<byte[]> json(@SessionAttribute("lastImportResult") ImportResult result)
+            throws JsonProcessingException {
+        return download(objectMapper.writeValueAsString(result.getErrors()), "import-errors.json", "application/json");
+    }
+
+    private ResponseEntity<byte[]> download(String content, String filename, String mediaType) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType(mediaType));
+        headers.setContentDisposition(ContentDisposition.attachment().filename(filename).build());
+        return ResponseEntity.ok().headers(headers).body(content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String escape(String value) {
+        String safe = value == null ? "" : value;
+        return "\"" + safe.replace("\"", "\"\"") + "\"";
+    }
+}

--- a/src/main/java/com/zeus/upload/controller/UploadController.java
+++ b/src/main/java/com/zeus/upload/controller/UploadController.java
@@ -28,13 +28,12 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.SessionAttributes;
-import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.util.StringUtils;
 
 @Controller
-@SessionAttributes("previewContext")
+@SessionAttributes({"previewContext", "lastImportResult"})
 public class UploadController {
 
     private static final Logger log = LoggerFactory.getLogger(UploadController.class);
@@ -167,8 +166,7 @@ public class UploadController {
             @Valid @ModelAttribute("importRequest") ImportRequest importRequest,
             BindingResult bindingResult,
             @ModelAttribute("previewContext") PreviewContext previewContext,
-            Model model,
-            SessionStatus sessionStatus
+            Model model
     ) {
         if (previewContext.getParsedCsv() == null) {
             model.addAttribute("errorMessage", "No upload context found. Please upload the CSV again.");
@@ -209,7 +207,7 @@ public class UploadController {
             result = executeConfiguredFlow(importRequest, previewContext);
         }
         model.addAttribute("result", result);
-        sessionStatus.setComplete();
+        model.addAttribute("lastImportResult", result);
         return "result";
     }
 

--- a/src/main/resources/templates/result.html
+++ b/src/main/resources/templates/result.html
@@ -26,6 +26,10 @@
 
                     <div th:if="${result.errors != null and !result.errors.isEmpty()}">
                         <h5>Errors</h5>
+                        <div class="mb-2">
+                            <a class="btn btn-sm btn-outline-secondary" th:href="@{/result/errors.csv}">Download CSV</a>
+                            <a class="btn btn-sm btn-outline-secondary" th:href="@{/result/errors.json}">Download JSON</a>
+                        </div>
                         <div class="table-responsive">
                             <table class="table table-sm table-striped">
                                 <thead>

--- a/src/test/java/com/zeus/upload/controller/ErrorReportControllerTest.java
+++ b/src/test/java/com/zeus/upload/controller/ErrorReportControllerTest.java
@@ -1,0 +1,24 @@
+package com.zeus.upload.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zeus.upload.domain.ImportResult;
+import com.zeus.upload.domain.ParseError;
+import org.junit.jupiter.api.Test;
+
+class ErrorReportControllerTest {
+
+    @Test
+    void shouldExportErrorsAsCsvAndJson() throws Exception {
+        ImportResult result = ImportResult.failure(
+                "failed", "", java.util.List.of(new ParseError(2, "NAME", "A,lice", "Invalid value")));
+        ErrorReportController controller = new ErrorReportController(new ObjectMapper());
+
+        String csv = new String(controller.csv(result).getBody(), java.nio.charset.StandardCharsets.UTF_8);
+        String json = new String(controller.json(result).getBody(), java.nio.charset.StandardCharsets.UTF_8);
+
+        assertThat(csv).contains("row,column,value,message").contains("\"A,lice\"");
+        assertThat(json).contains("\"rowNumber\":2").contains("\"message\":\"Invalid value\"");
+    }
+}


### PR DESCRIPTION
## What changed\n- retain the last import result for report downloads\n- add CSV and JSON error report endpoints\n- add download actions to the result page\n- document the GitHub issue/agenda alignment\n\n## Validation\n- Maven test: 46 tests, 0 failures, 1 skipped\n- GitHub Actions CI runs the same Maven suite\n\nCloses #10\n