### PR TITLE
Add asynchronous import jobs API

### DIFF
--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -55,6 +55,10 @@ explicit key mappings and are covered by H2 integration tests.
 Import profiles are now available through `/api/profiles` as validated JSON
 files, including list, load, save and delete operations.
 
+Asynchronous imports are now available through `/api/jobs/import`, with queued,
+running, succeeded, failed and cancelled states plus status listing, polling
+and cancellation endpoints. The browser progress-bar can build on this API.
+
 ## Product Direction
 
 `zeus-easy-upload` is no longer just a CSV-to-DB prototype. The current application already supports:

--- a/src/main/java/com/zeus/upload/controller/ImportJobController.java
+++ b/src/main/java/com/zeus/upload/controller/ImportJobController.java
@@ -1,0 +1,114 @@
+package com.zeus.upload.controller;
+
+import com.zeus.upload.domain.CsvImportOptions;
+import com.zeus.upload.domain.DbColumnMeta;
+import com.zeus.upload.domain.ImportJob;
+import com.zeus.upload.domain.ImportRequest;
+import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.domain.PreviewContext;
+import com.zeus.upload.flow.FlowConfigurationFactory;
+import com.zeus.upload.flow.FlowExecutionService;
+import com.zeus.upload.service.CsvParsingService;
+import com.zeus.upload.service.ImportJobService;
+import com.zeus.upload.service.MappingService;
+import com.zeus.upload.service.MetadataService;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/jobs")
+public class ImportJobController {
+
+    private final CsvParsingService csvParsingService;
+    private final MetadataService metadataService;
+    private final MappingService mappingService;
+    private final FlowConfigurationFactory configurationFactory;
+    private final FlowExecutionService flowExecutionService;
+    private final ImportJobService jobService;
+
+    public ImportJobController(
+            CsvParsingService csvParsingService,
+            MetadataService metadataService,
+            MappingService mappingService,
+            FlowConfigurationFactory configurationFactory,
+            FlowExecutionService flowExecutionService,
+            ImportJobService jobService
+    ) {
+        this.csvParsingService = csvParsingService;
+        this.metadataService = metadataService;
+        this.mappingService = mappingService;
+        this.configurationFactory = configurationFactory;
+        this.flowExecutionService = flowExecutionService;
+        this.jobService = jobService;
+    }
+
+    @PostMapping(value = "/import", consumes = "multipart/form-data")
+    public ResponseEntity<ImportJob> submit(
+            @RequestParam MultipartFile file,
+            @RequestParam String library,
+            @RequestParam String tableName,
+            @RequestParam(defaultValue = "INSERT") String operation,
+            @RequestParam(required = false) String existingTableName,
+            @RequestParam(required = false) List<String> keyColumns,
+            @RequestParam(defaultValue = "false") boolean dryRun,
+            @RequestParam(required = false) String csvDelimiter,
+            @RequestParam(required = false) String csvEncoding,
+            @RequestParam(required = false) String csvQuote
+    ) throws IOException {
+        CsvImportOptions options = new CsvImportOptions();
+        options.setDelimiter(csvDelimiter);
+        options.setEncoding(csvEncoding);
+        options.setQuote(csvQuote);
+        ParsedCsv parsed = csvParsingService.parse(file, options);
+        boolean existing = existingTableName != null && !existingTableName.isBlank();
+        ImportRequest request = new ImportRequest();
+        request.setLibrary(library);
+        request.setTableName(existing ? existingTableName : tableName);
+        request.setExistingTableName(existing ? existingTableName : null);
+        request.setUseExistingTable(existing);
+        request.setOperation(existing ? operation : "CREATE");
+        request.setDryRun(dryRun);
+        request.setColumns(parsed.getProposals());
+        request.setKeyColumns(keyColumns);
+        request.setCsvDelimiter(csvDelimiter);
+        request.setCsvEncoding(csvEncoding);
+        request.setCsvQuote(csvQuote);
+
+        PreviewContext context = new PreviewContext();
+        context.setParsedCsv(parsed);
+        if (existing) {
+            List<DbColumnMeta> columns = metadataService.listColumns(library, existingTableName);
+            context.setDbColumns(columns);
+            context.setMappings(mappingService.autoMap(parsed, columns));
+            request.setMappings(context.getMappings());
+        }
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(jobService.submit(
+                () -> flowExecutionService.execute(configurationFactory.fromImportContext(request, context))));
+    }
+
+    @GetMapping
+    public List<ImportJob> list() {
+        return jobService.list();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ImportJob> get(@PathVariable String id) {
+        ImportJob job = jobService.get(id);
+        return job == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(job);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> cancel(@PathVariable String id) {
+        return jobService.cancel(id) ? ResponseEntity.accepted().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/zeus/upload/domain/ImportJob.java
+++ b/src/main/java/com/zeus/upload/domain/ImportJob.java
@@ -1,0 +1,53 @@
+package com.zeus.upload.domain;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class ImportJob {
+
+    private final String id = UUID.randomUUID().toString();
+    private volatile ImportJobStatus status = ImportJobStatus.QUEUED;
+    private volatile int progress;
+    private volatile String message = "Queued";
+    private volatile ImportResult result;
+    private final Instant createdAt = Instant.now();
+    private volatile Instant startedAt;
+    private volatile Instant finishedAt;
+
+    public String getId() { return id; }
+    public ImportJobStatus getStatus() { return status; }
+    public int getProgress() { return progress; }
+    public String getMessage() { return message; }
+    public ImportResult getResult() { return result; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getStartedAt() { return startedAt; }
+    public Instant getFinishedAt() { return finishedAt; }
+
+    public synchronized void markRunning() {
+        status = ImportJobStatus.RUNNING;
+        progress = 5;
+        message = "Running";
+        startedAt = Instant.now();
+    }
+
+    public synchronized void markSucceeded(ImportResult result) {
+        status = ImportJobStatus.SUCCEEDED;
+        progress = 100;
+        message = result == null ? "Completed" : result.getMessage();
+        this.result = result;
+        finishedAt = Instant.now();
+    }
+
+    public synchronized void markFailed(String message, ImportResult result) {
+        status = ImportJobStatus.FAILED;
+        this.message = message;
+        this.result = result;
+        finishedAt = Instant.now();
+    }
+
+    public synchronized void markCancelled() {
+        status = ImportJobStatus.CANCELLED;
+        message = "Cancelled";
+        finishedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/zeus/upload/domain/ImportJobStatus.java
+++ b/src/main/java/com/zeus/upload/domain/ImportJobStatus.java
@@ -1,0 +1,9 @@
+package com.zeus.upload.domain;
+
+public enum ImportJobStatus {
+    QUEUED,
+    RUNNING,
+    SUCCEEDED,
+    FAILED,
+    CANCELLED
+}

--- a/src/main/java/com/zeus/upload/service/ImportJobService.java
+++ b/src/main/java/com/zeus/upload/service/ImportJobService.java
@@ -1,0 +1,73 @@
+package com.zeus.upload.service;
+
+import com.zeus.upload.domain.ImportJob;
+import com.zeus.upload.domain.ImportResult;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+import jakarta.annotation.PreDestroy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ImportJobService {
+
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+    private final Map<String, ImportJob> jobs = new ConcurrentHashMap<>();
+    private final Map<String, Future<?>> futures = new ConcurrentHashMap<>();
+
+    public ImportJob submit(Supplier<ImportResult> task) {
+        ImportJob job = new ImportJob();
+        jobs.put(job.getId(), job);
+        futures.put(job.getId(), executor.submit(() -> {
+            job.markRunning();
+            try {
+                ImportResult result = task.get();
+                if (Thread.currentThread().isInterrupted()) {
+                    job.markCancelled();
+                } else if (result != null && result.isSuccess()) {
+                    job.markSucceeded(result);
+                } else {
+                    job.markFailed(result == null ? "Import returned no result" : result.getMessage(), result);
+                }
+            } catch (Exception ex) {
+                job.markFailed(ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage(), null);
+            } finally {
+                futures.remove(job.getId());
+            }
+        }));
+        return job;
+    }
+
+    public ImportJob get(String id) {
+        return jobs.get(id);
+    }
+
+    public List<ImportJob> list() {
+        return jobs.values().stream()
+                .sorted(Comparator.comparing(ImportJob::getCreatedAt).reversed())
+                .toList();
+    }
+
+    public boolean cancel(String id) {
+        ImportJob job = jobs.get(id);
+        Future<?> future = futures.get(id);
+        if (job == null || future == null || job.getStatus().ordinal() >= 2) {
+            return false;
+        }
+        boolean cancelled = future.cancel(true);
+        if (cancelled) {
+            job.markCancelled();
+        }
+        return cancelled;
+    }
+
+    @PreDestroy
+    void shutdown() {
+        executor.shutdownNow();
+    }
+}

--- a/src/test/java/com/zeus/upload/service/ImportJobServiceTest.java
+++ b/src/test/java/com/zeus/upload/service/ImportJobServiceTest.java
@@ -1,0 +1,40 @@
+package com.zeus.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.domain.ImportJobStatus;
+import com.zeus.upload.domain.ImportResult;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class ImportJobServiceTest {
+
+    @Test
+    void shouldTrackSuccessfulJobLifecycle() {
+        var service = new ImportJobService();
+        var job = service.submit(() -> ImportResult.success("done", "", 3));
+
+        await(() -> job.getStatus() == ImportJobStatus.SUCCEEDED);
+        assertThat(job.getProgress()).isEqualTo(100);
+        assertThat(job.getResult().getInsertedRows()).isEqualTo(3);
+        service.shutdown();
+    }
+
+    @Test
+    void shouldTrackFailedJob() {
+        var service = new ImportJobService();
+        var job = service.submit(() -> ImportResult.failure("failed", "", java.util.List.of()));
+
+        await(() -> job.getStatus() == ImportJobStatus.FAILED);
+        assertThat(job.getMessage()).isEqualTo("failed");
+        service.shutdown();
+    }
+
+    private void await(java.util.function.BooleanSupplier condition) {
+        long deadline = System.nanoTime() + Duration.ofSeconds(3).toNanos();
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.yield();
+        }
+        assertThat(condition.getAsBoolean()).isTrue();
+    }
+}


### PR DESCRIPTION
## What changed\n- add queued/running/succeeded/failed/cancelled import job states\n- execute imports asynchronously with in-memory job tracking\n- add multipart REST import submission at /api/jobs/import\n- add job listing, polling and cancellation endpoints\n- cover successful and failed job lifecycles with tests\n- update the agenda with async API status\n\n## Validation\n- Maven test: 50 tests, 0 failures, 1 skipped\n- GitHub Actions CI runs the same Maven suite\n\nCloses #6\nCloses #7\nCloses #9\n