### PR TITLE
Stream database source records

### DIFF
--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -64,7 +64,8 @@ that preserves record field order, quotes values safely and creates parent
 directories as needed.
 
 The database source connector is now available as a neutral-record source,
-enabling DB-to-CSV and DB-to-DB flows through the existing `DataFlow` seam.
+enabling DB-to-CSV and DB-to-DB flows through the existing `DataFlow` seam. Its
+JDBC rows are streamed with bounded fetch size and lifecycle-safe cleanup.
 
 ## Product Direction
 

--- a/src/main/java/com/zeus/upload/connector/db/DbTableSourceConnector.java
+++ b/src/main/java/com/zeus/upload/connector/db/DbTableSourceConnector.java
@@ -7,10 +7,12 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Spliterators;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.sql.DataSource;
 import com.zeus.upload.sql.SqlDialect;
 
@@ -28,26 +30,86 @@ public class DbTableSourceConnector implements SourceConnector {
 
     @Override
     public Stream<DataRecord> read() {
-        List<DataRecord> records = new ArrayList<>();
         String projection = configuration.getColumns().isEmpty()
                 ? "*"
                 : configuration.getColumns().stream().map(sqlDialect::quoteIdentifier).reduce((a, b) -> a + ", " + b).orElse("*");
         String sql = "SELECT " + projection + " FROM "
                 + sqlDialect.qualifyTable(configuration.getLibrary(), configuration.getTableName());
-        try (Connection connection = dataSource.getConnection();
-             Statement statement = connection.createStatement();
-             ResultSet resultSet = statement.executeQuery(sql)) {
-            int columnCount = resultSet.getMetaData().getColumnCount();
-            while (resultSet.next()) {
-                DataRecord record = new DataRecord();
-                for (int index = 1; index <= columnCount; index++) {
-                    record.set(resultSet.getMetaData().getColumnLabel(index), resultSet.getObject(index));
-                }
-                records.add(record);
-            }
-            return records.stream();
+        Connection connection = null;
+        Statement statement = null;
+        try {
+            connection = dataSource.getConnection();
+            statement = connection.createStatement();
+            statement.setFetchSize(500);
+            ResultSet resultSet = statement.executeQuery(sql);
+            return streamRows(connection, statement, resultSet);
         } catch (SQLException ex) {
+            try { if (statement != null) statement.close(); } catch (SQLException ignored) { }
+            try { if (connection != null) connection.close(); } catch (SQLException ignored) { }
             throw new IllegalStateException("Could not read DB source: " + ex.getMessage(), ex);
         }
+    }
+
+    private Stream<DataRecord> streamRows(Connection connection, Statement statement, ResultSet resultSet)
+            throws SQLException {
+        int columnCount = resultSet.getMetaData().getColumnCount();
+        List<String> columnLabels = new java.util.ArrayList<>(columnCount);
+        for (int index = 1; index <= columnCount; index++) {
+            columnLabels.add(resultSet.getMetaData().getColumnLabel(index));
+        }
+
+        Iterator<DataRecord> iterator = new Iterator<>() {
+            private boolean advanced;
+            private boolean hasNext;
+            private boolean closed;
+
+            @Override
+            public boolean hasNext() {
+                if (closed) return false;
+                if (!advanced) {
+                    try {
+                        hasNext = resultSet.next();
+                        advanced = true;
+                        if (!hasNext) closeResources();
+                    } catch (SQLException ex) {
+                        closeResources();
+                        throw new IllegalStateException("Could not read DB source row: " + ex.getMessage(), ex);
+                    }
+                }
+                return hasNext;
+            }
+
+            @Override
+            public DataRecord next() {
+                if (!hasNext()) throw new java.util.NoSuchElementException();
+                advanced = false;
+                DataRecord record = new DataRecord();
+                try {
+                    for (int index = 1; index <= columnLabels.size(); index++) {
+                        record.set(columnLabels.get(index - 1), resultSet.getObject(index));
+                    }
+                    return record;
+                } catch (SQLException ex) {
+                    closeResources();
+                    throw new IllegalStateException("Could not read DB source row: " + ex.getMessage(), ex);
+                }
+            }
+
+            private void closeResources() {
+                if (closed) return;
+                closed = true;
+                try { resultSet.close(); } catch (SQLException ignored) { }
+                try { statement.close(); } catch (SQLException ignored) { }
+                try { connection.close(); } catch (SQLException ignored) { }
+            }
+        };
+
+        return StreamSupport.stream(
+                        Spliterators.spliteratorUnknownSize(iterator, java.util.Spliterator.ORDERED), false)
+                .onClose(() -> {
+                    try { resultSet.close(); } catch (SQLException ignored) { }
+                    try { statement.close(); } catch (SQLException ignored) { }
+                    try { connection.close(); } catch (SQLException ignored) { }
+                });
     }
 }


### PR DESCRIPTION
## Summary
- stream JDBC rows instead of materializing the complete result set
- configure a bounded fetch size
- close JDBC resources on exhaustion, errors, and stream close
- document the large-import guardrail in the roadmap

## Validation
- Local Maven test: 52 tests, 0 failures, 1 skipped
- GitHub Actions Maven test required before merge