### PR TITLE
Add filesystem and REST connectors with encrypted connection profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.log
 __pycache__/
 *.py[cod]
+/.local/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# zeus-easy-upload
+# zeus-easy-upload
 
 Spring-Boot-Webanwendung zum Import beliebiger CSV-Dateien in IBM i DB2/400 Tabellen.
 
@@ -26,6 +26,8 @@ Version 1 Fokus:
 Aktueller First-Class-Flow:
 
 - CSV -> DB table
+- filesystem CSV source/target for bounded local staging
+- REST JSON source/target with explicit deployment and security policy
 
 Minimale Architektur in der aktuellen Iteration:
 
@@ -40,14 +42,10 @@ Wichtig:
 - vorhandene Services fuer Parsing, Mapping, Metadata und Import bleiben das Rueckgrat der Implementierung
 - die Connector-Abstraktion ist bewusst inkrementell und noch kein Plugin-System
 
-Geplante naechste Connector-Richtungen:
+Naechste Connector-Richtungen:
 
-- DB source
-- CSV export / target
 - FTP
 - SFTP
-- REST
-- filesystem
 - cloud/object storage
 
 ## Voraussetzungen
@@ -81,7 +79,26 @@ app:
   default-library: BIB
   sample-rows: 200
   batch-size: 500
+  connection-profile-directory: connections
+  connection-master-key: ${ZEUS_CONNECTION_MASTER_KEY:}
 ```
+
+## GUI und Verbindungsprofile
+
+Die Anwendung bietet unter /connections eine erweiterbare GUI fuer DB2/400- und
+REST-Verbindungsprofile. Profile enthalten nur Metadaten; Zugangsdaten werden
+mit AES-256-GCM verschluesselt. Der Master-Key wird ausschliesslich ueber
+ZEUS_CONNECTION_MASTER_KEY oder app.connection-master-key bereitgestellt.
+
+Fuer lokale Entwicklungsprofile kann APP_CONNECTION_PROFILE_DIRECTORY=.local/connections
+gesetzt werden. Das Verzeichnis .local/ ist absichtlich git-ignoriert und darf
+nicht versioniert werden. Der Master-Key muss ausserhalb des Repositories
+gesichert werden.
+
+IBM-i JDBC-URLs duerfen Treiberattribute wie translate binary=true enthalten;
+diese URL wird zur Validierung sicher behandelt und unveraendert an den Treiber
+weitergegeben. Die Verbindungsauswahl aus gespeicherten Profilen und ein
+dedizierter GUI-Verbindungstest sind noch separate Erweiterungspakete.
 
 ## IBM i JDBC Hinweise
 
@@ -130,7 +147,10 @@ Regeln:
 
 ## Tests
 
-Enthaltene Unit-Tests:
+Enthaltene Tests decken neben dem Importkern auch Filesystem- und REST-Connectoren,
+verschluesselte Verbindungsprofile sowie GUI-nahe Profilvalidierung ab.
+
+Beispielhafte Unit-Tests:
 - `ColumnNameSanitizerTest`
 - `TypeInferenceServiceTest`
 - `DecimalDetectionTest`

--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -61,7 +61,8 @@ and cancellation endpoints. The browser progress-bar can build on this API.
 
 The connector foundation now also includes a configurable UTF-8 CSV target
 that preserves record field order, quotes values safely and creates parent
-directories as needed.
+directories as needed. It can stream records when a header order is supplied,
+avoiding full result materialization for large exports.
 
 The database source connector is now available as a neutral-record source,
 enabling DB-to-CSV and DB-to-DB flows through the existing `DataFlow` seam. Its

--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -5,14 +5,14 @@
 Product goal: turn the current CSV-to-DB flow into a safe, comfortable mass-data
 processing workspace with automatic mapping and precise manual control.
 
-### Phase 0 — Safe foundation (current)
+### Phase 0 ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â Safe foundation (current)
 
 - Preserve the existing CSV -> DB2/400 workflow.
 - Make every write operation previewable via a transaction-backed dry run.
 - Expose a neutral operation model in the flow configuration.
 - Keep validation, mapping and execution results explicit and testable.
 
-### Phase 1 — Mass-data MVP
+### Phase 1 ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â Mass-data MVP
 
 - CSV and Excel upload with encoding, delimiter and quote options.
 - Insert, update, upsert/merge and delete operations.
@@ -20,14 +20,14 @@ processing workspace with automatic mapping and precise manual control.
 - Key-column selection, transformations and null/empty-value policies.
 - Preview of affected rows, validation errors and conflict handling.
 
-### Phase 2 — Repeatable workflows
+### Phase 2 ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â Repeatable workflows
 
 - Save and load import profiles.
 - Background jobs with progress, cancellation and retry.
 - Job history, downloadable error reports and audit trail.
 - API endpoints for starting and inspecting jobs.
 
-### Phase 3 — Connectors and automation
+### Phase 3 ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â Connectors and automation
 
 - Database sources and targets beyond the initial DB2/400 connector.
 - REST, filesystem, FTP/SFTP and object-storage connectors.
@@ -131,10 +131,10 @@ The active architecture priority is to add a minimal connector seam without brea
 
 After the minimal connector seam is in place, planned expansion areas are:
 
-- filesystem connector
+- filesystem connector (implemented)
 - FTP connector foundation
 - SFTP connector foundation
-- REST connector foundation
+- REST connector foundation (implemented)
 - cloud/object storage connector foundation
 
 Issue #47 is now covered by the protocol connector foundation document. The
@@ -180,7 +180,7 @@ foundation; UI polish and durable job-history storage remain follow-up work.
 
 - `#5` Import-Profile speichern & laden
 - `#6` Async Import mit Progress-Bar (UI)
-- `#7` REST API zusätzlich zur GUI
+- `#7` REST API zusÃƒÆ’Ã‚Â¤tzlich zur GUI
 - `#9` Import Job Tracking + Progress Persistence
 - `#10` Fehlerreport Export (CSV/JSON Download)
 - `#11` Integrations-Test-Setup (Profile "it") + Doku IBM i
@@ -240,3 +240,35 @@ Add additional connectors incrementally after the seam is proven:
 - No generic runtime connector registry is planned in this phase
 - The current UI and current import behavior must remain intact
 - Existing logic should be wrapped first and only extracted further when a second real connector pair justifies it
+
+## Filesystem connector package
+
+The first concrete protocol package is implemented for local staging:
+
+- filesystem CSV source and target configurations with explicit root, path, charset, delimiter and quote
+- normalized root resolution that rejects absolute paths and traversal outside the configured root
+- lazy CSV source streaming with lifecycle-safe stream cleanup
+- nested-directory creation and streaming CSV target output through the existing writer
+- factory registration and unit tests for round-trip behavior, escaping and path safety
+
+## REST connector package
+
+The first REST connector package is implemented against the REST policy:
+
+- allowlisted HTTP(S) endpoints with production HTTPS enforcement and private-address protection
+- runtime Bearer/Basic secrets, bounded retries, timeouts and response/request limits
+- JSON source with page-number and cursor pagination
+- JSON target with bounded POST/PUT batches and idempotency headers
+- deterministic in-process HTTP emulator tests without external network access
+
+## GUI foundation and connection profiles
+
+The first GUI foundation is implemented as an additive Thymeleaf surface:
+
+- shared visual tokens and navigation entry point for the import and connection areas
+- connection profile page with create, load, list and delete interactions
+- DB2/400 and REST endpoint configuration fields
+- AES-256-GCM encrypted credentials with an externally supplied Base64 master key
+- metadata-only API responses and preservation of existing secrets on empty edits
+
+Runtime connector selection from saved profiles and a dedicated connection-test action remain separate follow-up packages.

--- a/docs/architecture/connection-profiles.md
+++ b/docs/architecture/connection-profiles.md
@@ -1,0 +1,54 @@
+# Connection Profiles and GUI Configuration
+
+The GUI now provides `/connections` for managing provider-neutral connection
+profiles. A profile currently contains a safe name, type (`DB2_400` or `REST`),
+endpoint URL, description and optional credentials.
+
+## Secret handling
+
+Passwords and tokens are never stored as profile fields. They are serialized
+to JSON, encrypted with AES-256-GCM and stored separately inside the profile
+file as IV plus ciphertext. The profile API returns only
+`credentialsConfigured: true/false`; it never returns the credentials.
+
+The encryption key must be supplied outside the repository.
+
+For PowerShell, generate a key with the compatible API below:
+
+    $bytes = New-Object byte[] 32
+    $rng = [Security.Cryptography.RandomNumberGenerator]::Create()
+    $rng.GetBytes($bytes)
+    $rng.Dispose()
+    [Convert]::ToBase64String($bytes)
+
+The key can also be provided as `app.connection-master-key`. Environment
+configuration is preferred for deployments. If no key is configured, the
+application can still start and list non-secret metadata, but saving a
+connection profile is rejected. The key is not generated automatically and
+must be backed up and rotated through an explicit migration process.
+
+## API
+
+- `GET /api/connections` — list metadata without secrets
+- `GET /api/connections/{name}` — load metadata without secrets
+- `POST /api/connections` — validate and save a profile
+- `DELETE /api/connections/{name}` — delete a profile
+
+An empty credential field in the GUI preserves an existing encrypted secret.
+Endpoint URLs must not contain embedded credentials or URI fragments. JDBC
+URLs may contain IBM-i driver attributes such as translate binary=true; the
+attribute is preserved for the driver while spaces are encoded only during
+URI validation. REST endpoints must use HTTP(S); production allowlist and
+SSRF checks remain part of the later runtime connector selection.
+
+The default profile directory is connections. Local development should use
+APP_CONNECTION_PROFILE_DIRECTORY=.local/connections; .local/ is ignored by
+Git and must never be committed.
+
+## Extension seam
+
+The profile model intentionally does not contain provider-specific runtime
+objects. Future connector factories can resolve a profile through
+`ConnectionProfileService.loadCredentials(name)` at execution time, inject
+the values into the existing REST/DB connector settings, and keep them out of
+import profiles, job payloads, logs and API responses.

--- a/docs/architecture/protocol-connectors.md
+++ b/docs/architecture/protocol-connectors.md
@@ -57,8 +57,13 @@ opt-in integration environments.
 
 ## Current status
 
-The neutral connector seam, CSV target, and database source are implemented.
-This document completes the architecture foundation for the protocol track.
-Concrete adapters should be delivered as separate, narrowly scoped packages
-once deployment policy and credential handling are available.
+The neutral connector seam, CSV target, database source, filesystem CSV
+source/target and REST JSON source/target are implemented. The filesystem
+adapter enforces a configured root and the REST adapter follows the deployment,
+allowlist, SSRF, limit, retry and idempotency rules in the REST connector policy.
+
+Together with the GUI foundation, the application now supports provider-neutral
+DB2/400 and REST connection profiles with AES-256-GCM protected credentials.
+Runtime connector selection, profile-backed execution and a dedicated GUI
+connection-test action remain follow-up packages.
 

--- a/docs/architecture/rest-connector-policy.md
+++ b/docs/architecture/rest-connector-policy.md
@@ -1,0 +1,161 @@
+# REST Connector Policy
+
+This policy defines the minimum deployment and runtime rules for the REST
+source and target connector. It is deliberately provider-neutral and is the
+decision baseline for the first REST implementation package.
+
+## Deployment profiles
+
+The connector has two explicit profiles:
+
+- `test`: HTTP is allowed for local emulators; credentials may be supplied by
+  test configuration; no external network access is assumed.
+- `production`: HTTPS is mandatory; certificate and hostname verification are
+  mandatory; HTTP and redirects to HTTP are rejected.
+
+The profile is selected by deployment configuration and cannot be changed by
+an import profile or an API request.
+
+## Destination allowlist and SSRF protection
+
+Every request must match an explicit URL allowlist entry. The allowlist is
+configured by an administrator and is not user-editable at runtime.
+
+An entry contains:
+
+- scheme (`https` in production; `http` may be enabled only in `test`)
+- normalized hostname
+- optional port (default 443 for HTTPS and 80 for HTTP)
+- allowed path prefix
+
+The connector must reject:
+
+- URLs with credentials, fragments, unsupported schemes or unexpected ports
+- loopback, link-local, multicast, unspecified and private/reserved IP ranges
+  in production
+- DNS results that resolve to a forbidden range
+- redirects unless the complete redirect target is checked against the same
+  allowlist and network policy
+
+DNS resolution must happen at connection time and the resolved addresses must
+be checked before connecting. The connector must not log authorization headers,
+query secrets or complete request bodies.
+
+## Secrets and authentication
+
+Secrets are injected through a runtime `SecretProvider` boundary. They must
+never be stored in import profiles, serialized job payloads, exceptions,
+metrics, audit records or downloadable reports.
+
+The first implementation supports:
+
+- no authentication
+- HTTP Bearer token
+- HTTP Basic authentication
+
+Credentials are attached only to requests matching the configured allowlist
+entry. The token value is held in memory for the request lifecycle and is
+redacted in all error messages. OAuth flows, client certificates and automatic
+token refresh are explicitly out of scope for the first package.
+
+## Request and response limits
+
+The following limits are mandatory configuration with safe defaults:
+
+| Setting | Default | Maximum |
+|---|---:|---:|
+| connect timeout | 5 s | 30 s |
+| request timeout | 30 s | 5 min |
+| maximum response bytes | 10 MiB | 100 MiB |
+| maximum request bytes | 10 MiB | 100 MiB |
+| maximum records per page | 1,000 | 10,000 |
+| maximum pages per operation | 1,000 | 10,000 |
+| maximum retries | 2 | 5 |
+
+Limits are enforced while streaming. A response or request exceeding its
+limit fails with a stable connector error and is not materialized further.
+
+## Retry and rate limiting
+
+Retries use exponential backoff with jitter and are limited to transport
+errors, HTTP 408, 429 and 5xx responses. POST requests are retried only when
+an idempotency key is configured and the target explicitly supports it.
+
+The connector honors `Retry-After` for 429 and 503 responses, capped by the
+configured request timeout. No retry occurs for authentication, authorization,
+validation, or other 4xx errors.
+
+An optional per-connector rate limit is enforced before sending a request.
+Concurrency defaults to one request per connector instance.
+
+## REST source contract
+
+The first source adapter supports `GET` only and requires:
+
+- an allowlisted endpoint
+- an explicitly configured JSON content type
+- a response containing either a JSON array or a configured records field
+- optional page-number or cursor pagination, never both at once
+
+Each JSON object becomes one `DataRecord`. Nested objects and arrays are kept
+as JSON values. Pagination stops at the configured page limit, an absent next
+cursor, or an empty page. A missing or malformed cursor is a failure.
+
+The source streams records and must not load the complete response or complete
+dataset into the UI.
+
+## REST target contract
+
+The first target adapter supports `POST` and `PUT` only. The method, endpoint,
+request content type and response success range are explicit configuration.
+The default success range is 200-299.
+
+Records are sent in bounded JSON batches. The target reports the number of
+accepted records and preserves the first actionable remote error. DELETE and
+PATCH are out of scope for the first adapter and require a separate destructive
+operation policy with preview and confirmation.
+
+For POST, an idempotency key is mandatory when retries are enabled. Keys are
+derived from the operation ID and batch number and are sent through the
+configured idempotency header. PUT is considered idempotent only when the
+configured resource URL identifies the complete batch replacement.
+
+## Cancellation, audit and observability
+
+Cancellation closes the active HTTP body, stops pagination and prevents new
+retries or batches. Every operation receives a correlation ID. Logs and audit
+events may include endpoint host/path, method, status, duration, byte counts,
+record counts and retry count, but never secrets or full payloads.
+
+Stable error categories are required:
+
+- `CONFIGURATION`
+- `SECURITY_POLICY`
+- `AUTHENTICATION`
+- `TIMEOUT`
+- `RATE_LIMIT`
+- `REMOTE_FAILURE`
+- `PAYLOAD_LIMIT`
+- `PARSE_FAILURE`
+- `CANCELLED`
+
+## Acceptance criteria for implementation
+
+The REST package is ready for implementation when these tests exist:
+
+1. allowlisted HTTPS requests succeed and non-allowlisted requests fail before
+   network I/O;
+2. private-IP, redirect and unsupported-scheme checks are enforced;
+3. secrets are absent from exceptions, logs and serialized job/profile data;
+4. timeout, response-size, page-count and retry limits are enforced;
+5. source pagination streams records and stops deterministically;
+6. target batches, success/error handling and idempotency headers are tested;
+7. cancellation closes the response body and prevents further requests;
+8. an in-process HTTP emulator covers the complete test profile without real
+   external network access.
+
+## Explicitly deferred
+
+OAuth/client-certificate authentication, multipart uploads, webhooks,
+GraphQL, DELETE/PATCH targets, distributed rate-limit coordination and
+provider-specific pagination are separate packages.

--- a/src/main/java/com/zeus/upload/config/AppProperties.java
+++ b/src/main/java/com/zeus/upload/config/AppProperties.java
@@ -23,6 +23,10 @@ public class AppProperties {
 
     private String profileDirectory = "profiles";
 
+    private String connectionProfileDirectory = "connections";
+
+    private String connectionMasterKey = "";
+
     public String getDefaultLibrary() {
         return defaultLibrary;
     }
@@ -53,5 +57,20 @@ public class AppProperties {
 
     public void setProfileDirectory(String profileDirectory) {
         this.profileDirectory = profileDirectory;
+    }
+    public String getConnectionProfileDirectory() {
+        return connectionProfileDirectory;
+    }
+
+    public void setConnectionProfileDirectory(String connectionProfileDirectory) {
+        this.connectionProfileDirectory = connectionProfileDirectory;
+    }
+
+    public String getConnectionMasterKey() {
+        return connectionMasterKey;
+    }
+
+    public void setConnectionMasterKey(String connectionMasterKey) {
+        this.connectionMasterKey = connectionMasterKey;
     }
 }

--- a/src/main/java/com/zeus/upload/connector/ConnectorFactory.java
+++ b/src/main/java/com/zeus/upload/connector/ConnectorFactory.java
@@ -4,10 +4,18 @@ import com.zeus.upload.connector.db.DbTableTargetConnector;
 import com.zeus.upload.connector.db.DbTableSourceConnector;
 import com.zeus.upload.connector.file.CsvSourceConnector;
 import com.zeus.upload.connector.file.CsvTargetConnector;
+import com.zeus.upload.connector.file.FilesystemCsvSourceConnector;
+import com.zeus.upload.connector.file.FilesystemCsvTargetConnector;
+import com.zeus.upload.connector.rest.RestJsonSourceConnector;
+import com.zeus.upload.connector.rest.RestJsonTargetConnector;
 import com.zeus.upload.flow.CsvSourceConfiguration;
 import com.zeus.upload.flow.CsvTargetConfiguration;
 import com.zeus.upload.flow.DbTableTargetConfiguration;
 import com.zeus.upload.flow.DbTableSourceConfiguration;
+import com.zeus.upload.flow.FilesystemCsvSourceConfiguration;
+import com.zeus.upload.flow.FilesystemCsvTargetConfiguration;
+import com.zeus.upload.flow.RestSourceConfiguration;
+import com.zeus.upload.flow.RestTargetConfiguration;
 import com.zeus.upload.flow.SourceConfiguration;
 import com.zeus.upload.flow.TargetConfiguration;
 import com.zeus.upload.service.ImportService;
@@ -41,6 +49,12 @@ public class ConnectorFactory {
         if (configuration instanceof DbTableSourceConfiguration dbSourceConfiguration) {
             return new DbTableSourceConnector(dataSource, sqlDialect, dbSourceConfiguration);
         }
+        if (configuration instanceof FilesystemCsvSourceConfiguration filesystemConfiguration) {
+            return new FilesystemCsvSourceConnector(filesystemConfiguration);
+        }
+        if (configuration instanceof RestSourceConfiguration restConfiguration) {
+            return new RestJsonSourceConnector(restConfiguration);
+        }
         throw new IllegalArgumentException("Unsupported source configuration: " + configuration.getClass().getName());
     }
 
@@ -50,6 +64,12 @@ public class ConnectorFactory {
         }
         if (configuration instanceof CsvTargetConfiguration csvTargetConfiguration) {
             return new CsvTargetConnector(csvTargetConfiguration);
+        }
+        if (configuration instanceof FilesystemCsvTargetConfiguration filesystemConfiguration) {
+            return new FilesystemCsvTargetConnector(filesystemConfiguration);
+        }
+        if (configuration instanceof RestTargetConfiguration restConfiguration) {
+            return new RestJsonTargetConnector(restConfiguration);
         }
         throw new IllegalArgumentException("Unsupported target configuration: " + configuration.getClass().getName());
     }

--- a/src/main/java/com/zeus/upload/connector/file/CsvTargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/file/CsvTargetConnector.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -22,12 +23,12 @@ public class CsvTargetConnector implements TargetConnector {
 
     @Override
     public void write(Stream<DataRecord> records) {
-        List<DataRecord> materialized = records.toList();
-        List<String> headers = new ArrayList<>();
-        for (DataRecord record : materialized) {
-            for (String key : record.asMap().keySet()) {
-                if (!headers.contains(key)) headers.add(key);
-            }
+        Iterator<DataRecord> iterator = records.iterator();
+        List<String> headers = new ArrayList<>(configuration.getHeaders());
+        DataRecord firstRecord = null;
+        if (headers.isEmpty() && iterator.hasNext()) {
+            firstRecord = iterator.next();
+            headers.addAll(firstRecord.asMap().keySet());
         }
         try {
             if (configuration.getOutputFile().getParent() != null) {
@@ -35,16 +36,21 @@ public class CsvTargetConnector implements TargetConnector {
             }
             try (BufferedWriter writer = Files.newBufferedWriter(configuration.getOutputFile(), StandardCharsets.UTF_8)) {
                 writeRow(writer, headers);
-                for (DataRecord record : materialized) {
-                    List<String> values = headers.stream()
-                            .map(header -> String.valueOf(record.get(header) == null ? "" : record.get(header)))
-                            .toList();
-                    writeRow(writer, values);
+                if (firstRecord != null) writeRecord(writer, headers, firstRecord);
+                while (iterator.hasNext()) {
+                    writeRecord(writer, headers, iterator.next());
                 }
             }
         } catch (IOException ex) {
             throw new IllegalStateException("Could not write CSV target: " + ex.getMessage(), ex);
         }
+    }
+
+    private void writeRecord(BufferedWriter writer, List<String> headers, DataRecord record) throws IOException {
+        List<String> values = headers.stream()
+                .map(header -> String.valueOf(record.get(header) == null ? "" : record.get(header)))
+                .toList();
+        writeRow(writer, values);
     }
 
     private void writeRow(BufferedWriter writer, List<String> values) throws IOException {

--- a/src/main/java/com/zeus/upload/connector/file/CsvTargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/file/CsvTargetConnector.java
@@ -5,7 +5,6 @@ import com.zeus.upload.flow.CsvTargetConfiguration;
 import com.zeus.upload.flow.DataRecord;
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -34,7 +33,7 @@ public class CsvTargetConnector implements TargetConnector {
             if (configuration.getOutputFile().getParent() != null) {
                 Files.createDirectories(configuration.getOutputFile().getParent());
             }
-            try (BufferedWriter writer = Files.newBufferedWriter(configuration.getOutputFile(), StandardCharsets.UTF_8)) {
+            try (BufferedWriter writer = Files.newBufferedWriter(configuration.getOutputFile(), configuration.getCharset())) {
                 writeRow(writer, headers);
                 if (firstRecord != null) writeRecord(writer, headers, firstRecord);
                 while (iterator.hasNext()) {

--- a/src/main/java/com/zeus/upload/connector/file/FilesystemCsvSourceConnector.java
+++ b/src/main/java/com/zeus/upload/connector/file/FilesystemCsvSourceConnector.java
@@ -1,0 +1,66 @@
+package com.zeus.upload.connector.file;
+
+import com.zeus.upload.connector.SourceConnector;
+import com.zeus.upload.flow.DataRecord;
+import com.zeus.upload.flow.FilesystemCsvSourceConfiguration;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+
+public class FilesystemCsvSourceConnector implements SourceConnector {
+    private final FilesystemCsvSourceConfiguration configuration;
+
+    public FilesystemCsvSourceConnector(FilesystemCsvSourceConfiguration configuration) {
+        this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
+    }
+
+    @Override
+    public Stream<DataRecord> read() {
+        Path input = FilesystemPathResolver.resolve(configuration.getRootDirectory(), configuration.getRelativeFile());
+        try {
+            BufferedReader reader = Files.newBufferedReader(input, configuration.getCharset());
+            CSVParser parser = CSVFormat.DEFAULT.builder()
+                    .setDelimiter(configuration.getDelimiter())
+                    .setQuote(configuration.getQuote())
+                    .setHeader()
+                    .setSkipHeaderRecord(true)
+                    .setIgnoreEmptyLines(true)
+                    .build().parse(reader);
+            List<String> headers = parser.getHeaderNames();
+            if (headers.isEmpty()) {
+                closeQuietly(parser, reader);
+                throw new IllegalArgumentException("CSV has no header row: " + configuration.getRelativeFile());
+            }
+            Iterator<DataRecord> records = parser.stream()
+                    .map(record -> toDataRecord(headers, record))
+                    .iterator();
+            return StreamSupport.stream(Spliterators.spliteratorUnknownSize(records, 0), false)
+                    .onClose(() -> closeQuietly(parser, reader));
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not read filesystem CSV source: " + input, ex);
+        }
+    }
+
+    private DataRecord toDataRecord(List<String> headers, CSVRecord csvRecord) {
+        DataRecord record = new DataRecord();
+        for (int index = 0; index < headers.size(); index++) {
+            record.set(headers.get(index), csvRecord.isSet(index) ? csvRecord.get(index) : null);
+        }
+        return record;
+    }
+
+    private void closeQuietly(CSVParser parser, BufferedReader reader) {
+        try { parser.close(); } catch (IOException ignored) { }
+        try { reader.close(); } catch (IOException ignored) { }
+    }
+}

--- a/src/main/java/com/zeus/upload/connector/file/FilesystemCsvTargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/file/FilesystemCsvTargetConnector.java
@@ -1,0 +1,32 @@
+package com.zeus.upload.connector.file;
+
+import com.zeus.upload.connector.TargetConnector;
+import com.zeus.upload.flow.CsvTargetConfiguration;
+import com.zeus.upload.flow.DataRecord;
+import com.zeus.upload.flow.FilesystemCsvTargetConfiguration;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class FilesystemCsvTargetConnector implements TargetConnector {
+    private final FilesystemCsvTargetConfiguration configuration;
+
+    public FilesystemCsvTargetConnector(FilesystemCsvTargetConfiguration configuration) {
+        this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
+    }
+
+    @Override
+    public void write(Stream<DataRecord> records) {
+        Path output = FilesystemPathResolver.resolve(configuration.getRootDirectory(), configuration.getRelativeFile());
+        try {
+            if (output.getParent() != null) Files.createDirectories(output.getParent());
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not create filesystem target directory: " + output.getParent(), ex);
+        }
+        new CsvTargetConnector(new CsvTargetConfiguration(
+                output, configuration.getDelimiter(), configuration.getQuote(), configuration.getCharset(), configuration.getHeaders()))
+                .write(records);
+    }
+}

--- a/src/main/java/com/zeus/upload/connector/file/FilesystemPathResolver.java
+++ b/src/main/java/com/zeus/upload/connector/file/FilesystemPathResolver.java
@@ -1,0 +1,18 @@
+package com.zeus.upload.connector.file;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+final class FilesystemPathResolver {
+    private FilesystemPathResolver() { }
+
+    static Path resolve(Path rootDirectory, String relativeFile) {
+        Path root = Objects.requireNonNull(rootDirectory, "rootDirectory must not be null")
+                .toAbsolutePath().normalize();
+        Path requested = Path.of(Objects.requireNonNull(relativeFile, "relativeFile must not be null"));
+        if (requested.isAbsolute()) throw new IllegalArgumentException("Filesystem connector requires a relative file path");
+        Path resolved = root.resolve(requested).normalize();
+        if (!resolved.startsWith(root)) throw new IllegalArgumentException("Filesystem path escapes the configured root directory");
+        return resolved;
+    }
+}

--- a/src/main/java/com/zeus/upload/connector/rest/RestAuthentication.java
+++ b/src/main/java/com/zeus/upload/connector/rest/RestAuthentication.java
@@ -1,0 +1,43 @@
+package com.zeus.upload.connector.rest;
+
+import java.util.Objects;
+
+public final class RestAuthentication {
+
+    public enum Type { NONE, BEARER, BASIC }
+
+    private final Type type;
+    private final String username;
+    private final String secretKey;
+
+    private RestAuthentication(Type type, String username, String secretKey) {
+        this.type = type;
+        this.username = username;
+        this.secretKey = secretKey;
+    }
+
+    public static RestAuthentication none() {
+        return new RestAuthentication(Type.NONE, null, null);
+    }
+
+    public static RestAuthentication bearer(String tokenSecretKey) {
+        return new RestAuthentication(Type.BEARER, null,
+                requireSecretKey(tokenSecretKey));
+    }
+
+    public static RestAuthentication basic(String username, String passwordSecretKey) {
+        return new RestAuthentication(Type.BASIC, Objects.requireNonNull(username, "username must not be null"),
+                requireSecretKey(passwordSecretKey));
+    }
+
+    private static String requireSecretKey(String secretKey) {
+        if (secretKey == null || secretKey.isBlank()) {
+            throw new IllegalArgumentException("secretKey must not be blank");
+        }
+        return secretKey;
+    }
+
+    public Type getType() { return type; }
+    public String getUsername() { return username; }
+    public String getSecretKey() { return secretKey; }
+}

--- a/src/main/java/com/zeus/upload/connector/rest/RestConnectorException.java
+++ b/src/main/java/com/zeus/upload/connector/rest/RestConnectorException.java
@@ -1,0 +1,23 @@
+package com.zeus.upload.connector.rest;
+
+public class RestConnectorException extends RuntimeException {
+
+    public enum Category {
+        CONFIGURATION, SECURITY_POLICY, AUTHENTICATION, TIMEOUT, RATE_LIMIT,
+        REMOTE_FAILURE, PAYLOAD_LIMIT, PARSE_FAILURE, CANCELLED
+    }
+
+    private final Category category;
+
+    public RestConnectorException(Category category, String message) {
+        super(message);
+        this.category = category;
+    }
+
+    public RestConnectorException(Category category, String message, Throwable cause) {
+        super(message, cause);
+        this.category = category;
+    }
+
+    public Category getCategory() { return category; }
+}

--- a/src/main/java/com/zeus/upload/connector/rest/RestConnectorSettings.java
+++ b/src/main/java/com/zeus/upload/connector/rest/RestConnectorSettings.java
@@ -1,0 +1,161 @@
+package com.zeus.upload.connector.rest;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+
+public final class RestConnectorSettings {
+
+    private final RestDeploymentProfile profile;
+    private final List<RestEndpointRule> allowlist;
+    private final SecretProvider secretProvider;
+    private final RestAuthentication authentication;
+    private final Duration connectTimeout;
+    private final Duration requestTimeout;
+    private final int maxResponseBytes;
+    private final int maxRequestBytes;
+    private final int maxRetries;
+    private final int maxRecordsPerPage;
+    private final RestEndpointValidator endpointValidator;
+
+    private RestConnectorSettings(Builder builder) {
+        profile = builder.profile;
+        allowlist = List.copyOf(builder.allowlist);
+        secretProvider = builder.secretProvider;
+        authentication = builder.authentication;
+        connectTimeout = builder.connectTimeout;
+        requestTimeout = builder.requestTimeout;
+        maxResponseBytes = builder.maxResponseBytes;
+        maxRequestBytes = builder.maxRequestBytes;
+        maxRetries = builder.maxRetries;
+        maxRecordsPerPage = builder.maxRecordsPerPage;
+        endpointValidator = new RestEndpointValidator(profile, allowlist);
+        if (allowlist.isEmpty()) throw new IllegalArgumentException("REST endpoint allowlist must not be empty");
+        if (authentication.getType() != RestAuthentication.Type.NONE && secretProvider == null) {
+            throw new IllegalArgumentException("A SecretProvider is required for authenticated REST access");
+        }
+    }
+
+    public static Builder builder() { return new Builder(); }
+
+    public void validateEndpoint(URI endpoint) {
+        endpointValidator.validate(endpoint);
+    }
+
+    public HttpClient createHttpClient() {
+        return HttpClient.newBuilder()
+                .connectTimeout(connectTimeout)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
+    }
+
+    public String authorizationHeader() {
+        if (authentication.getType() == RestAuthentication.Type.NONE) return null;
+        String secret = secretProvider.resolve(authentication.getSecretKey());
+        if (secret == null || secret.isBlank()) throw new RestConnectorException(
+                RestConnectorException.Category.AUTHENTICATION, "Configured REST secret is unavailable");
+        if (authentication.getType() == RestAuthentication.Type.BEARER) return "Bearer " + secret;
+        String basic = authentication.getUsername() + ":" + secret;
+        return "Basic " + Base64.getEncoder().encodeToString(basic.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    public RestDeploymentProfile getProfile() { return profile; }
+    public Duration getRequestTimeout() { return requestTimeout; }
+    public int getMaxResponseBytes() { return maxResponseBytes; }
+    public int getMaxRequestBytes() { return maxRequestBytes; }
+    public int getMaxRetries() { return maxRetries; }
+    public int getMaxRecordsPerPage() { return maxRecordsPerPage; }
+
+    public static final class Builder {
+        private RestDeploymentProfile profile = RestDeploymentProfile.PRODUCTION;
+        private List<RestEndpointRule> allowlist = List.of();
+        private SecretProvider secretProvider;
+        private RestAuthentication authentication = RestAuthentication.none();
+        private Duration connectTimeout = Duration.ofSeconds(5);
+        private Duration requestTimeout = Duration.ofSeconds(30);
+        private int maxResponseBytes = 10 * 1024 * 1024;
+        private int maxRequestBytes = 10 * 1024 * 1024;
+        private int maxRetries = 2;
+        private int maxRecordsPerPage = 1_000;
+
+        public Builder profile(RestDeploymentProfile value) { profile = Objects.requireNonNull(value); return this; }
+        public Builder allowlist(List<RestEndpointRule> value) { allowlist = Objects.requireNonNull(value); return this; }
+        public Builder secretProvider(SecretProvider value) { secretProvider = value; return this; }
+        public Builder authentication(RestAuthentication value) { authentication = Objects.requireNonNull(value); return this; }
+        public Builder connectTimeout(Duration value) { connectTimeout = bounded(value, Duration.ofMillis(1), Duration.ofSeconds(30), "connectTimeout"); return this; }
+        public Builder requestTimeout(Duration value) { requestTimeout = bounded(value, Duration.ofMillis(1), Duration.ofMinutes(5), "requestTimeout"); return this; }
+        public Builder maxResponseBytes(int value) { maxResponseBytes = bounded(value, 1, 100 * 1024 * 1024, "maxResponseBytes"); return this; }
+        public Builder maxRequestBytes(int value) { maxRequestBytes = bounded(value, 1, 100 * 1024 * 1024, "maxRequestBytes"); return this; }
+        public Builder maxRetries(int value) { maxRetries = bounded(value, 0, 5, "maxRetries"); return this; }
+        public Builder maxRecordsPerPage(int value) { maxRecordsPerPage = bounded(value, 1, 10_000, "maxRecordsPerPage"); return this; }
+
+        public RestConnectorSettings build() { return new RestConnectorSettings(this); }
+
+        private Duration bounded(Duration value, Duration min, Duration max, String name) {
+            Objects.requireNonNull(value, name + " must not be null");
+            if (value.compareTo(min) < 0 || value.compareTo(max) > 0) throw new IllegalArgumentException(name + " is outside the allowed range");
+            return value;
+        }
+
+        private int bounded(int value, int min, int max, String name) {
+            if (value < min || value > max) throw new IllegalArgumentException(name + " is outside the allowed range");
+            return value;
+        }
+    }
+
+    private static final class RestEndpointValidator {
+        private final RestDeploymentProfile profile;
+        private final List<RestEndpointRule> allowlist;
+
+        private RestEndpointValidator(RestDeploymentProfile profile, List<RestEndpointRule> allowlist) {
+            this.profile = profile;
+            this.allowlist = allowlist;
+        }
+
+        private void validate(URI endpoint) {
+            if (endpoint == null || endpoint.getHost() == null || endpoint.getUserInfo() != null
+                    || endpoint.getFragment() != null || endpoint.getQuery() != null && endpoint.getQuery().contains("#")) {
+                throw new RestConnectorException(RestConnectorException.Category.SECURITY_POLICY, "REST endpoint URI is not allowed");
+            }
+            if (!"https".equalsIgnoreCase(endpoint.getScheme())
+                    && !(profile == RestDeploymentProfile.TEST && "http".equalsIgnoreCase(endpoint.getScheme()))) {
+                throw new RestConnectorException(RestConnectorException.Category.SECURITY_POLICY, "REST endpoint scheme is not allowed");
+            }
+            if (allowlist.stream().noneMatch(rule -> rule.matches(endpoint))) {
+                throw new RestConnectorException(RestConnectorException.Category.SECURITY_POLICY, "REST endpoint is not allowlisted");
+            }
+            if (profile == RestDeploymentProfile.PRODUCTION) {
+                try {
+                    for (InetAddress address : InetAddress.getAllByName(endpoint.getHost())) {
+                        if (isPrivateOrReserved(address)) throw new RestConnectorException(
+                                RestConnectorException.Category.SECURITY_POLICY, "REST endpoint resolves to a private or reserved address");
+                    }
+                } catch (UnknownHostException ex) {
+                    throw new RestConnectorException(RestConnectorException.Category.SECURITY_POLICY, "REST endpoint host cannot be resolved", ex);
+                }
+            }
+        }
+
+        private boolean isPrivateOrReserved(InetAddress address) {
+            byte[] bytes = address.getAddress();
+            if (address.isAnyLocalAddress() || address.isLoopbackAddress() || address.isLinkLocalAddress()
+                    || address.isSiteLocalAddress() || address.isMulticastAddress()) return true;
+            if (bytes.length == 4) {
+                int first = bytes[0] & 0xff;
+                int second = bytes[1] & 0xff;
+                return first == 0 || first == 10 || first == 127 || first >= 224
+                        || first == 169 && second == 254
+                        || first == 172 && second >= 16 && second <= 31
+                        || first == 192 && second == 168
+                        || first == 100 && second >= 64 && second <= 127
+                        || first == 198 && (second == 18 || second == 19);
+            }
+            return (bytes[0] & 0xff) == 0xfc || (bytes[0] & 0xfe) == 0xfc;
+        }
+    }
+}

--- a/src/main/java/com/zeus/upload/connector/rest/RestDeploymentProfile.java
+++ b/src/main/java/com/zeus/upload/connector/rest/RestDeploymentProfile.java
@@ -1,0 +1,6 @@
+package com.zeus.upload.connector.rest;
+
+public enum RestDeploymentProfile {
+    TEST,
+    PRODUCTION
+}

--- a/src/main/java/com/zeus/upload/connector/rest/RestEndpointRule.java
+++ b/src/main/java/com/zeus/upload/connector/rest/RestEndpointRule.java
@@ -1,0 +1,51 @@
+package com.zeus.upload.connector.rest;
+
+import java.net.URI;
+import java.util.Locale;
+import java.util.Objects;
+
+public final class RestEndpointRule {
+
+    private final String scheme;
+    private final String hostname;
+    private final int port;
+    private final String pathPrefix;
+
+    public RestEndpointRule(String scheme, String hostname, int port, String pathPrefix) {
+        this.scheme = requireText(scheme, "scheme").toLowerCase(Locale.ROOT);
+        this.hostname = requireText(hostname, "hostname").toLowerCase(Locale.ROOT);
+        if (port < 1 || port > 65535) throw new IllegalArgumentException("port must be between 1 and 65535");
+        this.port = port;
+        this.pathPrefix = normalizePathPrefix(pathPrefix);
+    }
+
+    public boolean matches(URI endpoint) {
+        int effectivePort = endpoint.getPort() > 0 ? endpoint.getPort() : defaultPort(endpoint.getScheme());
+        String endpointPath = endpoint.getPath() == null || endpoint.getPath().isBlank() ? "/" : endpoint.getPath();
+        return scheme.equalsIgnoreCase(endpoint.getScheme())
+                && hostname.equalsIgnoreCase(endpoint.getHost())
+                && port == effectivePort
+                && (endpointPath.equals(pathPrefix) || endpointPath.startsWith(pathPrefix.endsWith("/")
+                ? pathPrefix : pathPrefix + "/"));
+    }
+
+    private int defaultPort(String endpointScheme) {
+        return "https".equalsIgnoreCase(endpointScheme) ? 443 : 80;
+    }
+
+    private String normalizePathPrefix(String value) {
+        String prefix = value == null || value.isBlank() ? "/" : value.trim();
+        if (!prefix.startsWith("/")) prefix = "/" + prefix;
+        return prefix.length() > 1 && prefix.endsWith("/") ? prefix.substring(0, prefix.length() - 1) : prefix;
+    }
+
+    private String requireText(String value, String field) {
+        if (value == null || value.isBlank()) throw new IllegalArgumentException(field + " must not be blank");
+        return value.trim();
+    }
+
+    public String getScheme() { return scheme; }
+    public String getHostname() { return hostname; }
+    public int getPort() { return port; }
+    public String getPathPrefix() { return pathPrefix; }
+}

--- a/src/main/java/com/zeus/upload/connector/rest/RestHttpClient.java
+++ b/src/main/java/com/zeus/upload/connector/rest/RestHttpClient.java
@@ -1,0 +1,124 @@
+package com.zeus.upload.connector.rest;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class RestHttpClient {
+
+    private final RestConnectorSettings settings;
+    private final HttpClient client;
+
+    RestHttpClient(RestConnectorSettings settings) {
+        this.settings = settings;
+        this.client = settings.createHttpClient();
+    }
+
+    byte[] execute(URI endpoint, String method, byte[] requestBody, Map<String, String> headers, boolean retryable) {
+        settings.validateEndpoint(endpoint);
+        if (requestBody != null && requestBody.length > settings.getMaxRequestBytes()) {
+            throw new RestConnectorException(RestConnectorException.Category.PAYLOAD_LIMIT, "REST request exceeds the configured size limit");
+        }
+        int attempts = retryable ? settings.getMaxRetries() : 0;
+        for (int attempt = 0; ; attempt++) {
+            try {
+                HttpRequest.Builder builder = HttpRequest.newBuilder(endpoint)
+                        .timeout(settings.getRequestTimeout())
+                        .header("Accept", "application/json");
+                if (headers != null) headers.forEach((name, value) -> builder.header(name, value));
+                String authorization = settings.authorizationHeader();
+                if (authorization != null) builder.header("Authorization", authorization);
+                HttpRequest.BodyPublisher body = requestBody == null
+                        ? HttpRequest.BodyPublishers.noBody()
+                        : HttpRequest.BodyPublishers.ofByteArray(requestBody);
+                HttpResponse<InputStream> response = client.send(
+                        builder.method(method, body).build(), HttpResponse.BodyHandlers.ofInputStream());
+                int status = response.statusCode();
+                byte[] payload;
+                try (InputStream stream = response.body()) {
+                    payload = readLimited(stream, settings.getMaxResponseBytes());
+                }
+                if (status >= 200 && status <= 299) return payload;
+                if (attempt < attempts && isRetryableStatus(status)) {
+                    pause(retryDelay(attempt, response.headers().firstValue("Retry-After").orElse(null)));
+                    continue;
+                }
+                throw remoteFailure(status);
+            } catch (RestConnectorException ex) {
+                throw ex;
+            } catch (java.net.http.HttpTimeoutException ex) {
+                if (attempt < attempts) {
+                    pause(backoff(attempt));
+                    continue;
+                }
+                throw new RestConnectorException(RestConnectorException.Category.TIMEOUT, "REST request timed out", ex);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                throw new RestConnectorException(RestConnectorException.Category.CANCELLED, "REST request was interrupted", ex);
+            } catch (IOException ex) {
+                if (attempt < attempts) {
+                    pause(backoff(attempt));
+                    continue;
+                }
+                throw new RestConnectorException(RestConnectorException.Category.REMOTE_FAILURE, "REST request failed", ex);
+            }
+        }
+    }
+
+    private byte[] readLimited(InputStream stream, int limit) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream(Math.min(limit, 8192));
+        byte[] buffer = new byte[8192];
+        int total = 0;
+        int read;
+        while ((read = stream.read(buffer)) >= 0) {
+            total += read;
+            if (total > limit) throw new RestConnectorException(
+                    RestConnectorException.Category.PAYLOAD_LIMIT, "REST response exceeds the configured size limit");
+            output.write(buffer, 0, read);
+        }
+        return output.toByteArray();
+    }
+
+    private boolean isRetryableStatus(int status) {
+        return status == 408 || status == 429 || status >= 500;
+    }
+
+    private RestConnectorException remoteFailure(int status) {
+        RestConnectorException.Category category = status == 429
+                ? RestConnectorException.Category.RATE_LIMIT
+                : RestConnectorException.Category.REMOTE_FAILURE;
+        return new RestConnectorException(category, "REST endpoint returned HTTP status " + status);
+    }
+
+    private Duration retryDelay(int attempt, String retryAfter) {
+        if (retryAfter != null) {
+            try {
+                return Duration.ofSeconds(Math.min(Long.parseLong(retryAfter), 5));
+            } catch (NumberFormatException ignored) {
+                // Fall back to bounded exponential backoff.
+            }
+        }
+        return backoff(attempt);
+    }
+
+    private Duration backoff(int attempt) {
+        return Duration.ofMillis(Math.min(1_000, 50L * (1L << Math.min(attempt, 4))));
+    }
+
+    private void pause(Duration delay) {
+        try {
+            Thread.sleep(delay.toMillis());
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new RestConnectorException(RestConnectorException.Category.CANCELLED, "REST retry was interrupted", ex);
+        }
+    }
+}

--- a/src/main/java/com/zeus/upload/connector/rest/RestJsonSourceConnector.java
+++ b/src/main/java/com/zeus/upload/connector/rest/RestJsonSourceConnector.java
@@ -1,0 +1,162 @@
+package com.zeus.upload.connector.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zeus.upload.connector.SourceConnector;
+import com.zeus.upload.flow.DataRecord;
+import com.zeus.upload.flow.RestSourceConfiguration;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public final class RestJsonSourceConnector implements SourceConnector {
+
+    private final RestSourceConfiguration configuration;
+    private final ObjectMapper objectMapper;
+
+    public RestJsonSourceConnector(RestSourceConfiguration configuration) {
+        this(configuration, new ObjectMapper());
+    }
+
+    public RestJsonSourceConnector(RestSourceConfiguration configuration, ObjectMapper objectMapper) {
+        this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+    }
+
+    @Override
+    public Stream<DataRecord> read() {
+        RestJsonIterator iterator = new RestJsonIterator();
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false)
+                .onClose(iterator::close);
+    }
+
+    private final class RestJsonIterator implements Iterator<DataRecord> {
+        private final RestHttpClient httpClient = new RestHttpClient(configuration.getSettings());
+        private Iterator<JsonNode> currentPage = List.<JsonNode>of().iterator();
+        private int pageNumber;
+        private String cursor;
+        private boolean firstPage = true;
+        private boolean finished;
+        private boolean closed;
+
+        @Override
+        public boolean hasNext() {
+            if (closed) return false;
+            while (!currentPage.hasNext() && !finished) loadNextPage();
+            return currentPage.hasNext();
+        }
+
+        @Override
+        public DataRecord next() {
+            if (!hasNext()) throw new NoSuchElementException();
+            return toRecord(currentPage.next());
+        }
+
+        private void loadNextPage() {
+            RestPaginationConfiguration pagination = configuration.getPagination();
+            if (pagination.getMode() == RestPaginationMode.NONE && !firstPage) {
+                finished = true;
+                return;
+            }
+            if (pageNumber >= pagination.getMaxPages()) {
+                throw new RestConnectorException(RestConnectorException.Category.PAYLOAD_LIMIT,
+                        "REST pagination exceeded the configured page limit");
+            }
+            URI requestUri = requestUri(pagination);
+            byte[] response = httpClient.execute(requestUri, "GET", null, Map.of(), true);
+            Page page = parsePage(response);
+            pageNumber++;
+            firstPage = false;
+            currentPage = page.records.iterator();
+            if (pagination.getMode() == RestPaginationMode.NONE
+                    || page.records.isEmpty()
+                    || pagination.getMode() == RestPaginationMode.PAGE_NUMBER
+                    && page.records.size() < pagination.getPageSize()) {
+                finished = true;
+            } else if (pagination.getMode() == RestPaginationMode.CURSOR) {
+                cursor = page.nextCursor;
+                if (cursor == null || cursor.isBlank()) finished = true;
+            }
+        }
+
+        private URI requestUri(RestPaginationConfiguration pagination) {
+            if (pagination.getMode() == RestPaginationMode.NONE) return configuration.getEndpoint();
+            if (pagination.getMode() == RestPaginationMode.PAGE_NUMBER) {
+                return withQuery(configuration.getEndpoint(), List.of(
+                        Map.entry(pagination.getPageParameter(), String.valueOf(pageNumber + 1)),
+                        Map.entry(pagination.getPageSizeParameter(), String.valueOf(pagination.getPageSize()))));
+            }
+            if (cursor == null) return configuration.getEndpoint();
+            return withQuery(configuration.getEndpoint(), List.of(Map.entry(pagination.getCursorParameter(), cursor)));
+        }
+        private URI withQuery(URI endpoint, List<Map.Entry<String, String>> parameters) {
+            StringBuilder query = new StringBuilder(endpoint.getRawQuery() == null ? "" : endpoint.getRawQuery());
+            for (Map.Entry<String, String> parameter : parameters) {
+                if (query.length() > 0) query.append('&');
+                query.append(URLEncoder.encode(parameter.getKey(), StandardCharsets.UTF_8));
+                query.append('=').append(URLEncoder.encode(parameter.getValue(), StandardCharsets.UTF_8));
+            }
+            String base = endpoint.getScheme() + "://" + endpoint.getRawAuthority()
+                    + (endpoint.getRawPath() == null ? "" : endpoint.getRawPath());
+            return URI.create(base + "?" + query);
+        }
+
+
+        private Page parsePage(byte[] response) {
+            try {
+                JsonNode root = objectMapper.readTree(response);
+                List<JsonNode> records = new ArrayList<>();
+                JsonNode recordsNode = root;
+                String nextCursor = null;
+                if (root != null && root.isObject()) {
+                    String field = configuration.getRecordsField();
+                    if (field == null) throw new RestConnectorException(RestConnectorException.Category.PARSE_FAILURE,
+                            "REST object response requires recordsField");
+                    recordsNode = root.get(field);
+                    if (configuration.getPagination().getMode() == RestPaginationMode.CURSOR) {
+                        JsonNode cursorNode = root.get(configuration.getPagination().getNextCursorField());
+                        if (cursorNode != null && !cursorNode.isNull()) nextCursor = cursorNode.asText();
+                    }
+                }
+                if (recordsNode == null || !recordsNode.isArray()) {
+                    throw new RestConnectorException(RestConnectorException.Category.PARSE_FAILURE,
+                            "REST response does not contain a JSON array of records");
+                }
+                if (recordsNode.size() > configuration.getSettings().getMaxRecordsPerPage()) {
+                    throw new RestConnectorException(RestConnectorException.Category.PAYLOAD_LIMIT,
+                            "REST response exceeds the configured record limit");
+                }
+                for (JsonNode record : recordsNode) {
+                    if (!record.isObject()) throw new RestConnectorException(RestConnectorException.Category.PARSE_FAILURE,
+                            "REST records must be JSON objects");
+                    records.add(record);
+                }
+                return new Page(records, nextCursor);
+            } catch (RestConnectorException ex) {
+                throw ex;
+            } catch (Exception ex) {
+                throw new RestConnectorException(RestConnectorException.Category.PARSE_FAILURE,
+                        "Could not parse REST JSON response", ex);
+            }
+        }
+
+        private DataRecord toRecord(JsonNode node) {
+            DataRecord record = new DataRecord();
+            node.fields().forEachRemaining(entry -> record.set(entry.getKey(), objectMapper.convertValue(entry.getValue(), Object.class)));
+            return record;
+        }
+
+        private void close() { closed = true; }
+    }
+
+    private record Page(List<JsonNode> records, String nextCursor) { }
+}

--- a/src/main/java/com/zeus/upload/connector/rest/RestJsonTargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/rest/RestJsonTargetConnector.java
@@ -1,0 +1,81 @@
+package com.zeus.upload.connector.rest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zeus.upload.connector.TargetConnector;
+import com.zeus.upload.flow.DataRecord;
+import com.zeus.upload.flow.RestTargetConfiguration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+public final class RestJsonTargetConnector implements TargetConnector {
+
+    private final RestTargetConfiguration configuration;
+    private final ObjectMapper objectMapper;
+    private final RestHttpClient httpClient;
+    private long acceptedRecordCount;
+
+    public RestJsonTargetConnector(RestTargetConfiguration configuration) {
+        this(configuration, new ObjectMapper());
+    }
+
+    public RestJsonTargetConnector(RestTargetConfiguration configuration, ObjectMapper objectMapper) {
+        this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+        this.httpClient = new RestHttpClient(configuration.getSettings());
+    }
+
+    @Override
+    public void write(Stream<DataRecord> records) {
+        String operationId = UUID.randomUUID().toString();
+        List<Map<String, Object>> batch = new ArrayList<>();
+        AtomicLong batchCounter = new AtomicLong();
+        var iterator = records.iterator();
+        while (iterator.hasNext()) {
+            batch.add(iterator.next().asMap());
+            if (batch.size() >= configuration.getBatchSize()) {
+                sendSplit(batch, operationId, batchCounter);
+                batch = new ArrayList<>();
+            }
+        }
+        if (!batch.isEmpty()) sendSplit(batch, operationId, batchCounter);
+    }
+
+    public long getAcceptedRecordCount() { return acceptedRecordCount; }
+
+    private void sendSplit(List<Map<String, Object>> batch, String operationId, AtomicLong batchCounter) {
+        byte[] body = serialize(batch);
+        if (body.length > configuration.getSettings().getMaxRequestBytes()) {
+            if (batch.size() == 1) throw new RestConnectorException(RestConnectorException.Category.PAYLOAD_LIMIT,
+                    "REST record exceeds the configured request size limit");
+            int midpoint = batch.size() / 2;
+            sendSplit(new ArrayList<>(batch.subList(0, midpoint)), operationId, batchCounter);
+            sendSplit(new ArrayList<>(batch.subList(midpoint, batch.size())), operationId, batchCounter);
+            return;
+        }
+        java.util.Map<String, String> headers = new java.util.LinkedHashMap<>();
+        headers.put("Content-Type", "application/json");
+        if (configuration.getIdempotencyHeader() != null) {
+            headers.put(configuration.getIdempotencyHeader(), operationId + "-" + batchCounter.incrementAndGet());
+        }
+        boolean retryable = configuration.getMethod() == RestTargetConfiguration.Method.PUT
+                || configuration.getIdempotencyHeader() != null;
+        httpClient.execute(
+                configuration.getEndpoint(), configuration.getMethod().name(), body, headers, retryable);
+        acceptedRecordCount += batch.size();
+    }
+
+    private byte[] serialize(List<Map<String, Object>> batch) {
+        try {
+            return objectMapper.writeValueAsBytes(batch);
+        } catch (JsonProcessingException ex) {
+            throw new RestConnectorException(RestConnectorException.Category.PARSE_FAILURE,
+                    "Could not serialize REST request payload", ex);
+        }
+    }
+}

--- a/src/main/java/com/zeus/upload/connector/rest/RestPaginationConfiguration.java
+++ b/src/main/java/com/zeus/upload/connector/rest/RestPaginationConfiguration.java
@@ -1,0 +1,69 @@
+package com.zeus.upload.connector.rest;
+
+import java.util.Objects;
+
+public final class RestPaginationConfiguration {
+
+    private final RestPaginationMode mode;
+    private final String pageParameter;
+    private final String pageSizeParameter;
+    private final String cursorParameter;
+    private final String recordsField;
+    private final String nextCursorField;
+    private final int pageSize;
+    private final int maxPages;
+
+    private RestPaginationConfiguration(Builder builder) {
+        mode = builder.mode;
+        pageParameter = builder.pageParameter;
+        pageSizeParameter = builder.pageSizeParameter;
+        cursorParameter = builder.cursorParameter;
+        recordsField = builder.recordsField;
+        nextCursorField = builder.nextCursorField;
+        pageSize = builder.pageSize;
+        maxPages = builder.maxPages;
+        if (mode == RestPaginationMode.CURSOR && (recordsField == null || nextCursorField == null)) {
+            throw new IllegalArgumentException("Cursor pagination requires recordsField and nextCursorField");
+        }
+        if (mode != RestPaginationMode.NONE && recordsField == null) {
+            throw new IllegalArgumentException("Pagination requires recordsField");
+        }
+    }
+
+    public static RestPaginationConfiguration none() { return builder().mode(RestPaginationMode.NONE).build(); }
+    public static Builder builder() { return new Builder(); }
+    public RestPaginationMode getMode() { return mode; }
+    public String getPageParameter() { return pageParameter; }
+    public String getPageSizeParameter() { return pageSizeParameter; }
+    public String getCursorParameter() { return cursorParameter; }
+    public String getRecordsField() { return recordsField; }
+    public String getNextCursorField() { return nextCursorField; }
+    public int getPageSize() { return pageSize; }
+    public int getMaxPages() { return maxPages; }
+
+    public static final class Builder {
+        private RestPaginationMode mode = RestPaginationMode.NONE;
+        private String pageParameter = "page";
+        private String pageSizeParameter = "pageSize";
+        private String cursorParameter = "cursor";
+        private String recordsField;
+        private String nextCursorField;
+        private int pageSize = 100;
+        private int maxPages = 1_000;
+
+        public Builder mode(RestPaginationMode value) { mode = Objects.requireNonNull(value); return this; }
+        public Builder pageParameter(String value) { pageParameter = text(value, "pageParameter"); return this; }
+        public Builder pageSizeParameter(String value) { pageSizeParameter = text(value, "pageSizeParameter"); return this; }
+        public Builder cursorParameter(String value) { cursorParameter = text(value, "cursorParameter"); return this; }
+        public Builder recordsField(String value) { recordsField = text(value, "recordsField"); return this; }
+        public Builder nextCursorField(String value) { nextCursorField = text(value, "nextCursorField"); return this; }
+        public Builder pageSize(int value) { if (value < 1 || value > 10_000) throw new IllegalArgumentException("pageSize is outside the allowed range"); pageSize = value; return this; }
+        public Builder maxPages(int value) { if (value < 1 || value > 10_000) throw new IllegalArgumentException("maxPages is outside the allowed range"); maxPages = value; return this; }
+        public RestPaginationConfiguration build() { return new RestPaginationConfiguration(this); }
+
+        private String text(String value, String name) {
+            if (value == null || value.isBlank()) throw new IllegalArgumentException(name + " must not be blank");
+            return value;
+        }
+    }
+}

--- a/src/main/java/com/zeus/upload/connector/rest/RestPaginationMode.java
+++ b/src/main/java/com/zeus/upload/connector/rest/RestPaginationMode.java
@@ -1,0 +1,7 @@
+package com.zeus.upload.connector.rest;
+
+public enum RestPaginationMode {
+    NONE,
+    PAGE_NUMBER,
+    CURSOR
+}

--- a/src/main/java/com/zeus/upload/connector/rest/SecretProvider.java
+++ b/src/main/java/com/zeus/upload/connector/rest/SecretProvider.java
@@ -1,0 +1,6 @@
+package com.zeus.upload.connector.rest;
+
+@FunctionalInterface
+public interface SecretProvider {
+    String resolve(String secretKey);
+}

--- a/src/main/java/com/zeus/upload/controller/ConnectionPageController.java
+++ b/src/main/java/com/zeus/upload/controller/ConnectionPageController.java
@@ -1,0 +1,22 @@
+package com.zeus.upload.controller;
+
+import com.zeus.upload.service.ConnectionCryptoService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class ConnectionPageController {
+
+    private final ConnectionCryptoService cryptoService;
+
+    public ConnectionPageController(ConnectionCryptoService cryptoService) {
+        this.cryptoService = cryptoService;
+    }
+
+    @GetMapping("/connections")
+    public String connections(Model model) {
+        model.addAttribute("encryptionConfigured", cryptoService.isConfigured());
+        return "connections";
+    }
+}

--- a/src/main/java/com/zeus/upload/controller/ConnectionProfileController.java
+++ b/src/main/java/com/zeus/upload/controller/ConnectionProfileController.java
@@ -1,0 +1,65 @@
+package com.zeus.upload.controller;
+
+import com.zeus.upload.domain.ConnectionProfile;
+import com.zeus.upload.domain.ConnectionProfileRequest;
+import com.zeus.upload.service.ConnectionCryptoService;
+import com.zeus.upload.service.ConnectionProfileService;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/connections")
+public class ConnectionProfileController {
+
+    private final ConnectionProfileService profileService;
+    private final ConnectionCryptoService cryptoService;
+
+    public ConnectionProfileController(ConnectionProfileService profileService, ConnectionCryptoService cryptoService) {
+        this.profileService = profileService;
+        this.cryptoService = cryptoService;
+    }
+
+    @GetMapping
+    public List<ConnectionProfile> list() throws IOException {
+        return profileService.list();
+    }
+
+    @GetMapping("/{name}")
+    public ConnectionProfile load(@PathVariable String name) throws IOException {
+        try {
+            return profileService.load(name);
+        } catch (NoSuchFileException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Connection profile not found");
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<ConnectionProfile> save(@RequestBody ConnectionProfileRequest request) throws IOException {
+        if (!cryptoService.isConfigured()) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                    "Connection encryption is not configured");
+        }
+        try {
+            return ResponseEntity.status(HttpStatus.CREATED).body(profileService.save(request));
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
+    }
+
+    @DeleteMapping("/{name}")
+    public ResponseEntity<Void> delete(@PathVariable String name) throws IOException {
+        profileService.delete(name);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/zeus/upload/domain/ConnectionProfile.java
+++ b/src/main/java/com/zeus/upload/domain/ConnectionProfile.java
@@ -1,0 +1,37 @@
+package com.zeus.upload.domain;
+
+public class ConnectionProfile {
+
+    private String name;
+    private ConnectionType type;
+    private String endpoint;
+    private String description;
+    private boolean credentialsConfigured;
+    private String updatedAt;
+
+    public ConnectionProfile() {
+    }
+
+    public ConnectionProfile(String name, ConnectionType type, String endpoint, String description,
+                             boolean credentialsConfigured, String updatedAt) {
+        this.name = name;
+        this.type = type;
+        this.endpoint = endpoint;
+        this.description = description;
+        this.credentialsConfigured = credentialsConfigured;
+        this.updatedAt = updatedAt;
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public ConnectionType getType() { return type; }
+    public void setType(ConnectionType type) { this.type = type; }
+    public String getEndpoint() { return endpoint; }
+    public void setEndpoint(String endpoint) { this.endpoint = endpoint; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public boolean isCredentialsConfigured() { return credentialsConfigured; }
+    public void setCredentialsConfigured(boolean credentialsConfigured) { this.credentialsConfigured = credentialsConfigured; }
+    public String getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(String updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/src/main/java/com/zeus/upload/domain/ConnectionProfileRequest.java
+++ b/src/main/java/com/zeus/upload/domain/ConnectionProfileRequest.java
@@ -1,0 +1,26 @@
+package com.zeus.upload.domain;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ConnectionProfileRequest {
+
+    private String name;
+    private ConnectionType type;
+    private String endpoint;
+    private String description;
+    private Map<String, String> credentials = new LinkedHashMap<>();
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public ConnectionType getType() { return type; }
+    public void setType(ConnectionType type) { this.type = type; }
+    public String getEndpoint() { return endpoint; }
+    public void setEndpoint(String endpoint) { this.endpoint = endpoint; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public Map<String, String> getCredentials() { return credentials; }
+    public void setCredentials(Map<String, String> credentials) {
+        this.credentials = credentials == null ? new LinkedHashMap<>() : new LinkedHashMap<>(credentials);
+    }
+}

--- a/src/main/java/com/zeus/upload/domain/ConnectionType.java
+++ b/src/main/java/com/zeus/upload/domain/ConnectionType.java
@@ -1,0 +1,6 @@
+package com.zeus.upload.domain;
+
+public enum ConnectionType {
+    DB2_400,
+    REST
+}

--- a/src/main/java/com/zeus/upload/domain/EncryptedConnectionSecrets.java
+++ b/src/main/java/com/zeus/upload/domain/EncryptedConnectionSecrets.java
@@ -1,0 +1,20 @@
+package com.zeus.upload.domain;
+
+public class EncryptedConnectionSecrets {
+
+    private String iv;
+    private String ciphertext;
+
+    public EncryptedConnectionSecrets() {
+    }
+
+    public EncryptedConnectionSecrets(String iv, String ciphertext) {
+        this.iv = iv;
+        this.ciphertext = ciphertext;
+    }
+
+    public String getIv() { return iv; }
+    public void setIv(String iv) { this.iv = iv; }
+    public String getCiphertext() { return ciphertext; }
+    public void setCiphertext(String ciphertext) { this.ciphertext = ciphertext; }
+}

--- a/src/main/java/com/zeus/upload/flow/CsvTargetConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/CsvTargetConfiguration.java
@@ -1,5 +1,7 @@
 package com.zeus.upload.flow;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
@@ -7,23 +9,30 @@ import java.util.Objects;
 public class CsvTargetConfiguration implements TargetConfiguration {
 
     private final Path outputFile;
+    private final Charset charset;
     private final char delimiter;
     private final char quote;
     private final List<String> headers;
 
     public CsvTargetConfiguration(Path outputFile, char delimiter, char quote) {
-        this(outputFile, delimiter, quote, List.of());
+        this(outputFile, delimiter, quote, StandardCharsets.UTF_8, List.of());
     }
 
     public CsvTargetConfiguration(Path outputFile, char delimiter, char quote, List<String> headers) {
+        this(outputFile, delimiter, quote, StandardCharsets.UTF_8, headers);
+    }
+
+    public CsvTargetConfiguration(Path outputFile, char delimiter, char quote, Charset charset, List<String> headers) {
         this.outputFile = Objects.requireNonNull(outputFile, "outputFile must not be null");
         this.delimiter = delimiter;
+        this.charset = Objects.requireNonNull(charset, "charset must not be null");
         this.quote = quote;
         this.headers = headers == null ? List.of() : List.copyOf(headers);
     }
 
     public Path getOutputFile() { return outputFile; }
     public char getDelimiter() { return delimiter; }
+    public Charset getCharset() { return charset; }
     public char getQuote() { return quote; }
     public List<String> getHeaders() { return headers; }
 }

--- a/src/main/java/com/zeus/upload/flow/CsvTargetConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/CsvTargetConfiguration.java
@@ -1,6 +1,7 @@
 package com.zeus.upload.flow;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Objects;
 
 public class CsvTargetConfiguration implements TargetConfiguration {
@@ -8,14 +9,21 @@ public class CsvTargetConfiguration implements TargetConfiguration {
     private final Path outputFile;
     private final char delimiter;
     private final char quote;
+    private final List<String> headers;
 
     public CsvTargetConfiguration(Path outputFile, char delimiter, char quote) {
+        this(outputFile, delimiter, quote, List.of());
+    }
+
+    public CsvTargetConfiguration(Path outputFile, char delimiter, char quote, List<String> headers) {
         this.outputFile = Objects.requireNonNull(outputFile, "outputFile must not be null");
         this.delimiter = delimiter;
         this.quote = quote;
+        this.headers = headers == null ? List.of() : List.copyOf(headers);
     }
 
     public Path getOutputFile() { return outputFile; }
     public char getDelimiter() { return delimiter; }
     public char getQuote() { return quote; }
+    public List<String> getHeaders() { return headers; }
 }

--- a/src/main/java/com/zeus/upload/flow/FilesystemCsvSourceConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/FilesystemCsvSourceConfiguration.java
@@ -1,0 +1,39 @@
+package com.zeus.upload.flow;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class FilesystemCsvSourceConfiguration implements SourceConfiguration {
+    private final Path rootDirectory;
+    private final String relativeFile;
+    private final Charset charset;
+    private final char delimiter;
+    private final char quote;
+
+    public FilesystemCsvSourceConfiguration(Path rootDirectory, String relativeFile) {
+        this(rootDirectory, relativeFile, StandardCharsets.UTF_8, ',', '"');
+    }
+
+    public FilesystemCsvSourceConfiguration(Path rootDirectory, String relativeFile, Charset charset,
+                                            char delimiter, char quote) {
+        this.rootDirectory = Objects.requireNonNull(rootDirectory, "rootDirectory must not be null");
+        this.relativeFile = requireRelativeFile(relativeFile);
+        this.charset = Objects.requireNonNull(charset, "charset must not be null");
+        this.delimiter = delimiter;
+        this.quote = quote;
+    }
+
+    private String requireRelativeFile(String value) {
+        if (value == null || value.isBlank()) throw new IllegalArgumentException("relativeFile must not be blank");
+        if (Path.of(value).isAbsolute()) throw new IllegalArgumentException("Filesystem connector requires a relative file path");
+        return value;
+    }
+
+    public Path getRootDirectory() { return rootDirectory; }
+    public String getRelativeFile() { return relativeFile; }
+    public Charset getCharset() { return charset; }
+    public char getDelimiter() { return delimiter; }
+    public char getQuote() { return quote; }
+}

--- a/src/main/java/com/zeus/upload/flow/FilesystemCsvTargetConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/FilesystemCsvTargetConfiguration.java
@@ -1,0 +1,43 @@
+package com.zeus.upload.flow;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+public class FilesystemCsvTargetConfiguration implements TargetConfiguration {
+    private final Path rootDirectory;
+    private final String relativeFile;
+    private final Charset charset;
+    private final char delimiter;
+    private final char quote;
+    private final List<String> headers;
+
+    public FilesystemCsvTargetConfiguration(Path rootDirectory, String relativeFile, List<String> headers) {
+        this(rootDirectory, relativeFile, StandardCharsets.UTF_8, ',', '"', headers);
+    }
+
+    public FilesystemCsvTargetConfiguration(Path rootDirectory, String relativeFile, Charset charset,
+                                            char delimiter, char quote, List<String> headers) {
+        this.rootDirectory = Objects.requireNonNull(rootDirectory, "rootDirectory must not be null");
+        this.relativeFile = requireRelativeFile(relativeFile);
+        this.charset = Objects.requireNonNull(charset, "charset must not be null");
+        this.delimiter = delimiter;
+        this.quote = quote;
+        this.headers = headers == null ? List.of() : List.copyOf(headers);
+    }
+
+    private String requireRelativeFile(String value) {
+        if (value == null || value.isBlank()) throw new IllegalArgumentException("relativeFile must not be blank");
+        if (Path.of(value).isAbsolute()) throw new IllegalArgumentException("Filesystem connector requires a relative file path");
+        return value;
+    }
+
+    public Path getRootDirectory() { return rootDirectory; }
+    public String getRelativeFile() { return relativeFile; }
+    public Charset getCharset() { return charset; }
+    public char getDelimiter() { return delimiter; }
+    public char getQuote() { return quote; }
+    public List<String> getHeaders() { return headers; }
+}

--- a/src/main/java/com/zeus/upload/flow/RestSourceConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/RestSourceConfiguration.java
@@ -1,0 +1,30 @@
+package com.zeus.upload.flow;
+
+import com.zeus.upload.connector.rest.RestConnectorSettings;
+import com.zeus.upload.connector.rest.RestPaginationConfiguration;
+import java.net.URI;
+import java.util.Objects;
+
+public final class RestSourceConfiguration implements SourceConfiguration {
+    private final URI endpoint;
+    private final String recordsField;
+    private final RestPaginationConfiguration pagination;
+    private final RestConnectorSettings settings;
+
+    public RestSourceConfiguration(URI endpoint, String recordsField,
+                                   RestPaginationConfiguration pagination,
+                                   RestConnectorSettings settings) {
+        this.endpoint = Objects.requireNonNull(endpoint, "endpoint must not be null");
+        this.recordsField = recordsField == null || recordsField.isBlank() ? null : recordsField;
+        this.pagination = Objects.requireNonNull(pagination, "pagination must not be null");
+        this.settings = Objects.requireNonNull(settings, "settings must not be null");
+        if (pagination.getMode() != com.zeus.upload.connector.rest.RestPaginationMode.NONE && this.recordsField == null) {
+            throw new IllegalArgumentException("Paginated REST source requires recordsField");
+        }
+    }
+
+    public URI getEndpoint() { return endpoint; }
+    public String getRecordsField() { return recordsField; }
+    public RestPaginationConfiguration getPagination() { return pagination; }
+    public RestConnectorSettings getSettings() { return settings; }
+}

--- a/src/main/java/com/zeus/upload/flow/RestTargetConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/RestTargetConfiguration.java
@@ -1,0 +1,35 @@
+package com.zeus.upload.flow;
+
+import com.zeus.upload.connector.rest.RestConnectorSettings;
+import java.net.URI;
+import java.util.Objects;
+
+public final class RestTargetConfiguration implements TargetConfiguration {
+    public enum Method { POST, PUT }
+
+    private final URI endpoint;
+    private final Method method;
+    private final int batchSize;
+    private final String idempotencyHeader;
+    private final RestConnectorSettings settings;
+
+    public RestTargetConfiguration(URI endpoint, Method method, int batchSize,
+                                   String idempotencyHeader, RestConnectorSettings settings) {
+        this.endpoint = Objects.requireNonNull(endpoint, "endpoint must not be null");
+        this.method = Objects.requireNonNull(method, "method must not be null");
+        if (batchSize < 1 || batchSize > 10_000) throw new IllegalArgumentException("batchSize is outside the allowed range");
+        this.batchSize = batchSize;
+        this.idempotencyHeader = idempotencyHeader == null || idempotencyHeader.isBlank()
+                ? null : idempotencyHeader;
+        this.settings = Objects.requireNonNull(settings, "settings must not be null");
+        if (method == Method.POST && settings.getMaxRetries() > 0 && this.idempotencyHeader == null) {
+            throw new IllegalArgumentException("POST targets with retries require an idempotency header");
+        }
+    }
+
+    public URI getEndpoint() { return endpoint; }
+    public Method getMethod() { return method; }
+    public int getBatchSize() { return batchSize; }
+    public String getIdempotencyHeader() { return idempotencyHeader; }
+    public RestConnectorSettings getSettings() { return settings; }
+}

--- a/src/main/java/com/zeus/upload/service/ConnectionCryptoService.java
+++ b/src/main/java/com/zeus/upload/service/ConnectionCryptoService.java
@@ -1,0 +1,101 @@
+package com.zeus.upload.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zeus.upload.config.AppProperties;
+import com.zeus.upload.domain.EncryptedConnectionSecrets;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ConnectionCryptoService {
+
+    private static final String CIPHER = "AES/GCM/NoPadding";
+    private static final int IV_LENGTH = 12;
+    private static final int TAG_LENGTH_BITS = 128;
+
+    private final ObjectMapper objectMapper;
+    private final SecretKeySpec masterKey;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    @Autowired
+    public ConnectionCryptoService(ObjectMapper objectMapper, AppProperties appProperties) {
+        this(objectMapper, appProperties.getConnectionMasterKey());
+    }
+
+    ConnectionCryptoService(ObjectMapper objectMapper, String encodedMasterKey) {
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+        this.masterKey = parseKey(encodedMasterKey);
+    }
+
+    public boolean isConfigured() {
+        return masterKey != null;
+    }
+
+    public EncryptedConnectionSecrets encrypt(Map<String, String> secrets, String associatedData) {
+        requireConfigured();
+        try {
+            byte[] iv = new byte[IV_LENGTH];
+            secureRandom.nextBytes(iv);
+            Cipher cipher = Cipher.getInstance(CIPHER);
+            cipher.init(Cipher.ENCRYPT_MODE, masterKey, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+            cipher.updateAAD(aad(associatedData));
+            byte[] ciphertext = cipher.doFinal(objectMapper.writeValueAsBytes(new LinkedHashMap<>(secrets)));
+            return new EncryptedConnectionSecrets(encode(iv), encode(ciphertext));
+        } catch (GeneralSecurityException | JsonProcessingException ex) {
+            throw new IllegalStateException("Could not encrypt connection secrets", ex);
+        }
+    }
+
+    public Map<String, String> decrypt(EncryptedConnectionSecrets encrypted, String associatedData) {
+        requireConfigured();
+        Objects.requireNonNull(encrypted, "encrypted secrets must not be null");
+        try {
+            byte[] iv = Base64.getDecoder().decode(encrypted.getIv());
+            byte[] ciphertext = Base64.getDecoder().decode(encrypted.getCiphertext());
+            Cipher cipher = Cipher.getInstance(CIPHER);
+            cipher.init(Cipher.DECRYPT_MODE, masterKey, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+            cipher.updateAAD(aad(associatedData));
+            return new LinkedHashMap<>(objectMapper.readValue(cipher.doFinal(ciphertext), new TypeReference<>() { }));
+        } catch (GeneralSecurityException | java.io.IOException | IllegalArgumentException ex) {
+            throw new IllegalStateException("Could not decrypt connection secrets", ex);
+        }
+    }
+
+    private SecretKeySpec parseKey(String encodedMasterKey) {
+        if (encodedMasterKey == null || encodedMasterKey.isBlank()) return null;
+        try {
+            byte[] key = Base64.getDecoder().decode(encodedMasterKey.trim());
+            if (key.length != 32) throw new IllegalArgumentException("Connection master key must decode to 32 bytes");
+            return new SecretKeySpec(key, "AES");
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalStateException("Connection master key must be Base64 encoded and 256 bit", ex);
+        }
+    }
+
+    private void requireConfigured() {
+        if (!isConfigured()) {
+            throw new IllegalStateException("Encrypted connection profiles require app.connection master key or ZEUS_CONNECTION_MASTER_KEY");
+        }
+    }
+
+    private byte[] aad(String associatedData) {
+        return Objects.requireNonNull(associatedData, "associatedData must not be null")
+                .getBytes(StandardCharsets.UTF_8);
+    }
+
+    private String encode(byte[] value) {
+        return Base64.getEncoder().encodeToString(value);
+    }
+}

--- a/src/main/java/com/zeus/upload/service/ConnectionProfileService.java
+++ b/src/main/java/com/zeus/upload/service/ConnectionProfileService.java
@@ -1,0 +1,183 @@
+package com.zeus.upload.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zeus.upload.config.AppProperties;
+import com.zeus.upload.domain.ConnectionProfile;
+import com.zeus.upload.domain.ConnectionProfileRequest;
+import com.zeus.upload.domain.EncryptedConnectionSecrets;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.net.URI;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class ConnectionProfileService {
+
+    private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9][A-Za-z0-9_-]{0,63}");
+    private final ObjectMapper objectMapper;
+    private final ConnectionCryptoService cryptoService;
+    private final Path connectionDirectory;
+
+    @Autowired
+    public ConnectionProfileService(ObjectMapper objectMapper, AppProperties appProperties,
+                                    ConnectionCryptoService cryptoService) {
+        this(objectMapper, Path.of(appProperties.getConnectionProfileDirectory()), cryptoService);
+    }
+
+    ConnectionProfileService(ObjectMapper objectMapper, Path connectionDirectory,
+                             ConnectionCryptoService cryptoService) {
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+        this.connectionDirectory = Objects.requireNonNull(connectionDirectory, "connectionDirectory must not be null")
+                .toAbsolutePath().normalize();
+        this.cryptoService = Objects.requireNonNull(cryptoService, "cryptoService must not be null");
+    }
+
+    public ConnectionProfile save(ConnectionProfileRequest request) throws IOException {
+        validateRequest(request);
+        String safeName = validateName(request.getName());
+        Path target = profilePath(safeName);
+        StoredConnectionProfile previous = Files.exists(target) ? readStored(target) : null;
+        Map<String, String> credentials = sanitizeCredentials(request.getCredentials());
+        EncryptedConnectionSecrets encrypted = previous == null ? null : previous.getSecrets();
+        String newAssociatedData = associatedData(safeName, request.getType(), request.getEndpoint());
+        if (!credentials.isEmpty()) {
+            encrypted = cryptoService.encrypt(credentials, newAssociatedData);
+        } else if (encrypted != null && previous != null
+                && !associatedData(safeName, previous.getProfile().getType(), previous.getProfile().getEndpoint()).equals(newAssociatedData)) {
+            throw new IllegalArgumentException("Changing a connection endpoint or type requires replacing its credentials");
+        }
+        ConnectionProfile profile = new ConnectionProfile(
+                safeName, request.getType(), request.getEndpoint().trim(), trimToNull(request.getDescription()),
+                encrypted != null, Instant.now().toString());
+        StoredConnectionProfile stored = new StoredConnectionProfile(profile, encrypted);
+        Files.createDirectories(connectionDirectory);
+        Path temporary = Files.createTempFile(connectionDirectory, safeName + "-", ".tmp");
+        try {
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(temporary.toFile(), stored);
+            try {
+                Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (java.nio.file.AtomicMoveNotSupportedException ex) {
+                Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+        return profile;
+    }
+
+    public ConnectionProfile load(String name) throws IOException {
+        return readStored(profilePath(validateName(name))).getProfile();
+    }
+
+    public Map<String, String> loadCredentials(String name) throws IOException {
+        StoredConnectionProfile stored = readStored(profilePath(validateName(name)));
+        if (stored.getSecrets() == null) return Map.of();
+        ConnectionProfile profile = stored.getProfile();
+        return cryptoService.decrypt(stored.getSecrets(), associatedData(
+                profile.getName(), profile.getType(), profile.getEndpoint()));
+    }
+
+    public List<ConnectionProfile> list() throws IOException {
+        if (!Files.isDirectory(connectionDirectory)) return List.of();
+        try (var paths = Files.list(connectionDirectory)) {
+            return paths.filter(path -> path.getFileName().toString().endsWith(".json"))
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .map(path -> {
+                        try { return readStored(path).getProfile(); }
+                        catch (IOException ex) { throw new IllegalStateException("Could not read connection profile", ex); }
+                    })
+                    .toList();
+        }
+    }
+
+    public void delete(String name) throws IOException {
+        Files.deleteIfExists(profilePath(validateName(name)));
+    }
+
+    private StoredConnectionProfile readStored(Path path) throws IOException {
+        return objectMapper.readValue(path.toFile(), StoredConnectionProfile.class);
+    }
+
+    private Path profilePath(String name) {
+        return connectionDirectory.resolve(name + ".json").normalize();
+    }
+
+    private void validateRequest(ConnectionProfileRequest request) {
+        if (request == null || !StringUtils.hasText(request.getName())) throw new IllegalArgumentException("Connection name must not be blank");
+        if (request.getType() == null) throw new IllegalArgumentException("Connection type must be selected");
+        if (!StringUtils.hasText(request.getEndpoint())) throw new IllegalArgumentException("Connection endpoint must not be blank");
+        if (request.getEndpoint().length() > 2_000) throw new IllegalArgumentException("Connection endpoint is too long");
+        try {
+            String endpointValue = request.getEndpoint().trim();
+            if (endpointValue.chars().anyMatch(Character::isISOControl)) {
+                throw new IllegalArgumentException("Connection endpoint must not contain control characters");
+            }
+            // JT400 uses JDBC attributes such as "translate binary=true" with a space.
+            // Encode spaces for URI validation while preserving the original JDBC URL.
+            URI endpoint = URI.create(endpointValue.replace(" ", "%20"));
+            if (endpoint.getUserInfo() != null || endpoint.getFragment() != null) {
+                throw new IllegalArgumentException("Connection endpoint must not contain credentials or fragments");
+            }
+            if (request.getType() == com.zeus.upload.domain.ConnectionType.REST
+                    && !("http".equalsIgnoreCase(endpoint.getScheme()) || "https".equalsIgnoreCase(endpoint.getScheme()))) {
+                throw new IllegalArgumentException("REST connections require an HTTP(S) endpoint");
+            }
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Connection endpoint is invalid", ex);
+        }
+    }
+
+    private Map<String, String> sanitizeCredentials(Map<String, String> input) {
+        Map<String, String> result = new LinkedHashMap<>();
+        if (input == null) return result;
+        if (input.size() > 20) throw new IllegalArgumentException("Too many connection credentials");
+        input.forEach((key, value) -> {
+            if (StringUtils.hasText(key) && value != null && !value.isBlank()) {
+                if (key.length() > 64 || value.length() > 10_000) throw new IllegalArgumentException("Connection credential is too long");
+                result.put(key.trim(), value);
+            }
+        });
+        return result;
+    }
+
+    private String associatedData(String name, com.zeus.upload.domain.ConnectionType type, String endpoint) {
+        return name + "|" + type.name() + "|" + endpoint.trim();
+    }
+
+    private String validateName(String name) {
+        if (!StringUtils.hasText(name) || !SAFE_NAME.matcher(name).matches()) {
+            throw new IllegalArgumentException("Connection name must match [A-Za-z0-9][A-Za-z0-9_-]{0,63}.");
+        }
+        return name;
+    }
+
+    private String trimToNull(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    public static class StoredConnectionProfile {
+        private ConnectionProfile profile;
+        private EncryptedConnectionSecrets secrets;
+
+        public StoredConnectionProfile() { }
+        StoredConnectionProfile(ConnectionProfile profile, EncryptedConnectionSecrets secrets) {
+            this.profile = profile;
+            this.secrets = secrets;
+        }
+        public ConnectionProfile getProfile() { return profile; }
+        public void setProfile(ConnectionProfile profile) { this.profile = profile; }
+        public EncryptedConnectionSecrets getSecrets() { return secrets; }
+        public void setSecrets(EncryptedConnectionSecrets secrets) { this.secrets = secrets; }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,8 @@ app:
   sample-rows: 200
   batch-size: 500
   profile-directory: profiles
+  connection-profile-directory: connections
+  connection-master-key: ${ZEUS_CONNECTION_MASTER_KEY:}
 
 logging:
   level:

--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -1,0 +1,11 @@
+:root {
+    --zeus-ink: #172033;
+    --zeus-muted: #6b7280;
+    --zeus-accent: #3157d5;
+}
+
+body { color: var(--zeus-ink); }
+.app-page { max-width: 1440px; }
+.app-card { border: 0; border-radius: 1rem; box-shadow: 0 .35rem 1.2rem rgba(23, 32, 51, .08); }
+.eyebrow { color: var(--zeus-accent); font-size: .72rem; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }
+.list-group-item-action { cursor: pointer; }

--- a/src/main/resources/static/js/connections.js
+++ b/src/main/resources/static/js/connections.js
@@ -1,0 +1,86 @@
+(() => {
+    const form = document.getElementById('connectionForm');
+    const list = document.getElementById('connectionList');
+    const status = document.getElementById('connectionStatus');
+    const newButton = document.getElementById('newConnection');
+    const fields = {
+        name: document.getElementById('connectionName'),
+        type: document.getElementById('connectionType'),
+        endpoint: document.getElementById('connectionEndpoint'),
+        description: document.getElementById('connectionDescription'),
+        username: document.getElementById('connectionUsername'),
+        secret: document.getElementById('connectionSecret')
+    };
+
+    const showStatus = (message, kind = 'info') => {
+        status.textContent = message;
+        status.className = `alert alert-${kind}`;
+    };
+
+    const resetForm = () => {
+        form.reset();
+        fields.type.value = 'DB2_400';
+        fields.secret.value = '';
+    };
+
+    const render = (profiles) => {
+        list.replaceChildren();
+        if (!profiles.length) {
+            list.innerHTML = '<div class="text-secondary small">Noch keine Profile gespeichert.</div>';
+            return;
+        }
+        profiles.forEach(profile => {
+            const item = document.createElement('button');
+            item.type = 'button';
+            item.className = 'list-group-item list-group-item-action px-0 py-3';
+            item.innerHTML = `<div class="d-flex justify-content-between gap-2"><strong></strong><span class="badge text-bg-light"></span></div><div class="small text-secondary text-truncate"></div>`;
+            item.querySelector('strong').textContent = profile.name;
+            item.querySelector('.badge').textContent = profile.credentialsConfigured ? 'Secret gesetzt' : 'Ohne Secret';
+            item.querySelector('.text-secondary').textContent = profile.endpoint || '';
+            item.addEventListener('click', () => loadProfile(profile.name));
+            list.appendChild(item);
+        });
+    };
+
+    const loadProfiles = async () => {
+        const response = await fetch('/api/connections');
+        if (!response.ok) throw new Error(`Laden fehlgeschlagen (${response.status})`);
+        render(await response.json());
+    };
+
+    const loadProfile = async (name) => {
+        const response = await fetch(`/api/connections/${encodeURIComponent(name)}`);
+        if (!response.ok) { showStatus('Profil konnte nicht geladen werden.', 'danger'); return; }
+        const profile = await response.json();
+        fields.name.value = profile.name || '';
+        fields.type.value = profile.type || 'DB2_400';
+        fields.endpoint.value = profile.endpoint || '';
+        fields.description.value = profile.description || '';
+        fields.username.value = '';
+        fields.secret.value = '';
+        showStatus('Profil geladen. Ein leeres Secret lässt das bestehende Secret unverändert.', 'info');
+    };
+
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!form.reportValidity()) return;
+        const credentials = {};
+        if (fields.username.value.trim()) credentials.username = fields.username.value.trim();
+        if (fields.secret.value) credentials.secret = fields.secret.value;
+        try {
+            const response = await fetch('/api/connections', {
+                method: 'POST', headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    name: fields.name.value.trim(), type: fields.type.value,
+                    endpoint: fields.endpoint.value.trim(), description: fields.description.value.trim(), credentials
+                })
+            });
+            if (!response.ok) throw new Error((await response.json().catch(() => ({}))).message || `Speichern fehlgeschlagen (${response.status})`);
+            showStatus('Verbindung verschlüsselt gespeichert.', 'success');
+            await loadProfiles();
+        } catch (error) { showStatus(error.message, 'danger'); }
+    });
+
+    newButton.addEventListener('click', resetForm);
+    loadProfiles().catch(error => showStatus(error.message, 'danger'));
+})();

--- a/src/main/resources/templates/connections.html
+++ b/src/main/resources/templates/connections.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="de" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Verbindungen - Zeus Easy Upload</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" th:href="@{/css/app.css}">
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg bg-white border-bottom shadow-sm">
+    <div class="container-fluid px-4">
+        <a class="navbar-brand fw-semibold" th:href="@{/}">Zeus Easy Upload</a>
+        <div class="navbar-nav">
+            <a class="nav-link" th:href="@{/}">Import</a>
+            <a class="nav-link active" th:href="@{/connections}">Verbindungen</a>
+        </div>
+    </div>
+</nav>
+
+<main class="container py-4 app-page">
+    <div class="d-flex justify-content-between align-items-start gap-3 mb-4">
+        <div>
+            <p class="eyebrow mb-1">System configuration</p>
+            <h1 class="h3 mb-1">Verbindungsprofile</h1>
+            <p class="text-secondary mb-0">Endpunkte und Zugangsdaten zentral verwalten.</p>
+        </div>
+        <a class="btn btn-outline-secondary" th:href="@{/}">Zum Import</a>
+    </div>
+
+    <div th:if="${!encryptionConfigured}" class="alert alert-warning">
+        <strong>Verschlüsselung ist nicht eingerichtet.</strong>
+        Zum Speichern von Zugangsdaten muss <code>ZEUS_CONNECTION_MASTER_KEY</code>
+        (Base64, 256 Bit) gesetzt werden.
+    </div>
+    <div id="connectionStatus" class="alert d-none" role="status"></div>
+
+    <div class="row g-4">
+        <section class="col-xl-7">
+            <div class="card app-card">
+                <div class="card-body p-4">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <h2 class="h5 mb-0">Profil bearbeiten</h2>
+                        <button id="newConnection" type="button" class="btn btn-sm btn-outline-secondary">Neu</button>
+                    </div>
+                    <form id="connectionForm" novalidate>
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label for="connectionName" class="form-label">Name</label>
+                                <input id="connectionName" class="form-control" pattern="[A-Za-z0-9][A-Za-z0-9_-]{0,63}" required>
+                                <div class="form-text">Nur Buchstaben, Zahlen, Bindestrich und Unterstrich.</div>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="connectionType" class="form-label">Typ</label>
+                                <select id="connectionType" class="form-select" required>
+                                    <option value="DB2_400">IBM i DB2/400</option>
+                                    <option value="REST">REST API</option>
+                                </select>
+                            </div>
+                            <div class="col-12">
+                                <label for="connectionEndpoint" class="form-label">Verbindungs-URL</label>
+                                <input id="connectionEndpoint" class="form-control" placeholder="jdbc:as400://system/bib oder https://api.example.com" required>
+                            </div>
+                            <div class="col-12">
+                                <label for="connectionDescription" class="form-label">Beschreibung</label>
+                                <textarea id="connectionDescription" class="form-control" rows="2" maxlength="500"></textarea>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="connectionUsername" class="form-label">Benutzername</label>
+                                <input id="connectionUsername" class="form-control" autocomplete="username">
+                            </div>
+                            <div class="col-md-6">
+                                <label for="connectionSecret" class="form-label">Passwort / Token</label>
+                                <input id="connectionSecret" type="password" class="form-control" autocomplete="new-password">
+                                <div class="form-text">Leer lassen, um das bestehende Secret beizubehalten.</div>
+                            </div>
+                        </div>
+                        <div class="d-flex justify-content-end mt-4">
+                            <button id="saveConnection" type="submit" class="btn btn-primary" th:disabled="${!encryptionConfigured}">Verschlüsselt speichern</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </section>
+
+        <section class="col-xl-5">
+            <div class="card app-card">
+                <div class="card-body p-4">
+                    <h2 class="h5 mb-3">Gespeicherte Profile</h2>
+                    <div id="connectionList" class="list-group list-group-flush">
+                        <div class="text-secondary small">Profile werden geladen ...</div>
+                    </div>
+                    <p class="text-secondary small mt-3 mb-0">Secrets werden nie in dieser Liste oder beim Laden eines Profils zurückgegeben.</p>
+                </div>
+            </div>
+        </section>
+    </div>
+</main>
+<script th:src="@{/js/connections.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -5,8 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Zeus Easy Upload</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" th:href="@{/css/app.css}">
 </head>
 <body class="bg-light">
+<nav class="navbar navbar-expand-lg bg-white border-bottom shadow-sm mb-4"><div class="container"><a class="navbar-brand fw-semibold" th:href="@{/}">Zeus Easy Upload</a><div class="navbar-nav"><a class="nav-link active" th:href="@{/}">Import</a><a class="nav-link" th:href="@{/connections}">Verbindungen</a></div></div></nav>
 <div class="container py-5">
     <div class="row justify-content-center">
         <div class="col-lg-8">

--- a/src/test/java/com/zeus/upload/connector/file/CsvTargetConnectorTest.java
+++ b/src/test/java/com/zeus/upload/connector/file/CsvTargetConnectorTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.zeus.upload.flow.CsvTargetConfiguration;
 import com.zeus.upload.flow.DataRecord;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
@@ -23,5 +24,22 @@ class CsvTargetConnectorTest {
         new CsvTargetConnector(new CsvTargetConfiguration(file, ';', '"')).write(Stream.of(first, second));
 
         assertThat(Files.readString(file)).isEqualTo("\"ID\";\"NAME\"\r\n\"1\";\"Alice, \"\"A\"\"\"\r\n\"2\";\"Bob\"\r\n");
+    }
+
+    @Test
+    void shouldStreamRecordsUsingConfiguredHeaderOrder() throws Exception {
+        var file = Files.createTempFile("zeus-export-stream", ".csv");
+        var first = new DataRecord();
+        first.set("NAME", "Alice");
+        first.set("ID", 1);
+        var second = new DataRecord();
+        second.set("NAME", "Bob");
+        second.set("ID", 2);
+        second.set("IGNORED", "not part of the schema");
+
+        new CsvTargetConnector(new CsvTargetConfiguration(file, ';', '"', List.of("ID", "NAME")))
+                .write(Stream.of(first, second));
+
+        assertThat(Files.readString(file)).isEqualTo("\"ID\";\"NAME\"\r\n\"1\";\"Alice\"\r\n\"2\";\"Bob\"\r\n");
     }
 }

--- a/src/test/java/com/zeus/upload/connector/file/FilesystemCsvConnectorTest.java
+++ b/src/test/java/com/zeus/upload/connector/file/FilesystemCsvConnectorTest.java
@@ -1,0 +1,82 @@
+package com.zeus.upload.connector.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import com.zeus.upload.connector.ConnectorFactory;
+import com.zeus.upload.connector.SourceConnector;
+import com.zeus.upload.connector.TargetConnector;
+import com.zeus.upload.flow.DataRecord;
+import com.zeus.upload.flow.FilesystemCsvSourceConfiguration;
+import com.zeus.upload.flow.FilesystemCsvTargetConfiguration;
+import com.zeus.upload.service.ImportService;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class FilesystemCsvConnectorTest {
+
+    @Test
+    void readsCsvLazilyBelowConfiguredRoot() throws Exception {
+        Path root = Files.createTempDirectory("zeus-filesystem-source");
+        Files.createDirectories(root.resolve("incoming"));
+        Files.writeString(root.resolve("incoming/data.csv"), "id;name\n1;\"Ada;Lovelace\"\n2;Grace\n");
+
+        FilesystemCsvSourceConfiguration configuration = new FilesystemCsvSourceConfiguration(
+                root, "incoming/data.csv", StandardCharsets.UTF_8, ';', '"');
+
+        List<DataRecord> records;
+        try (Stream<DataRecord> stream = new FilesystemCsvSourceConnector(configuration).read()) {
+            records = stream.toList();
+        }
+
+        assertThat(records).hasSize(2);
+        assertThat(records.get(0).get("id")).isEqualTo("1");
+        assertThat(records.get(0).get("name")).isEqualTo("Ada;Lovelace");
+        assertThat(records.get(1).get("name")).isEqualTo("Grace");
+    }
+
+    @Test
+    void writesNestedCsvWithConfiguredCharsetAndEscaping() throws Exception {
+        Path root = Files.createTempDirectory("zeus-filesystem-target");
+        FilesystemCsvTargetConfiguration configuration = new FilesystemCsvTargetConfiguration(
+                root, "out/export.csv", StandardCharsets.ISO_8859_1, ';', '"', List.of("id", "name"));
+        DataRecord record = new DataRecord();
+        record.set("id", 1);
+        record.set("name", "Jörg;Test");
+
+        new FilesystemCsvTargetConnector(configuration).write(Stream.of(record));
+
+        assertThat(Files.readString(root.resolve("out/export.csv"), StandardCharsets.ISO_8859_1))
+                .isEqualTo("\"id\";\"name\"\r\n\"1\";\"Jörg;Test\"\r\n");
+    }
+
+    @Test
+    void rejectsPathsOutsideConfiguredRoot() throws Exception {
+        Path root = Files.createTempDirectory("zeus-filesystem-security");
+        FilesystemCsvSourceConfiguration source = new FilesystemCsvSourceConfiguration(root, "../outside.csv");
+
+        assertThatThrownBy(() -> new FilesystemCsvSourceConnector(source).read())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("escapes");
+        assertThatThrownBy(() -> new FilesystemCsvTargetConfiguration(root, root.resolve("absolute.csv").toString(), List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("relative");
+    }
+
+    @Test
+    void factoryCreatesFilesystemAdapters() throws Exception {
+        ConnectorFactory factory = new ConnectorFactory(mock(ImportService.class));
+        Path root = Files.createTempDirectory("zeus-filesystem-factory");
+
+        SourceConnector source = factory.createSource(new FilesystemCsvSourceConfiguration(root, "in.csv"));
+        TargetConnector target = factory.createTarget(new FilesystemCsvTargetConfiguration(root, "out.csv", List.of("id")));
+
+        assertThat(source).isInstanceOf(FilesystemCsvSourceConnector.class);
+        assertThat(target).isInstanceOf(FilesystemCsvTargetConnector.class);
+    }
+}

--- a/src/test/java/com/zeus/upload/connector/rest/RestConnectorTest.java
+++ b/src/test/java/com/zeus/upload/connector/rest/RestConnectorTest.java
@@ -1,0 +1,177 @@
+package com.zeus.upload.connector.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import com.zeus.upload.flow.DataRecord;
+import com.zeus.upload.flow.RestSourceConfiguration;
+import com.zeus.upload.flow.RestTargetConfiguration;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RestConnectorTest {
+
+    private HttpServer server;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void sourceStreamsPageNumberPagination() {
+        List<String> queries = new CopyOnWriteArrayList<>();
+        server.createContext("/api/items", exchange -> {
+            queries.add(exchange.getRequestURI().getRawQuery());
+            String body = exchange.getRequestURI().getQuery().contains("page=1")
+                    ? "{\"items\":[{\"id\":1}]}"
+                    : "{\"items\":[]}";
+            respond(exchange, 200, body);
+        });
+        RestConnectorSettings settings = settings("/api");
+        RestPaginationConfiguration pagination = RestPaginationConfiguration.builder()
+                .mode(RestPaginationMode.PAGE_NUMBER).recordsField("items")
+                .pageSize(1).maxPages(3).build();
+        RestSourceConfiguration configuration = new RestSourceConfiguration(
+                endpoint("/api/items"), "items", pagination, settings);
+
+        List<DataRecord> records;
+        try (Stream<DataRecord> stream = new RestJsonSourceConnector(configuration).read()) {
+            records = stream.toList();
+        }
+
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).get("id")).isEqualTo(1);
+        assertThat(queries).containsExactly("page=1&pageSize=1", "page=2&pageSize=1");
+    }
+
+    @Test
+    void sourceFollowsCursorPagination() {
+        server.createContext("/api/cursor", exchange -> {
+            String body = exchange.getRequestURI().getQuery() == null
+                    ? "{\"items\":[{\"id\":1}],\"next\":\"abc\"}"
+                    : "{\"items\":[{\"id\":2}],\"next\":null}";
+            respond(exchange, 200, body);
+        });
+        RestPaginationConfiguration pagination = RestPaginationConfiguration.builder()
+                .mode(RestPaginationMode.CURSOR).recordsField("items").nextCursorField("next")
+                .maxPages(3).build();
+        RestSourceConfiguration configuration = new RestSourceConfiguration(
+                endpoint("/api/cursor"), "items", pagination, settings("/api"));
+
+        try (Stream<DataRecord> stream = new RestJsonSourceConnector(configuration).read()) {
+            assertThat(stream.map(record -> record.get("id")).toList()).containsExactly(1, 2);
+        }
+    }
+
+    @Test
+    void targetBatchesRecordsAndSendsIdempotencyHeaders() {
+        List<byte[]> bodies = new CopyOnWriteArrayList<>();
+        List<String> idempotencyKeys = new CopyOnWriteArrayList<>();
+        server.createContext("/api/import", exchange -> {
+            bodies.add(exchange.getRequestBody().readAllBytes());
+            idempotencyKeys.add(exchange.getRequestHeaders().getFirst("Idempotency-Key"));
+            respond(exchange, 201, "{}");
+        });
+        RestConnectorSettings settings = RestConnectorSettings.builder()
+                .profile(RestDeploymentProfile.TEST)
+                .allowlist(List.of(new RestEndpointRule("http", "localhost", server.getAddress().getPort(), "/api")))
+                .maxRetries(1).build();
+        RestTargetConfiguration configuration = new RestTargetConfiguration(
+                endpoint("/api/import"), RestTargetConfiguration.Method.POST, 2,
+                "Idempotency-Key", settings);
+        RestJsonTargetConnector target = new RestJsonTargetConnector(configuration);
+
+        DataRecord first = record(1);
+        DataRecord second = record(2);
+        DataRecord third = record(3);
+        target.write(Stream.of(first, second, third));
+
+        assertThat(target.getAcceptedRecordCount()).isEqualTo(3);
+        assertThat(bodies).hasSize(2);
+        assertThat(new String(bodies.get(0), StandardCharsets.UTF_8)).contains("\"id\":1", "\"id\":2");
+        assertThat(new String(bodies.get(1), StandardCharsets.UTF_8)).contains("\"id\":3");
+        assertThat(idempotencyKeys).allMatch(key -> key != null && !key.isBlank());
+        assertThat(idempotencyKeys.get(0)).isNotEqualTo(idempotencyKeys.get(1));
+    }
+
+    @Test
+    void bearerSecretIsAddedAtRequestTime() {
+        List<String> authorization = new CopyOnWriteArrayList<>();
+        server.createContext("/api/auth", exchange -> {
+            authorization.add(exchange.getRequestHeaders().getFirst("Authorization"));
+            respond(exchange, 200, "[]");
+        });
+        RestConnectorSettings settings = RestConnectorSettings.builder()
+                .profile(RestDeploymentProfile.TEST)
+                .allowlist(List.of(new RestEndpointRule("http", "localhost", server.getAddress().getPort(), "/api")))
+                .authentication(RestAuthentication.bearer("service-token"))
+                .secretProvider(key -> "secret-value")
+                .build();
+        RestSourceConfiguration configuration = new RestSourceConfiguration(
+                endpoint("/api/auth"), null, RestPaginationConfiguration.none(), settings);
+
+        try (Stream<DataRecord> ignored = new RestJsonSourceConnector(configuration).read()) {
+            ignored.toList();
+        }
+
+        assertThat(authorization).containsExactly("Bearer secret-value");
+    }
+
+    @Test
+    void productionRejectsHttpBeforeNetworkAccess() {
+        RestConnectorSettings settings = RestConnectorSettings.builder()
+                .profile(RestDeploymentProfile.PRODUCTION)
+                .allowlist(List.of(new RestEndpointRule("http", "example.com", 80, "/")))
+                .build();
+
+        assertThatThrownBy(() -> settings.validateEndpoint(URI.create("http://example.com/records")))
+                .isInstanceOf(RestConnectorException.class)
+                .extracting(error -> ((RestConnectorException) error).getCategory())
+                .isEqualTo(RestConnectorException.Category.SECURITY_POLICY);
+    }
+
+    private RestConnectorSettings settings(String path) {
+        return RestConnectorSettings.builder()
+                .profile(RestDeploymentProfile.TEST)
+                .allowlist(List.of(new RestEndpointRule("http", "localhost", server.getAddress().getPort(), path)))
+                .build();
+    }
+
+    private URI endpoint(String path) {
+        return URI.create("http://localhost:" + server.getAddress().getPort() + path);
+    }
+
+    private DataRecord record(int id) {
+        DataRecord record = new DataRecord();
+        record.set("id", id);
+        record.set("name", "row-" + id);
+        return record;
+    }
+
+    private void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, payload.length);
+        try (var output = exchange.getResponseBody()) {
+            output.write(payload);
+        }
+    }
+}

--- a/src/test/java/com/zeus/upload/service/ConnectionProfileServiceTest.java
+++ b/src/test/java/com/zeus/upload/service/ConnectionProfileServiceTest.java
@@ -1,0 +1,94 @@
+package com.zeus.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zeus.upload.domain.ConnectionProfileRequest;
+import com.zeus.upload.domain.ConnectionType;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ConnectionProfileServiceTest {
+
+    private static final String MASTER_KEY = Base64.getEncoder().encodeToString(new byte[32]);
+
+    @Test
+    void storesSecretsEncryptedAndNeverReturnsThemFromProfileMetadata() throws Exception {
+        var directory = Files.createTempDirectory("zeus-connections");
+        var crypto = new ConnectionCryptoService(new ObjectMapper(), MASTER_KEY);
+        var service = new ConnectionProfileService(new ObjectMapper(), directory, crypto);
+        var request = request("rest-prod", ConnectionType.REST, "https://api.example.com/v1", Map.of(
+                "username", "service-user", "secret", "top-secret-token"));
+
+        var saved = service.save(request);
+
+        assertThat(saved.isCredentialsConfigured()).isTrue();
+        assertThat(service.load("rest-prod").getEndpoint()).isEqualTo("https://api.example.com/v1");
+        assertThat(service.loadCredentials("rest-prod"))
+                .containsEntry("username", "service-user")
+                .containsEntry("secret", "top-secret-token");
+        String stored = Files.readString(directory.resolve("rest-prod.json"));
+        assertThat(stored).doesNotContain("top-secret-token", "service-user");
+    }
+
+    @Test
+    void preservesExistingSecretWhenGuiLeavesCredentialFieldsEmpty() throws Exception {
+        var directory = Files.createTempDirectory("zeus-connections");
+        var crypto = new ConnectionCryptoService(new ObjectMapper(), MASTER_KEY);
+        var service = new ConnectionProfileService(new ObjectMapper(), directory, crypto);
+        service.save(request("db2", ConnectionType.DB2_400, "jdbc:as400://system/bib", Map.of("secret", "pw")));
+
+        service.save(request("db2", ConnectionType.DB2_400, "jdbc:as400://system/bib", Map.of()));
+
+        assertThat(service.loadCredentials("db2")).containsEntry("secret", "pw");
+    }
+
+    @Test
+    void acceptsJt400TranslateBinaryJdbcAttribute() throws Exception {
+        var directory = Files.createTempDirectory("zeus-connections");
+        var crypto = new ConnectionCryptoService(new ObjectMapper(), MASTER_KEY);
+        var service = new ConnectionProfileService(new ObjectMapper(), directory, crypto);
+        var endpoint = "jdbc:as400://system/bib;translate binary=true";
+
+        var saved = service.save(request("db2-translate", ConnectionType.DB2_400, endpoint, Map.of()));
+
+        assertThat(saved.getEndpoint()).isEqualTo(endpoint);
+    }
+
+    @Test
+    void refusesToSaveWhenMasterKeyIsMissing() throws Exception {
+        var directory = Files.createTempDirectory("zeus-connections");
+        var crypto = new ConnectionCryptoService(new ObjectMapper(), "");
+        var service = new ConnectionProfileService(new ObjectMapper(), directory, crypto);
+
+        assertThatThrownBy(() -> service.save(request("db2", ConnectionType.DB2_400,
+                "jdbc:as400://system/bib", Map.of("secret", "pw"))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("master key");
+    }
+
+    @Test
+    void rejectsCredentialsEmbeddedInEndpoint() {
+        var request = request("unsafe", ConnectionType.REST, "https://user:pw@example.com/api", Map.of());
+        var crypto = new ConnectionCryptoService(new ObjectMapper(), MASTER_KEY);
+        var service = new ConnectionProfileService(new ObjectMapper(),
+                java.nio.file.Path.of("target/test-connections"), crypto);
+
+        assertThatThrownBy(() -> service.save(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("endpoint");
+    }
+
+    private ConnectionProfileRequest request(String name, ConnectionType type, String endpoint,
+                                             Map<String, String> credentials) {
+        var request = new ConnectionProfileRequest();
+        request.setName(name);
+        request.setType(type);
+        request.setEndpoint(endpoint);
+        request.setCredentials(credentials);
+        return request;
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -7,3 +7,7 @@ spring:
   sql:
     init:
       mode: never
+
+app:
+  connection-profile-directory: ${java.io.tmpdir}/zeus-test-connections
+  connection-master-key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=


### PR DESCRIPTION
## What changed

- add filesystem CSV source/target connectors with root and traversal safety
- add policy-driven REST JSON source/target connectors with bounded retries, limits, pagination, batching and idempotency
- add the GUI foundation for DB2/400 and REST connection profiles
- encrypt stored connection secrets with AES-256-GCM and an externally supplied master key
- accept IBM i JDBC attributes such as translate binary=true while preserving the original URL
- update roadmap and architecture documentation without environment-specific connection data

## Validation

- mvn test
- 67 tests, 0 failures, 1 skipped
- local JDBC smoke test completed outside the repository

## Follow-up

Runtime connector selection, profile-backed execution and a dedicated GUI connection-test action remain separate packages.