### PR TITLE
Add persistent import profiles

### DIFF
--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -52,6 +52,9 @@ The first Phase 1 operation slice is also implemented: existing-table flows
 now expose Insert, Update, Upsert/Merge and Delete. Update and Delete require
 explicit key mappings and are covered by H2 integration tests.
 
+Import profiles are now available through `/api/profiles` as validated JSON
+files, including list, load, save and delete operations.
+
 ## Product Direction
 
 `zeus-easy-upload` is no longer just a CSV-to-DB prototype. The current application already supports:

--- a/src/main/java/com/zeus/upload/config/AppProperties.java
+++ b/src/main/java/com/zeus/upload/config/AppProperties.java
@@ -21,6 +21,8 @@ public class AppProperties {
     @Max(10_000)
     private int batchSize = 500;
 
+    private String profileDirectory = "profiles";
+
     public String getDefaultLibrary() {
         return defaultLibrary;
     }
@@ -43,5 +45,13 @@ public class AppProperties {
 
     public void setBatchSize(int batchSize) {
         this.batchSize = batchSize;
+    }
+
+    public String getProfileDirectory() {
+        return profileDirectory;
+    }
+
+    public void setProfileDirectory(String profileDirectory) {
+        this.profileDirectory = profileDirectory;
     }
 }

--- a/src/main/java/com/zeus/upload/controller/ImportProfileController.java
+++ b/src/main/java/com/zeus/upload/controller/ImportProfileController.java
@@ -1,0 +1,52 @@
+package com.zeus.upload.controller;
+
+import com.zeus.upload.domain.ImportProfile;
+import com.zeus.upload.domain.ImportRequest;
+import com.zeus.upload.service.ImportProfileService;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/profiles")
+public class ImportProfileController {
+
+    private final ImportProfileService profileService;
+
+    public ImportProfileController(ImportProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    @GetMapping
+    public List<String> list() throws IOException {
+        return profileService.list();
+    }
+
+    @GetMapping("/{name}")
+    public ImportProfile load(@PathVariable String name) throws IOException {
+        return profileService.load(name);
+    }
+
+    @PostMapping
+    public ResponseEntity<ImportProfile> save(
+            @RequestParam String name,
+            @RequestBody ImportRequest request
+    ) throws IOException {
+        return ResponseEntity.status(HttpStatus.CREATED).body(profileService.save(name, request));
+    }
+
+    @DeleteMapping("/{name}")
+    public ResponseEntity<Void> delete(@PathVariable String name) throws IOException {
+        profileService.delete(name);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/zeus/upload/domain/ImportProfile.java
+++ b/src/main/java/com/zeus/upload/domain/ImportProfile.java
@@ -1,0 +1,31 @@
+package com.zeus.upload.domain;
+
+public class ImportProfile {
+
+    private String name;
+    private ImportRequest request;
+
+    public ImportProfile() {
+    }
+
+    public ImportProfile(String name, ImportRequest request) {
+        this.name = name;
+        this.request = request;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ImportRequest getRequest() {
+        return request;
+    }
+
+    public void setRequest(ImportRequest request) {
+        this.request = request;
+    }
+}

--- a/src/main/java/com/zeus/upload/service/ImportProfileService.java
+++ b/src/main/java/com/zeus/upload/service/ImportProfileService.java
@@ -1,0 +1,75 @@
+package com.zeus.upload.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zeus.upload.config.AppProperties;
+import com.zeus.upload.domain.ImportProfile;
+import com.zeus.upload.domain.ImportRequest;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Service
+public class ImportProfileService {
+
+    private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9][A-Za-z0-9_-]{0,63}");
+
+    private final ObjectMapper objectMapper;
+    private final Path profileDirectory;
+
+    @Autowired
+    public ImportProfileService(ObjectMapper objectMapper, AppProperties appProperties) {
+        this(objectMapper, Path.of(appProperties.getProfileDirectory()));
+    }
+
+    ImportProfileService(ObjectMapper objectMapper, Path profileDirectory) {
+        this.objectMapper = Objects.requireNonNull(objectMapper);
+        this.profileDirectory = Objects.requireNonNull(profileDirectory).toAbsolutePath().normalize();
+    }
+
+    public ImportProfile save(String name, ImportRequest request) throws IOException {
+        String safeName = validateName(name);
+        Objects.requireNonNull(request, "request must not be null");
+        Files.createDirectories(profileDirectory);
+        ImportProfile profile = new ImportProfile(safeName, request);
+        objectMapper.writerWithDefaultPrettyPrinter().writeValue(profilePath(safeName).toFile(), profile);
+        return profile;
+    }
+
+    public ImportProfile load(String name) throws IOException {
+        return objectMapper.readValue(profilePath(validateName(name)).toFile(), ImportProfile.class);
+    }
+
+    public List<String> list() throws IOException {
+        if (!Files.isDirectory(profileDirectory)) {
+            return List.of();
+        }
+        try (var paths = Files.list(profileDirectory)) {
+            return paths.filter(path -> path.getFileName().toString().endsWith(".json"))
+                    .map(path -> path.getFileName().toString().replaceFirst("\\.json$", ""))
+                    .sorted(Comparator.naturalOrder())
+                    .toList();
+        }
+    }
+
+    public void delete(String name) throws IOException {
+        Files.deleteIfExists(profilePath(validateName(name)));
+    }
+
+    private Path profilePath(String name) {
+        return profileDirectory.resolve(name + ".json").normalize();
+    }
+
+    private String validateName(String name) {
+        if (!StringUtils.hasText(name) || !SAFE_NAME.matcher(name).matches()) {
+            throw new IllegalArgumentException("Profile name must match [A-Za-z0-9][A-Za-z0-9_-]{0,63}.");
+        }
+        return name;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,7 @@ app:
   default-library: BIB
   sample-rows: 200
   batch-size: 500
+  profile-directory: profiles
 
 logging:
   level:

--- a/src/test/java/com/zeus/upload/service/ImportProfileServiceTest.java
+++ b/src/test/java/com/zeus/upload/service/ImportProfileServiceTest.java
@@ -1,0 +1,38 @@
+package com.zeus.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zeus.upload.domain.ImportRequest;
+import java.nio.file.Files;
+import org.junit.jupiter.api.Test;
+
+class ImportProfileServiceTest {
+
+    @Test
+    void shouldSaveLoadListAndDeleteProfile() throws Exception {
+        var directory = Files.createTempDirectory("zeus-profiles");
+        var service = new ImportProfileService(new ObjectMapper(), directory);
+        var request = new ImportRequest();
+        request.setLibrary("BIB");
+        request.setTableName("CUSTOMER");
+        request.setOperation("UPSERT");
+
+        service.save("customer-sync", request);
+
+        assertThat(service.list()).containsExactly("customer-sync");
+        assertThat(service.load("customer-sync").getRequest().getOperation()).isEqualTo("UPSERT");
+        service.delete("customer-sync");
+        assertThat(service.list()).isEmpty();
+    }
+
+    @Test
+    void shouldRejectUnsafeProfileNames() throws Exception {
+        var service = new ImportProfileService(new ObjectMapper(), Files.createTempDirectory("zeus-profiles"));
+
+        assertThat(service.list()).isEmpty();
+        assertThatThrownBy(() -> service.delete("../outside"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## What changed\n- add validated JSON-backed import profile storage\n- expose list, load, save and delete endpoints at /api/profiles\n- persist operation, mapping, CSV settings and target configuration\n- add path-safe profile name validation and tests\n- update the agenda with issue alignment and profile status\n\n## Validation\n- Maven test: 48 tests, 0 failures, 1 skipped\n- GitHub Actions CI runs the same Maven suite\n\nCloses #5\n