### PR TITLE
Add CSV target connector

### DIFF
--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -59,6 +59,10 @@ Asynchronous imports are now available through `/api/jobs/import`, with queued,
 running, succeeded, failed and cancelled states plus status listing, polling
 and cancellation endpoints. The browser progress-bar can build on this API.
 
+The connector foundation now also includes a configurable UTF-8 CSV target
+that preserves record field order, quotes values safely and creates parent
+directories as needed.
+
 ## Product Direction
 
 `zeus-easy-upload` is no longer just a CSV-to-DB prototype. The current application already supports:

--- a/src/main/java/com/zeus/upload/connector/ConnectorFactory.java
+++ b/src/main/java/com/zeus/upload/connector/ConnectorFactory.java
@@ -2,7 +2,9 @@ package com.zeus.upload.connector;
 
 import com.zeus.upload.connector.db.DbTableTargetConnector;
 import com.zeus.upload.connector.file.CsvSourceConnector;
+import com.zeus.upload.connector.file.CsvTargetConnector;
 import com.zeus.upload.flow.CsvSourceConfiguration;
+import com.zeus.upload.flow.CsvTargetConfiguration;
 import com.zeus.upload.flow.DbTableTargetConfiguration;
 import com.zeus.upload.flow.SourceConfiguration;
 import com.zeus.upload.flow.TargetConfiguration;
@@ -28,6 +30,9 @@ public class ConnectorFactory {
     public TargetConnector createTarget(TargetConfiguration configuration) {
         if (configuration instanceof DbTableTargetConfiguration dbTableTargetConfiguration) {
             return new DbTableTargetConnector(importService, dbTableTargetConfiguration);
+        }
+        if (configuration instanceof CsvTargetConfiguration csvTargetConfiguration) {
+            return new CsvTargetConnector(csvTargetConfiguration);
         }
         throw new IllegalArgumentException("Unsupported target configuration: " + configuration.getClass().getName());
     }

--- a/src/main/java/com/zeus/upload/connector/file/CsvTargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/file/CsvTargetConnector.java
@@ -1,0 +1,61 @@
+package com.zeus.upload.connector.file;
+
+import com.zeus.upload.connector.TargetConnector;
+import com.zeus.upload.flow.CsvTargetConfiguration;
+import com.zeus.upload.flow.DataRecord;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class CsvTargetConnector implements TargetConnector {
+
+    private final CsvTargetConfiguration configuration;
+
+    public CsvTargetConnector(CsvTargetConfiguration configuration) {
+        this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
+    }
+
+    @Override
+    public void write(Stream<DataRecord> records) {
+        List<DataRecord> materialized = records.toList();
+        List<String> headers = new ArrayList<>();
+        for (DataRecord record : materialized) {
+            for (String key : record.asMap().keySet()) {
+                if (!headers.contains(key)) headers.add(key);
+            }
+        }
+        try {
+            if (configuration.getOutputFile().getParent() != null) {
+                Files.createDirectories(configuration.getOutputFile().getParent());
+            }
+            try (BufferedWriter writer = Files.newBufferedWriter(configuration.getOutputFile(), StandardCharsets.UTF_8)) {
+                writeRow(writer, headers);
+                for (DataRecord record : materialized) {
+                    List<String> values = headers.stream()
+                            .map(header -> String.valueOf(record.get(header) == null ? "" : record.get(header)))
+                            .toList();
+                    writeRow(writer, values);
+                }
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not write CSV target: " + ex.getMessage(), ex);
+        }
+    }
+
+    private void writeRow(BufferedWriter writer, List<String> values) throws IOException {
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) writer.write(configuration.getDelimiter());
+            String value = values.get(i);
+            writer.write(configuration.getQuote());
+            writer.write(value.replace(String.valueOf(configuration.getQuote()),
+                    String.valueOf(configuration.getQuote()) + configuration.getQuote()));
+            writer.write(configuration.getQuote());
+        }
+        writer.newLine();
+    }
+}

--- a/src/main/java/com/zeus/upload/connector/file/CsvTargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/file/CsvTargetConnector.java
@@ -56,6 +56,6 @@ public class CsvTargetConnector implements TargetConnector {
                     String.valueOf(configuration.getQuote()) + configuration.getQuote()));
             writer.write(configuration.getQuote());
         }
-        writer.newLine();
+        writer.write("\r\n");
     }
 }

--- a/src/main/java/com/zeus/upload/flow/CsvTargetConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/CsvTargetConfiguration.java
@@ -1,0 +1,21 @@
+package com.zeus.upload.flow;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class CsvTargetConfiguration implements TargetConfiguration {
+
+    private final Path outputFile;
+    private final char delimiter;
+    private final char quote;
+
+    public CsvTargetConfiguration(Path outputFile, char delimiter, char quote) {
+        this.outputFile = Objects.requireNonNull(outputFile, "outputFile must not be null");
+        this.delimiter = delimiter;
+        this.quote = quote;
+    }
+
+    public Path getOutputFile() { return outputFile; }
+    public char getDelimiter() { return delimiter; }
+    public char getQuote() { return quote; }
+}

--- a/src/test/java/com/zeus/upload/connector/file/CsvTargetConnectorTest.java
+++ b/src/test/java/com/zeus/upload/connector/file/CsvTargetConnectorTest.java
@@ -1,0 +1,27 @@
+package com.zeus.upload.connector.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.flow.CsvTargetConfiguration;
+import com.zeus.upload.flow.DataRecord;
+import java.nio.file.Files;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class CsvTargetConnectorTest {
+
+    @Test
+    void shouldWriteHeadersValuesAndEscapeQuotes() throws Exception {
+        var file = Files.createTempFile("zeus-export", ".csv");
+        var first = new DataRecord();
+        first.set("ID", 1);
+        first.set("NAME", "Alice, \"A\"");
+        var second = new DataRecord();
+        second.set("ID", 2);
+        second.set("NAME", "Bob");
+
+        new CsvTargetConnector(new CsvTargetConfiguration(file, ';', '"')).write(Stream.of(first, second));
+
+        assertThat(Files.readString(file)).isEqualTo("\"ID\";\"NAME\"\r\n\"1\";\"Alice, \"\"A\"\"\"\r\n\"2\";\"Bob\"\r\n");
+    }
+}


### PR DESCRIPTION
## What changed\n- add configurable CSV target connector to the connector factory\n- preserve first-seen record field order for headers\n- quote and escape values safely\n- create parent directories for export files\n- add export connector coverage and roadmap status\n\n## Validation\n- Maven test: 51 tests, 0 failures, 1 skipped\n- GitHub Actions CI runs the same Maven suite\n\nCloses #46\n