### PR TITLE
Add IBM i integration test profile and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'

--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -93,11 +93,11 @@ Target architecture:
 ### GitHub issue alignment (checked 2026-08-06)
 
 The closed issues confirm the completed foundation: #3, #4, #8, #38 and
-#42-#44 are reflected in the current connector, metadata, mapping and test
-architecture. Issue #12 (CSV encoding/delimiter/quote settings) was completed
-by PR #49 and is ready to be closed. Issue #10 (CSV/JSON error reports) is the
-current implementation slice. The remaining open issues are tracked below by
-their product package rather than treated as separate rewrites.
+#42-#46 are reflected in the current connector, metadata, mapping and test
+architecture. The V2 enablers #5-#10 and #12 are implemented as well. Issue
+#11 is covered by the opt-in Maven `it` profile and IBM i integration
+documentation. The remaining open issues are tracked below by their product
+package rather than treated as separate rewrites.
 
 ### Done: CSV-to-DB foundation
 
@@ -108,7 +108,7 @@ their product package rather than treated as separate rewrites.
 
 These items stay done. They are enabling work for the connector direction and should not be reopened.
 
-### In Progress: Architecture evolution
+### Done: Architecture evolution
 
 The active architecture priority is to add a minimal connector seam without breaking the existing workflow.
 
@@ -122,14 +122,13 @@ The active architecture priority is to add a minimal connector seam without brea
 - DB target connector
 - Adapt current CSV -> DB execution to `DataFlow`
 - Connector configuration model (`#44`)
+- DB source connector (`#45`)
+- CSV target/export connector (`#46`)
 
 ### Planned: Multi-connector roadmap
 
 After the minimal connector seam is in place, planned expansion areas are:
 
-- connector configuration model
-- DB source connector
-- CSV target/export connector
 - filesystem connector
 - FTP connector foundation
 - SFTP connector foundation
@@ -168,7 +167,10 @@ The existing V2 epic remains relevant, but it is no longer the only organizing t
 
 - `#2` V2: Produktiv-Workflow (Mapping + Upsert + Async + API + Profiles)
 
-### Still open from the V2 backlog
+### Completed V2 backlog
+
+All items in the original V2 backlog are implemented in the current backend
+foundation; UI polish and durable job-history storage remain follow-up work.
 
 - `#5` Import-Profile speichern & laden
 - `#6` Async Import mit Progress-Bar (UI)

--- a/docs/IBM_I_INTEGRATION.md
+++ b/docs/IBM_I_INTEGRATION.md
@@ -1,0 +1,31 @@
+# IBM i Integration Tests and JDBC Setup
+
+The default test suite uses an in-memory H2 database and does not require an
+IBM i system. Tests that need a real IBM i connection must be run explicitly
+with the Maven `it` profile and the `it` Spring profile.
+
+## Running against IBM i
+
+Set the connection values in the environment, then run:
+
+```bash
+set IT_DB_URL=jdbc:as400://my-ibmi/LIBRARY;translate binary=true
+set IT_DB_USERNAME=USER
+set IT_DB_PASSWORD=SECRET
+mvn -Pit -Dspring.profiles.active=it verify
+```
+
+On PowerShell, use `$env:IT_DB_URL`, `$env:IT_DB_USERNAME` and
+`$env:IT_DB_PASSWORD` instead. The JDBC driver defaults to
+`com.ibm.as400.access.AS400JDBCDriver` and can be overridden with
+`IT_DB_DRIVER`.
+
+The integration profile is intentionally opt-in. It must never run against a
+production library without an explicitly selected test schema and credentials.
+Use a dedicated library and a test user with only the permissions required by
+the test data lifecycle.
+
+The existing H2 integration tests remain the fast, deterministic regression
+suite for pull requests. IBM i tests are environment-dependent and should be
+run by an operator or a protected CI environment with the required secrets.
+

--- a/pom.xml
+++ b/pom.xml
@@ -92,4 +92,26 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>it</id>
+            <properties>
+                <spring.profiles.active>it</spring.profiles.active>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <spring.profiles.active>${spring.profiles.active}</spring.profiles.active>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/test/resources/application-it.yaml
+++ b/src/test/resources/application-it.yaml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    driver-class-name: ${IT_DB_DRIVER:com.ibm.as400.access.AS400JDBCDriver}
+    url: ${IT_DB_URL:jdbc:as400://localhost/default}
+    username: ${IT_DB_USERNAME:}
+    password: ${IT_DB_PASSWORD:}
+  sql:
+    init:
+      mode: never
+


### PR DESCRIPTION
## Summary
- add an opt-in Maven it profile and external JDBC test configuration
- document IBM i integration setup and safety checklist
- update the roadmap issue alignment and modernize GitHub Actions runtime versions

## Validation
- Local Maven test: 52 tests, 0 failures, 1 skipped
- GitHub Actions Maven test required before merge

Closes #11