### PR TITLE
Add database source connector

### DIFF
--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -63,6 +63,9 @@ The connector foundation now also includes a configurable UTF-8 CSV target
 that preserves record field order, quotes values safely and creates parent
 directories as needed.
 
+The database source connector is now available as a neutral-record source,
+enabling DB-to-CSV and DB-to-DB flows through the existing `DataFlow` seam.
+
 ## Product Direction
 
 `zeus-easy-upload` is no longer just a CSV-to-DB prototype. The current application already supports:

--- a/src/main/java/com/zeus/upload/connector/ConnectorFactory.java
+++ b/src/main/java/com/zeus/upload/connector/ConnectorFactory.java
@@ -1,28 +1,45 @@
 package com.zeus.upload.connector;
 
 import com.zeus.upload.connector.db.DbTableTargetConnector;
+import com.zeus.upload.connector.db.DbTableSourceConnector;
 import com.zeus.upload.connector.file.CsvSourceConnector;
 import com.zeus.upload.connector.file.CsvTargetConnector;
 import com.zeus.upload.flow.CsvSourceConfiguration;
 import com.zeus.upload.flow.CsvTargetConfiguration;
 import com.zeus.upload.flow.DbTableTargetConfiguration;
+import com.zeus.upload.flow.DbTableSourceConfiguration;
 import com.zeus.upload.flow.SourceConfiguration;
 import com.zeus.upload.flow.TargetConfiguration;
 import com.zeus.upload.service.ImportService;
+import com.zeus.upload.sql.SqlDialect;
+import javax.sql.DataSource;
 import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Component
 public class ConnectorFactory {
 
     private final ImportService importService;
+    private final DataSource dataSource;
+    private final SqlDialect sqlDialect;
 
     public ConnectorFactory(ImportService importService) {
+        this(importService, null, null);
+    }
+
+    @Autowired
+    public ConnectorFactory(ImportService importService, DataSource dataSource, SqlDialect sqlDialect) {
         this.importService = importService;
+        this.dataSource = dataSource;
+        this.sqlDialect = sqlDialect;
     }
 
     public SourceConnector createSource(SourceConfiguration configuration) {
         if (configuration instanceof CsvSourceConfiguration csvSourceConfiguration) {
             return new CsvSourceConnector(csvSourceConfiguration.getParsedCsv());
+        }
+        if (configuration instanceof DbTableSourceConfiguration dbSourceConfiguration) {
+            return new DbTableSourceConnector(dataSource, sqlDialect, dbSourceConfiguration);
         }
         throw new IllegalArgumentException("Unsupported source configuration: " + configuration.getClass().getName());
     }

--- a/src/main/java/com/zeus/upload/connector/db/DbTableSourceConnector.java
+++ b/src/main/java/com/zeus/upload/connector/db/DbTableSourceConnector.java
@@ -1,0 +1,53 @@
+package com.zeus.upload.connector.db;
+
+import com.zeus.upload.connector.SourceConnector;
+import com.zeus.upload.flow.DataRecord;
+import com.zeus.upload.flow.DbTableSourceConfiguration;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import javax.sql.DataSource;
+import com.zeus.upload.sql.SqlDialect;
+
+public class DbTableSourceConnector implements SourceConnector {
+
+    private final DataSource dataSource;
+    private final SqlDialect sqlDialect;
+    private final DbTableSourceConfiguration configuration;
+
+    public DbTableSourceConnector(DataSource dataSource, SqlDialect sqlDialect, DbTableSourceConfiguration configuration) {
+        this.dataSource = Objects.requireNonNull(dataSource);
+        this.sqlDialect = Objects.requireNonNull(sqlDialect);
+        this.configuration = Objects.requireNonNull(configuration);
+    }
+
+    @Override
+    public Stream<DataRecord> read() {
+        List<DataRecord> records = new ArrayList<>();
+        String projection = configuration.getColumns().isEmpty()
+                ? "*"
+                : configuration.getColumns().stream().map(sqlDialect::quoteIdentifier).reduce((a, b) -> a + ", " + b).orElse("*");
+        String sql = "SELECT " + projection + " FROM "
+                + sqlDialect.qualifyTable(configuration.getLibrary(), configuration.getTableName());
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            int columnCount = resultSet.getMetaData().getColumnCount();
+            while (resultSet.next()) {
+                DataRecord record = new DataRecord();
+                for (int index = 1; index <= columnCount; index++) {
+                    record.set(resultSet.getMetaData().getColumnLabel(index), resultSet.getObject(index));
+                }
+                records.add(record);
+            }
+            return records.stream();
+        } catch (SQLException ex) {
+            throw new IllegalStateException("Could not read DB source: " + ex.getMessage(), ex);
+        }
+    }
+}

--- a/src/main/java/com/zeus/upload/flow/DbTableSourceConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/DbTableSourceConfiguration.java
@@ -1,0 +1,21 @@
+package com.zeus.upload.flow;
+
+import java.util.List;
+import java.util.Objects;
+
+public class DbTableSourceConfiguration implements SourceConfiguration {
+
+    private final String library;
+    private final String tableName;
+    private final List<String> columns;
+
+    public DbTableSourceConfiguration(String library, String tableName, List<String> columns) {
+        this.library = Objects.requireNonNull(library, "library must not be null");
+        this.tableName = Objects.requireNonNull(tableName, "tableName must not be null");
+        this.columns = columns == null ? List.of() : List.copyOf(columns);
+    }
+
+    public String getLibrary() { return library; }
+    public String getTableName() { return tableName; }
+    public List<String> getColumns() { return columns; }
+}

--- a/src/test/java/com/zeus/upload/connector/db/DbTableSourceConnectorIntegrationTest.java
+++ b/src/test/java/com/zeus/upload/connector/db/DbTableSourceConnectorIntegrationTest.java
@@ -1,0 +1,45 @@
+package com.zeus.upload.connector.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.flow.DbTableSourceConfiguration;
+import com.zeus.upload.flow.DataRecord;
+import com.zeus.upload.sql.SqlDialect;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class DbTableSourceConnectorIntegrationTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private SqlDialect sqlDialect;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void shouldReadRowsAsNeutralRecords() {
+        jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS \"TESTLIB\"");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS \"TESTLIB\".\"H2_SOURCE_IT\"");
+        jdbcTemplate.execute("CREATE TABLE \"TESTLIB\".\"H2_SOURCE_IT\" (\"ID\" INTEGER, \"NAME\" VARCHAR(64))");
+        jdbcTemplate.update("INSERT INTO \"TESTLIB\".\"H2_SOURCE_IT\" VALUES (?, ?)", 1, "Alice");
+
+        List<DataRecord> records = new DbTableSourceConnector(
+                dataSource, sqlDialect,
+                new DbTableSourceConfiguration("TESTLIB", "H2_SOURCE_IT", List.of()))
+                .read().toList();
+
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).get("ID")).isEqualTo(1);
+        assertThat(records.get(0).get("NAME")).isEqualTo("Alice");
+    }
+}


### PR DESCRIPTION
## What changed\n- add configurable DB table source configuration\n- read DB rows into neutral DataRecord instances\n- register DB source in the connector factory\n- add H2 integration coverage and roadmap status\n\n## Validation\n- Maven test: 52 tests, 0 failures, 1 skipped\n- GitHub Actions CI runs the same Maven suite\n\nCloses #45\n