### PR TITLE
Add H2 local profile, SqlDialect multi-DB layer, and per-connection sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Copy to .env only if your tooling loads it. Never commit a real .env file.
+# Prefer setting variables in the shell or a secret manager.
+
+# --- Local H2 (optional; prefer: mvn -Plocal spring-boot:run) ---
+# SPRING_PROFILES_ACTIVE=local
+
+# --- IBM i (only when a system is available; leave empty for local H2) ---
+# SPRING_DATASOURCE_DRIVER=com.ibm.as400.access.AS400JDBCDriver
+# SPRING_DATASOURCE_URL=jdbc:as400://YOUR_HOST/YOUR_LIBRARY;translate binary=true
+# SPRING_DATASOURCE_USERNAME=
+# SPRING_DATASOURCE_PASSWORD=
+
+# AES-256-GCM master key for encrypted connection profiles (Base64 of 32 bytes)
+# ZEUS_CONNECTION_MASTER_KEY=
+
+# Optional paths (local profiles should stay under .local/)
+# APP_CONNECTION_PROFILE_DIRECTORY=.local/connections
+# APP_DEFAULT_LIBRARY=TESTLIB

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,16 @@
 *.log
 __pycache__/
 *.py[cod]
+
+# Local-only data, secrets, H2 files, connection profiles (never commit)
 /.local/
+.env
+.env.*
+!.env.example
+application-local-override.yaml
+application-local-override.yml
+*.h2.db
+*.mv.db
+*.trace.db
+connections/
+profiles/

--- a/README.md
+++ b/README.md
@@ -52,23 +52,42 @@ Naechste Connector-Richtungen:
 
 - Java 17
 - Maven 3.9+
-- Netzwerkzugriff auf IBM i
-- Benutzer mit Rechten zum:
-  - `CREATE TABLE`
-  - `DROP TABLE` (wenn Option aktiviert)
-  - `INSERT`
+- **Lokal (ohne IBM i):** nichts weiter — Profil `local` nutzt eingebettetes H2
+- **Gegen IBM i:** Netzwerkzugriff und Benutzer mit `CREATE TABLE` / optional `DROP TABLE` / `INSERT` / `UPDATE` / `DELETE` / `SELECT`
+
+## Lokale Entwicklung (H2, empfohlen ohne IBM i)
+
+```bash
+mvn -Plocal spring-boot:run
+```
+
+- App: `http://localhost:8080`
+- H2-Konsole: `http://localhost:8080/h2-console`
+- Default-Library/Schema: `TESTLIB`
+- Daten und Verbindungsprofile unter `.local/` (gitignored)
+
+CREATE TABLE, INSERT, UPDATE, DELETE und SELECT sind gegen H2 lauffaehig und
+durch Integrationstests abgedeckt. Details: [docs/LOCAL_DEVELOPMENT.md](docs/LOCAL_DEVELOPMENT.md).
+
+Multi-DB laeuft ueber einen erweiterbaren **`SqlDialect`-Layer** (nicht Hibernate):
+IBM i first-class, H2 lokal, PostgreSQL-Scaffold, Registry per JDBC-URL.
+Siehe [docs/architecture/sql-dialects.md](docs/architecture/sql-dialects.md).
+
+**Wichtig:** Niemals echte IBM-i-Credentials, Master-Keys oder interne
+Verbindungsdaten committen. JDBC-Zugang nur per Umgebungsvariablen
+(`SPRING_DATASOURCE_*`, `ZEUS_CONNECTION_MASTER_KEY`). Vorlage: `.env.example`.
 
 ## Konfiguration
 
-Datei: `src/main/resources/application.yaml`
+Datei: `src/main/resources/application.yaml` (Platzhalter via Env; keine Secrets im Repo)
 
 ```yaml
 spring:
   datasource:
-    driver-class-name: com.ibm.as400.access.AS400JDBCDriver
-    url: jdbc:as400://system/bib;translate binary=true
-    username: user
-    password: pass
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER:com.ibm.as400.access.AS400JDBCDriver}
+    url: ${SPRING_DATASOURCE_URL:jdbc:as400://localhost/}
+    username: ${SPRING_DATASOURCE_USERNAME:}
+    password: ${SPRING_DATASOURCE_PASSWORD:}
 
   servlet:
     multipart:
@@ -76,12 +95,14 @@ spring:
       max-request-size: 50MB
 
 app:
-  default-library: BIB
+  default-library: ${APP_DEFAULT_LIBRARY:BIB}
   sample-rows: 200
   batch-size: 500
-  connection-profile-directory: connections
+  connection-profile-directory: ${APP_CONNECTION_PROFILE_DIRECTORY:connections}
   connection-master-key: ${ZEUS_CONNECTION_MASTER_KEY:}
 ```
+
+Profil `local`: `src/main/resources/application-local.yaml` (H2 file DB unter `.local/h2`).
 
 ## GUI und Verbindungsprofile
 
@@ -91,9 +112,9 @@ mit AES-256-GCM verschluesselt. Der Master-Key wird ausschliesslich ueber
 ZEUS_CONNECTION_MASTER_KEY oder app.connection-master-key bereitgestellt.
 
 Fuer lokale Entwicklungsprofile kann APP_CONNECTION_PROFILE_DIRECTORY=.local/connections
-gesetzt werden. Das Verzeichnis .local/ ist absichtlich git-ignoriert und darf
-nicht versioniert werden. Der Master-Key muss ausserhalb des Repositories
-gesichert werden.
+gesetzt werden (beim Profil `local` bereits der Default). Das Verzeichnis `.local/`
+ist git-ignoriert und darf nicht versioniert werden. Der Master-Key muss
+ausserhalb des Repositories gesichert werden.
 
 IBM-i JDBC-URLs duerfen Treiberattribute wie translate binary=true enthalten;
 diese URL wird zur Validierung sicher behandelt und unveraendert an den Treiber
@@ -104,15 +125,27 @@ dedizierter GUI-Verbindungstest sind noch separate Erweiterungspakete.
 
 - Schema entspricht `Library`.
 - SQL arbeitet mit `LIB.TABLE`.
-- Identifier werden in GroÃŸbuchstaben normalisiert.
+- Identifier werden in Grossbuchstaben normalisiert.
 - Spaltennamen werden auf `A-Z0-9_` reduziert.
-- SpaltenlÃ¤nge wird auf 10 Zeichen begrenzt (Trunkierung + Hash-Suffix).
+- Spaltenlaenge wird auf 10 Zeichen begrenzt (Trunkierung + Hash-Suffix).
 - Leere Strings werden als `NULL` gespeichert.
 
 ## Starten
 
+Lokal (H2):
+
 ```bash
 mvn clean package
+mvn -Plocal spring-boot:run
+```
+
+Gegen IBM i (Credentials nur ueber Env):
+
+```bash
+# PowerShell-Beispiel — Werte nicht committen
+$env:SPRING_DATASOURCE_URL = "jdbc:as400://host/LIB;translate binary=true"
+$env:SPRING_DATASOURCE_USERNAME = "..."
+$env:SPRING_DATASOURCE_PASSWORD = "..."
 mvn spring-boot:run
 ```
 
@@ -147,20 +180,20 @@ Regeln:
 
 ## Tests
 
-Enthaltene Tests decken neben dem Importkern auch Filesystem- und REST-Connectoren,
-verschluesselte Verbindungsprofile sowie GUI-nahe Profilvalidierung ab.
+Die Standard-Testsuite laeuft **ausschliesslich gegen H2** (Profil `test`) und
+benoetigt kein IBM i. Abgedeckt sind u. a.:
 
-Beispielhafte Unit-Tests:
-- `ColumnNameSanitizerTest`
-- `TypeInferenceServiceTest`
-- `DecimalDetectionTest`
-- `DateParsingTest`
-
-AusfÃ¼hren:
+- CREATE TABLE + INSERT, INSERT existing, UPDATE, DELETE, SELECT (`H2CrudLifecycleIntegrationTest`, `H2ImportIntegrationTest`)
+- DB Source/Target Connectoren
+- Filesystem- und REST-Connectoren
+- Verschluesselte Verbindungsprofile
+- Typinferenz und Mapping
 
 ```bash
 mvn test
 ```
+
+Optionale Live-Tests gegen IBM i: [docs/IBM_I_INTEGRATION.md](docs/IBM_I_INTEGRATION.md).
 
 ## Screenshots
 

--- a/docs/IBM_I_INTEGRATION.md
+++ b/docs/IBM_I_INTEGRATION.md
@@ -1,8 +1,11 @@
 # IBM i Integration Tests and JDBC Setup
 
-The default test suite uses an in-memory H2 database and does not require an
-IBM i system. Tests that need a real IBM i connection must be run explicitly
-with the Maven `it` profile and the `it` Spring profile.
+The default test suite and the `local` Spring profile use H2 and do not require
+an IBM i system. See [LOCAL_DEVELOPMENT.md](LOCAL_DEVELOPMENT.md) for offline work.
+
+Tests that need a real IBM i connection must be run explicitly with the Maven
+`it` profile and the `it` Spring profile. **Never commit IBM i credentials**;
+pass them only via environment variables.
 
 ## Running against IBM i
 

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -1,0 +1,100 @@
+# Local development (H2, no IBM i)
+
+When no IBM i system is available, develop and test against an embedded **H2**
+database in DB2 compatibility mode. CREATE TABLE, INSERT, UPDATE, DELETE and
+SELECT are fully exercised by the default test suite and by the `local` profile.
+
+## Security: credentials must never reach GitHub
+
+| What | Where | Committed? |
+|------|--------|------------|
+| IBM i JDBC URL / user / password | Environment variables only | **No** |
+| Connection master key | `ZEUS_CONNECTION_MASTER_KEY` (env) | **No** |
+| Encrypted connection profiles | `.local/connections/` or custom dir | **No** (`.local/` is gitignored) |
+| H2 database files | `.local/h2/` | **No** |
+| Local override config | `application-local-override.yaml` | **No** (gitignored) |
+| `.env` files | project root | **No** |
+
+Use environment variables or a secret manager. Do not paste production credentials
+into YAML, Java sources, commit messages, issues, or CI logs.
+
+Safe pattern for IBM i (only when a system is available):
+
+```powershell
+$env:SPRING_DATASOURCE_URL = "jdbc:as400://host/LIBRARY;translate binary=true"
+$env:SPRING_DATASOURCE_USERNAME = "..."
+$env:SPRING_DATASOURCE_PASSWORD = "..."
+$env:ZEUS_CONNECTION_MASTER_KEY = "..."   # 32-byte key, Base64-encoded
+# Do NOT commit these values.
+```
+
+## Run the app against H2
+
+```bash
+mvn -Plocal spring-boot:run
+```
+
+Equivalent:
+
+```bash
+mvn spring-boot:run -Dspring-boot.run.profiles=local
+```
+
+- Application: http://localhost:8080  
+- H2 console: http://localhost:8080/h2-console  
+  - JDBC URL: `jdbc:h2:file:./.local/h2/zeus;MODE=DB2;AUTO_SERVER=TRUE;DATABASE_TO_UPPER=true`  
+  - User: `sa`  
+  - Password: *(empty)*  
+- Default library/schema: `TESTLIB`
+
+Data and connection profiles are stored under `.local/` and stay out of git.
+
+## Run tests (always H2)
+
+```bash
+mvn test
+```
+
+Default unit/integration tests use the `test` Spring profile and an in-memory H2
+database. No IBM i connection is required. Coverage includes:
+
+- CREATE TABLE + batch INSERT (`ImportService`, CSV import)
+- INSERT into existing table
+- UPDATE by key columns
+- DELETE by key columns
+- SELECT via `DbTableSourceConnector`
+- JDBC metadata (list tables / columns)
+
+IBM i live tests remain opt-in; see [IBM_I_INTEGRATION.md](IBM_I_INTEGRATION.md).
+
+## Profiles at a glance
+
+| Spring profile | Database | Dialect | Typical use |
+|----------------|----------|---------|-------------|
+| *(default)* | IBM i via env JDBC settings | `Db2iDialect` | Real system |
+| `local` | File H2 under `.local/h2` | `H2Dialect` | Offline development |
+| `test` | In-memory H2 | `H2Dialect` | `mvn test` |
+| `it` | Env-driven (usually IBM i) | `Db2iDialect` | Optional live IT |
+
+## Switching back to IBM i
+
+Unset or override the local profile and supply datasource env vars:
+
+```powershell
+# no -Plocal
+$env:SPRING_DATASOURCE_URL = "jdbc:as400://..."
+$env:SPRING_DATASOURCE_USERNAME = "..."
+$env:SPRING_DATASOURCE_PASSWORD = "..."
+mvn spring-boot:run
+```
+
+## Notes and limitations
+
+- H2 `MODE=DB2` approximates IBM i SQL; identifier rules (quoted, uppercased) match the app’s sanitizing.
+- DB2-style `MERGE ... USING (VALUES ...)` (upsert) is **not** supported on the H2 dialect; UPDATE/INSERT/DELETE paths are preferred for local work. Upsert remains IBM i (and PostgreSQL `ON CONFLICT`) oriented.
+- Schema/libraries: H2 auto-creates missing schemas on CREATE TABLE; IBM i libraries must already exist.
+- Multi-DB direction: expand `SqlDialect` / `SqlDialectRegistry` (not Hibernate). See [architecture/sql-dialects.md](architecture/sql-dialects.md).
+- Named JDBC connection profiles (type DB2_400, endpoint `jdbc:…`) can target
+  a separate DataSource per import/metadata call. Create them under
+  `/connections` with credentials encrypted; pick them on the import form.
+  Example local profile endpoint: same H2 URL as `application-local.yaml` or a second mem/file URL.

--- a/docs/architecture/connection-profiles.md
+++ b/docs/architecture/connection-profiles.md
@@ -52,3 +52,35 @@ objects. Future connector factories can resolve a profile through
 `ConnectionProfileService.loadCredentials(name)` at execution time, inject
 the values into the existing REST/DB connector settings, and keep them out of
 import profiles, job payloads, logs and API responses.
+
+### Database product mapping (dialect registry)
+
+`ConnectionType.DB2_400` maps to `DatabaseProduct.DB2_I` via
+`SqlDialectRegistry.resolveFromConnectionType`. JDBC endpoints can also be
+classified with `SqlDialectRegistry.detectProduct(jdbcUrl)`
+(`jdbc:as400:` → DB2_I, `jdbc:h2:` → H2, `jdbc:postgresql:` → POSTGRES).
+
+### Per-connection DataSource (runtime)
+
+Import, metadata and DB source connectors accept an optional
+`connectionProfileName`:
+
+| Path | Parameter |
+|------|-----------|
+| UI upload form | `connectionProfileName` select |
+| `POST /api/jobs/import` | form field `connectionProfileName` |
+| `GET /meta/tables` | query `connectionProfileName` |
+| `GET /meta/columns` | query `connectionProfileName` |
+| `ImportRequest` / flow config | field `connectionProfileName` |
+
+Resolution flow:
+
+1. Blank name → Spring bootstrap `DataSource` + default `SqlDialect`
+2. Named profile → decrypt credentials → `ConnectionDataSourceFactory`
+   → `DriverManagerDataSource` → dialect from JDBC URL (fallback connection type)
+3. REST profiles are rejected for JDBC operations
+
+Credential keys accepted: `username`/`user`, `password`/`secret`. Secrets are
+never logged, never returned by the API and never stored on `ImportRequest`.
+
+See also [sql-dialects.md](sql-dialects.md).

--- a/docs/architecture/sql-dialects.md
+++ b/docs/architecture/sql-dialects.md
@@ -1,0 +1,56 @@
+# SQL dialects and multi-database support
+
+zeus-easy-upload talks to databases through **JDBC + `SqlDialect`**, not through an ORM.
+Dynamic CREATE TABLE, batch DML, streaming SELECT and metadata do not map cleanly to
+Hibernate entities; dialects own product-specific SQL.
+
+## Products
+
+| `DatabaseProduct` | Dialect | Typical JDBC URL | Upsert |
+|-------------------|---------|------------------|--------|
+| `DB2_I` | `Db2iDialect` | `jdbc:as400://…` | `MERGE … USING (VALUES …)` |
+| `H2` | `H2Dialect` | `jdbc:h2:…` | unsupported (use INSERT/UPDATE/DELETE) |
+| `POSTGRES` | `PostgresDialect` | `jdbc:postgresql://…` | `INSERT … ON CONFLICT` |
+| `GENERIC_JDBC` | `GenericJdbcDialect` | other `jdbc:…` | unsupported |
+
+IBM i remains **first-class**. Local development and CI use H2 (`local` / `test` profiles).
+
+## Core types
+
+- `SqlDialect` — quoting, DDL types, INSERT/UPDATE/DELETE, upsert, schema helpers
+- `IdentifierPolicy` — max length, case, empty/leading-digit rules
+- `UpsertStrategy` / `UpsertSql` — product upsert shape + generated SQL
+- `SqlDialectRegistry` — resolve dialect from `DatabaseProduct`, `ConnectionType`, or JDBC URL
+
+## Spring wiring
+
+- Bootstrap `DataSource` (Spring Boot) for the default connection
+- Default `SqlDialect` bean: profiles `local` / `test` → H2, else DB2 i
+- `SqlDialectRegistry` for product resolution
+- `DbSessionFactory` opens a `DbSession` (DataSource + dialect) for either
+  the bootstrap DS or a named JDBC connection profile
+- `ImportService`, `JdbcMetadataService` and DB source connectors use sessions
+
+Per-connection details: [connection-profiles.md](connection-profiles.md).
+
+## Adding a dialect
+
+1. Add a `DatabaseProduct` value if needed.
+2. Implement `SqlDialect` (extend `AbstractSqlDialect` when double-quoted identifiers fit).
+3. Register it in `SqlDialectRegistry` / `SqlDialectConfiguration`.
+4. Extend `SqlDialectRegistry.detectProduct(jdbcUrl)`.
+5. Unit-test quoting, types and upsert SQL; add H2-style integration tests where possible.
+6. Never change `Db2iDialect` MERGE or 10-char create-name rules without IBM i IT (`-Pit`).
+
+## IBM i guardrails
+
+- Max created column name length: **10** (`IdentifierPolicy.ibmISystemNames()`)
+- No schema auto-create (libraries must exist)
+- DECIMAL precision/scale caps: 31
+- Upsert SQL surface for DB2 i must stay stable unless explicitly versioned
+
+## Security
+
+Dialects never embed credentials. JDBC URLs and secrets stay in environment variables
+or encrypted connection profiles under `.local/` (gitignored). Do not commit real IBM i
+or production connection data.

--- a/pom.xml
+++ b/pom.xml
@@ -70,10 +70,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Runtime scope: used by spring.profiles.active=local and tests; unused against IBM i. -->
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 
@@ -94,6 +95,13 @@
     </build>
 
     <profiles>
+        <!-- Local development against embedded H2 (no IBM i required). -->
+        <profile>
+            <id>local</id>
+            <properties>
+                <spring-boot.run.profiles>local</spring-boot.run.profiles>
+            </properties>
+        </profile>
         <profile>
             <id>it</id>
             <properties>

--- a/src/main/java/com/zeus/upload/config/SqlDialectConfiguration.java
+++ b/src/main/java/com/zeus/upload/config/SqlDialectConfiguration.java
@@ -1,8 +1,14 @@
 package com.zeus.upload.config;
 
+import com.zeus.upload.sql.DatabaseProduct;
 import com.zeus.upload.sql.Db2iDialect;
+import com.zeus.upload.sql.GenericJdbcDialect;
 import com.zeus.upload.sql.H2Dialect;
+import com.zeus.upload.sql.PostgresDialect;
 import com.zeus.upload.sql.SqlDialect;
+import com.zeus.upload.sql.SqlDialectRegistry;
+import java.util.EnumMap;
+import java.util.Map;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -11,14 +17,30 @@ import org.springframework.context.annotation.Profile;
 public class SqlDialectConfiguration {
 
     @Bean
-    @Profile("!test")
-    public SqlDialect db2iDialect() {
-        return new Db2iDialect();
+    public SqlDialectRegistry sqlDialectRegistry() {
+        Map<DatabaseProduct, SqlDialect> dialects = new EnumMap<>(DatabaseProduct.class);
+        dialects.put(DatabaseProduct.DB2_I, new Db2iDialect());
+        dialects.put(DatabaseProduct.H2, new H2Dialect());
+        dialects.put(DatabaseProduct.POSTGRES, new PostgresDialect());
+        dialects.put(DatabaseProduct.GENERIC_JDBC, new GenericJdbcDialect());
+        return new SqlDialectRegistry(dialects);
     }
 
+    /**
+     * Production / IBM i default (active when neither test nor local profile is set).
+     */
     @Bean
-    @Profile("test")
-    public SqlDialect h2Dialect() {
-        return new H2Dialect();
+    @Profile("!test & !local")
+    public SqlDialect db2iDialect(SqlDialectRegistry registry) {
+        return registry.get(DatabaseProduct.DB2_I);
+    }
+
+    /**
+     * Embedded H2 for unit/integration tests and offline local development.
+     */
+    @Bean
+    @Profile({"test", "local"})
+    public SqlDialect h2Dialect(SqlDialectRegistry registry) {
+        return registry.get(DatabaseProduct.H2);
     }
 }

--- a/src/main/java/com/zeus/upload/connector/ConnectorFactory.java
+++ b/src/main/java/com/zeus/upload/connector/ConnectorFactory.java
@@ -18,11 +18,14 @@ import com.zeus.upload.flow.RestSourceConfiguration;
 import com.zeus.upload.flow.RestTargetConfiguration;
 import com.zeus.upload.flow.SourceConfiguration;
 import com.zeus.upload.flow.TargetConfiguration;
+import com.zeus.upload.service.DbSession;
+import com.zeus.upload.service.DbSessionFactory;
 import com.zeus.upload.service.ImportService;
 import com.zeus.upload.sql.SqlDialect;
+import java.util.Objects;
 import javax.sql.DataSource;
-import org.springframework.stereotype.Component;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 @Component
 public class ConnectorFactory {
@@ -30,16 +33,23 @@ public class ConnectorFactory {
     private final ImportService importService;
     private final DataSource dataSource;
     private final SqlDialect sqlDialect;
+    private final DbSessionFactory dbSessionFactory;
 
     public ConnectorFactory(ImportService importService) {
-        this(importService, null, null);
+        this(importService, null, null, null);
     }
 
     @Autowired
-    public ConnectorFactory(ImportService importService, DataSource dataSource, SqlDialect sqlDialect) {
+    public ConnectorFactory(
+            ImportService importService,
+            DataSource dataSource,
+            SqlDialect sqlDialect,
+            DbSessionFactory dbSessionFactory
+    ) {
         this.importService = importService;
         this.dataSource = dataSource;
         this.sqlDialect = sqlDialect;
+        this.dbSessionFactory = dbSessionFactory;
     }
 
     public SourceConnector createSource(SourceConfiguration configuration) {
@@ -47,7 +57,7 @@ public class ConnectorFactory {
             return new CsvSourceConnector(csvSourceConfiguration.getParsedCsv());
         }
         if (configuration instanceof DbTableSourceConfiguration dbSourceConfiguration) {
-            return new DbTableSourceConnector(dataSource, sqlDialect, dbSourceConfiguration);
+            return createDbTableSource(dbSourceConfiguration);
         }
         if (configuration instanceof FilesystemCsvSourceConfiguration filesystemConfiguration) {
             return new FilesystemCsvSourceConnector(filesystemConfiguration);
@@ -72,5 +82,24 @@ public class ConnectorFactory {
             return new RestJsonTargetConnector(restConfiguration);
         }
         throw new IllegalArgumentException("Unsupported target configuration: " + configuration.getClass().getName());
+    }
+
+    private SourceConnector createDbTableSource(DbTableSourceConfiguration configuration) {
+        if (dbSessionFactory != null) {
+            return () -> {
+                DbSession session = dbSessionFactory.open(configuration.getConnectionProfileName());
+                try {
+                    return new DbTableSourceConnector(session.dataSource(), session.dialect(), configuration)
+                            .read()
+                            .onClose(session::close);
+                } catch (RuntimeException ex) {
+                    session.close();
+                    throw ex;
+                }
+            };
+        }
+        Objects.requireNonNull(dataSource, "dataSource");
+        Objects.requireNonNull(sqlDialect, "sqlDialect");
+        return new DbTableSourceConnector(dataSource, sqlDialect, configuration);
     }
 }

--- a/src/main/java/com/zeus/upload/connector/db/DbTableTargetConnector.java
+++ b/src/main/java/com/zeus/upload/connector/db/DbTableTargetConnector.java
@@ -28,6 +28,7 @@ public class DbTableTargetConnector implements ImportResultAwareTargetConnector 
     public void write(Stream<DataRecord> records) {
         ParsedCsv parsedCsv = new ParsedCsv();
         records.map(this::toRow).forEach(parsedCsv.getRows()::add);
+        String connection = configuration.getConnectionProfileName();
 
         if (configuration.getWriteMode() == DbTableWriteMode.CREATE_TABLE) {
             result = importService.importCsv(createImportRequest(), parsedCsv);
@@ -36,6 +37,7 @@ public class DbTableTargetConnector implements ImportResultAwareTargetConnector 
 
         if (configuration.getWriteMode() == DbTableWriteMode.UPSERT_EXISTING) {
             result = importService.upsertIntoExistingTable(
+                    connection,
                     configuration.getLibrary(),
                     configuration.getTableName(),
                     parsedCsv,
@@ -49,6 +51,7 @@ public class DbTableTargetConnector implements ImportResultAwareTargetConnector 
 
         if (configuration.getWriteMode() == DbTableWriteMode.UPDATE_EXISTING) {
             result = importService.updateIntoExistingTable(
+                    connection,
                     configuration.getLibrary(), configuration.getTableName(), parsedCsv,
                     configuration.getDbColumns(), configuration.getMappings(),
                     configuration.getKeyColumns(), configuration.isDryRun());
@@ -57,6 +60,7 @@ public class DbTableTargetConnector implements ImportResultAwareTargetConnector 
 
         if (configuration.getWriteMode() == DbTableWriteMode.DELETE_EXISTING) {
             result = importService.deleteFromExistingTable(
+                    connection,
                     configuration.getLibrary(), configuration.getTableName(), parsedCsv,
                     configuration.getDbColumns(), configuration.getMappings(),
                     configuration.getKeyColumns(), configuration.isDryRun());
@@ -64,6 +68,7 @@ public class DbTableTargetConnector implements ImportResultAwareTargetConnector 
         }
 
         result = importService.importIntoExistingTable(
+                connection,
                 configuration.getLibrary(),
                 configuration.getTableName(),
                 parsedCsv,
@@ -95,6 +100,7 @@ public class DbTableTargetConnector implements ImportResultAwareTargetConnector 
         importRequest.setDropAndRecreate(configuration.isDropAndRecreate());
         importRequest.setDryRun(configuration.isDryRun());
         importRequest.setColumns(configuration.getColumns());
+        importRequest.setConnectionProfileName(configuration.getConnectionProfileName());
         return importRequest;
     }
 }

--- a/src/main/java/com/zeus/upload/controller/ImportJobController.java
+++ b/src/main/java/com/zeus/upload/controller/ImportJobController.java
@@ -61,6 +61,7 @@ public class ImportJobController {
             @RequestParam(required = false) String existingTableName,
             @RequestParam(required = false) List<String> keyColumns,
             @RequestParam(defaultValue = "false") boolean dryRun,
+            @RequestParam(required = false) String connectionProfileName,
             @RequestParam(required = false) String csvDelimiter,
             @RequestParam(required = false) String csvEncoding,
             @RequestParam(required = false) String csvQuote
@@ -83,11 +84,12 @@ public class ImportJobController {
         request.setCsvDelimiter(csvDelimiter);
         request.setCsvEncoding(csvEncoding);
         request.setCsvQuote(csvQuote);
+        request.setConnectionProfileName(connectionProfileName);
 
         PreviewContext context = new PreviewContext();
         context.setParsedCsv(parsed);
         if (existing) {
-            List<DbColumnMeta> columns = metadataService.listColumns(library, existingTableName);
+            List<DbColumnMeta> columns = metadataService.listColumns(library, existingTableName, connectionProfileName);
             context.setDbColumns(columns);
             context.setMappings(mappingService.autoMap(parsed, columns));
             request.setMappings(context.getMappings());

--- a/src/main/java/com/zeus/upload/controller/MetadataController.java
+++ b/src/main/java/com/zeus/upload/controller/MetadataController.java
@@ -23,17 +23,25 @@ public class MetadataController {
     }
 
     @GetMapping("/tables")
-    public List<DbTableRef> listTables(@RequestParam("library") String library) {
+    public List<DbTableRef> listTables(
+            @RequestParam("library") String library,
+            @RequestParam(value = "connectionProfileName", required = false) String connectionProfileName
+    ) {
         if (!StringUtils.hasText(library)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "library must not be blank");
         }
-        return metadataService.listTables(library);
+        try {
+            return metadataService.listTables(library, connectionProfileName);
+        } catch (IllegalArgumentException | IllegalStateException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
     }
 
     @GetMapping("/columns")
     public List<DbColumnMeta> listColumns(
             @RequestParam("library") String library,
-            @RequestParam("table") String table
+            @RequestParam("table") String table,
+            @RequestParam(value = "connectionProfileName", required = false) String connectionProfileName
     ) {
         if (!StringUtils.hasText(library)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "library must not be blank");
@@ -41,6 +49,10 @@ public class MetadataController {
         if (!StringUtils.hasText(table)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "table must not be blank");
         }
-        return metadataService.listColumns(library, table);
+        try {
+            return metadataService.listColumns(library, table, connectionProfileName);
+        } catch (IllegalArgumentException | IllegalStateException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
+        }
     }
 }

--- a/src/main/java/com/zeus/upload/controller/UploadController.java
+++ b/src/main/java/com/zeus/upload/controller/UploadController.java
@@ -11,6 +11,9 @@ import com.zeus.upload.domain.MappingValidationResult;
 import com.zeus.upload.domain.PreviewContext;
 import com.zeus.upload.flow.FlowConfigurationFactory;
 import com.zeus.upload.flow.FlowExecutionService;
+import com.zeus.upload.domain.ConnectionProfile;
+import com.zeus.upload.domain.ConnectionType;
+import com.zeus.upload.service.ConnectionProfileService;
 import com.zeus.upload.service.CsvParsingService;
 import com.zeus.upload.service.MappingService;
 import com.zeus.upload.service.MetadataService;
@@ -45,6 +48,7 @@ public class UploadController {
     private final AppProperties appProperties;
     private final FlowConfigurationFactory flowConfigurationFactory;
     private final FlowExecutionService flowExecutionService;
+    private final ConnectionProfileService connectionProfileService;
 
     public UploadController(
             CsvParsingService csvParsingService,
@@ -52,7 +56,8 @@ public class UploadController {
             MappingService mappingService,
             AppProperties appProperties,
             FlowConfigurationFactory flowConfigurationFactory,
-            FlowExecutionService flowExecutionService
+            FlowExecutionService flowExecutionService,
+            ConnectionProfileService connectionProfileService
     ) {
         this.csvParsingService = csvParsingService;
         this.metadataService = metadataService;
@@ -60,6 +65,7 @@ public class UploadController {
         this.appProperties = appProperties;
         this.flowConfigurationFactory = flowConfigurationFactory;
         this.flowExecutionService = flowExecutionService;
+        this.connectionProfileService = connectionProfileService;
     }
 
     @ModelAttribute("previewContext")
@@ -75,6 +81,7 @@ public class UploadController {
             model.addAttribute("importRequest", request);
         }
         model.addAttribute("supportedTypes", SUPPORTED_TYPES);
+        model.addAttribute("jdbcConnections", listJdbcConnections());
         return "index";
     }
 
@@ -86,6 +93,7 @@ public class UploadController {
             @RequestParam(value = "dropAndRecreate", defaultValue = "false") boolean dropAndRecreate,
             @RequestParam(value = "useExistingTable", defaultValue = "false") boolean useExistingTable,
             @RequestParam(value = "existingTableName", required = false) String existingTableName,
+            @RequestParam(value = "connectionProfileName", required = false) String connectionProfileName,
             @RequestParam(value = "csvDelimiter", required = false) String csvDelimiter,
             @RequestParam(value = "csvEncoding", required = false) String csvEncoding,
             @RequestParam(value = "csvQuote", required = false) String csvQuote,
@@ -124,9 +132,13 @@ public class UploadController {
             request.setCsvDelimiter(csvDelimiter);
             request.setCsvEncoding(csvEncoding);
             request.setCsvQuote(csvQuote);
+            if (StringUtils.hasText(connectionProfileName)) {
+                request.setConnectionProfileName(connectionProfileName.trim());
+            }
 
             if (useExistingTable && StringUtils.hasText(existingTableName)) {
-                List<DbColumnMeta> dbColumns = metadataService.listColumns(library, existingTableName);
+                List<DbColumnMeta> dbColumns = metadataService.listColumns(
+                        library, existingTableName, request.getConnectionProfileName());
                 List<ColumnMapping> mappings = mappingService.autoMap(parsed, dbColumns);
                 request.setMappings(copyMappings(mappings));
                 previewContext.setDbColumns(dbColumns);
@@ -239,6 +251,17 @@ public class UploadController {
         return !StringUtils.hasText(options.getDelimiter())
                 && (!StringUtils.hasText(options.getEncoding()) || "UTF-8".equalsIgnoreCase(options.getEncoding()))
                 && (!StringUtils.hasText(options.getQuote()) || "\"".equals(options.getQuote()));
+    }
+
+    private List<ConnectionProfile> listJdbcConnections() {
+        try {
+            return connectionProfileService.list().stream()
+                    .filter(profile -> profile.getType() == ConnectionType.DB2_400)
+                    .toList();
+        } catch (IOException ex) {
+            log.warn("Could not list connection profiles: {}", ex.getMessage());
+            return List.of();
+        }
     }
 
     private List<ColumnMapping> copyMappings(List<ColumnMapping> source) {

--- a/src/main/java/com/zeus/upload/domain/ImportRequest.java
+++ b/src/main/java/com/zeus/upload/domain/ImportRequest.java
@@ -22,6 +22,11 @@ public class ImportRequest {
     private String csvEncoding;
     private String csvQuote;
     private String existingTableName;
+    /**
+     * Optional named JDBC connection profile. Blank uses the application bootstrap DataSource.
+     * Credentials are never stored on this request object.
+     */
+    private String connectionProfileName;
     private List<String> keyColumns = new ArrayList<>();
 
     @Valid
@@ -66,6 +71,14 @@ public class ImportRequest {
 
     public void setExistingTableName(String existingTableName) {
         this.existingTableName = existingTableName;
+    }
+
+    public String getConnectionProfileName() {
+        return connectionProfileName;
+    }
+
+    public void setConnectionProfileName(String connectionProfileName) {
+        this.connectionProfileName = connectionProfileName;
     }
 
     public boolean isUpsertEnabled() {

--- a/src/main/java/com/zeus/upload/flow/DbTableSourceConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/DbTableSourceConfiguration.java
@@ -8,14 +8,21 @@ public class DbTableSourceConfiguration implements SourceConfiguration {
     private final String library;
     private final String tableName;
     private final List<String> columns;
+    private final String connectionProfileName;
 
     public DbTableSourceConfiguration(String library, String tableName, List<String> columns) {
+        this(library, tableName, columns, null);
+    }
+
+    public DbTableSourceConfiguration(String library, String tableName, List<String> columns, String connectionProfileName) {
         this.library = Objects.requireNonNull(library, "library must not be null");
         this.tableName = Objects.requireNonNull(tableName, "tableName must not be null");
         this.columns = columns == null ? List.of() : List.copyOf(columns);
+        this.connectionProfileName = connectionProfileName;
     }
 
     public String getLibrary() { return library; }
     public String getTableName() { return tableName; }
     public List<String> getColumns() { return columns; }
+    public String getConnectionProfileName() { return connectionProfileName; }
 }

--- a/src/main/java/com/zeus/upload/flow/DbTableTargetConfiguration.java
+++ b/src/main/java/com/zeus/upload/flow/DbTableTargetConfiguration.java
@@ -14,6 +14,7 @@ public class DbTableTargetConfiguration implements TargetConfiguration {
     private final DbTableWriteMode writeMode;
     private final boolean dropAndRecreate;
     private final boolean dryRun;
+    private final String connectionProfileName;
     private final List<ColumnProposal> columns;
     private final List<ColumnMapping> mappings;
     private final List<String> keyColumns;
@@ -29,7 +30,7 @@ public class DbTableTargetConfiguration implements TargetConfiguration {
             List<String> keyColumns,
             List<DbColumnMeta> dbColumns
     ) {
-        this(library, tableName, writeMode, dropAndRecreate, false, columns, mappings, keyColumns, dbColumns);
+        this(library, tableName, writeMode, dropAndRecreate, false, null, columns, mappings, keyColumns, dbColumns);
     }
 
     public DbTableTargetConfiguration(
@@ -43,11 +44,27 @@ public class DbTableTargetConfiguration implements TargetConfiguration {
             List<String> keyColumns,
             List<DbColumnMeta> dbColumns
     ) {
+        this(library, tableName, writeMode, dropAndRecreate, dryRun, null, columns, mappings, keyColumns, dbColumns);
+    }
+
+    public DbTableTargetConfiguration(
+            String library,
+            String tableName,
+            DbTableWriteMode writeMode,
+            boolean dropAndRecreate,
+            boolean dryRun,
+            String connectionProfileName,
+            List<ColumnProposal> columns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns,
+            List<DbColumnMeta> dbColumns
+    ) {
         this.library = Objects.requireNonNull(library, "library must not be null");
         this.tableName = Objects.requireNonNull(tableName, "tableName must not be null");
         this.writeMode = Objects.requireNonNull(writeMode, "writeMode must not be null");
         this.dropAndRecreate = dropAndRecreate;
         this.dryRun = dryRun;
+        this.connectionProfileName = connectionProfileName;
         this.columns = columns == null ? List.of() : List.copyOf(new ArrayList<>(columns));
         this.mappings = mappings == null ? List.of() : List.copyOf(new ArrayList<>(mappings));
         this.keyColumns = keyColumns == null ? List.of() : List.copyOf(new ArrayList<>(keyColumns));
@@ -72,6 +89,10 @@ public class DbTableTargetConfiguration implements TargetConfiguration {
 
     public boolean isDryRun() {
         return dryRun;
+    }
+
+    public String getConnectionProfileName() {
+        return connectionProfileName;
     }
 
     public List<ColumnProposal> getColumns() {

--- a/src/main/java/com/zeus/upload/flow/FlowConfigurationFactory.java
+++ b/src/main/java/com/zeus/upload/flow/FlowConfigurationFactory.java
@@ -15,6 +15,7 @@ public class FlowConfigurationFactory {
                 resolveWriteMode(importRequest),
                 importRequest.isDropAndRecreate(),
                 importRequest.isDryRun(),
+                importRequest.getConnectionProfileName(),
                 importRequest.getColumns(),
                 importRequest.getMappings(),
                 importRequest.getKeyColumns(),

--- a/src/main/java/com/zeus/upload/service/ConnectionDataSourceFactory.java
+++ b/src/main/java/com/zeus/upload/service/ConnectionDataSourceFactory.java
@@ -1,0 +1,73 @@
+package com.zeus.upload.service;
+
+import com.zeus.upload.domain.ConnectionProfile;
+import com.zeus.upload.domain.ConnectionType;
+import com.zeus.upload.sql.DatabaseProduct;
+import com.zeus.upload.sql.SqlDialectRegistry;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import javax.sql.DataSource;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Builds a non-pooled {@link DataSource} from a connection profile endpoint and
+ * decrypted credentials. Never logs secrets.
+ */
+@Component
+public class ConnectionDataSourceFactory {
+
+    public DataSource create(ConnectionProfile profile, Map<String, String> credentials) {
+        Objects.requireNonNull(profile, "profile");
+        if (profile.getType() == ConnectionType.REST) {
+            throw new IllegalArgumentException(
+                    "Connection profile '" + profile.getName() + "' is REST and cannot be used as a JDBC DataSource.");
+        }
+        String url = profile.getEndpoint() == null ? "" : profile.getEndpoint().trim();
+        if (!StringUtils.hasText(url) || !url.toLowerCase(Locale.ROOT).startsWith("jdbc:")) {
+            throw new IllegalArgumentException(
+                    "Connection profile '" + profile.getName() + "' requires a jdbc: endpoint URL.");
+        }
+
+        Map<String, String> creds = credentials == null ? Map.of() : credentials;
+        String username = firstNonBlank(creds, "username", "user");
+        String password = firstNonBlank(creds, "password", "secret");
+
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setUrl(url);
+        if (username != null) {
+            dataSource.setUsername(username);
+        }
+        if (password != null) {
+            dataSource.setPassword(password);
+        }
+
+        String driver = resolveDriverClass(url);
+        if (driver != null) {
+            dataSource.setDriverClassName(driver);
+        }
+        return dataSource;
+    }
+
+    static String resolveDriverClass(String jdbcUrl) {
+        DatabaseProduct product = SqlDialectRegistry.detectProduct(jdbcUrl);
+        return switch (product) {
+            case DB2_I -> "com.ibm.as400.access.AS400JDBCDriver";
+            case H2 -> "org.h2.Driver";
+            case POSTGRES -> "org.postgresql.Driver";
+            case GENERIC_JDBC -> null;
+        };
+    }
+
+    private static String firstNonBlank(Map<String, String> map, String... keys) {
+        for (String key : keys) {
+            String value = map.get(key);
+            if (StringUtils.hasText(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/zeus/upload/service/DbSession.java
+++ b/src/main/java/com/zeus/upload/service/DbSession.java
@@ -1,0 +1,71 @@
+package com.zeus.upload.service;
+
+import com.zeus.upload.sql.DatabaseProduct;
+import com.zeus.upload.sql.SqlDialect;
+import java.util.Objects;
+import javax.sql.DataSource;
+
+/**
+ * Resolved JDBC execution context: DataSource + dialect for one import/metadata operation.
+ * Does not expose credentials. Close when the operation finishes (profile sessions may
+ * own pooled resources; the bootstrap session is a no-op on close).
+ */
+public final class DbSession implements AutoCloseable {
+
+    private final DataSource dataSource;
+    private final SqlDialect dialect;
+    private final String connectionProfileName;
+    private final DatabaseProduct product;
+    private final AutoCloseable closer;
+    private boolean closed;
+
+    public DbSession(
+            DataSource dataSource,
+            SqlDialect dialect,
+            String connectionProfileName,
+            DatabaseProduct product,
+            AutoCloseable closer
+    ) {
+        this.dataSource = Objects.requireNonNull(dataSource, "dataSource");
+        this.dialect = Objects.requireNonNull(dialect, "dialect");
+        this.connectionProfileName = connectionProfileName;
+        this.product = Objects.requireNonNull(product, "product");
+        this.closer = closer;
+    }
+
+    public DataSource dataSource() {
+        return dataSource;
+    }
+
+    public SqlDialect dialect() {
+        return dialect;
+    }
+
+    /** {@code null} when using the application bootstrap DataSource. */
+    public String connectionProfileName() {
+        return connectionProfileName;
+    }
+
+    public boolean isBootstrap() {
+        return connectionProfileName == null || connectionProfileName.isBlank();
+    }
+
+    public DatabaseProduct product() {
+        return product;
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (closer != null) {
+            try {
+                closer.close();
+            } catch (Exception ex) {
+                throw new IllegalStateException("Failed to close database session resources: " + ex.getMessage(), ex);
+            }
+        }
+    }
+}

--- a/src/main/java/com/zeus/upload/service/DbSessionFactory.java
+++ b/src/main/java/com/zeus/upload/service/DbSessionFactory.java
@@ -1,0 +1,98 @@
+package com.zeus.upload.service;
+
+import com.zeus.upload.domain.ConnectionProfile;
+import com.zeus.upload.domain.ConnectionType;
+import com.zeus.upload.sql.DatabaseProduct;
+import com.zeus.upload.sql.SqlDialect;
+import com.zeus.upload.sql.SqlDialectRegistry;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Opens {@link DbSession}s against the bootstrap Spring DataSource or a named
+ * encrypted connection profile. Credentials never leave this factory.
+ */
+@Service
+public class DbSessionFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(DbSessionFactory.class);
+
+    private final DataSource bootstrapDataSource;
+    private final SqlDialect bootstrapDialect;
+    private final ConnectionProfileService connectionProfileService;
+    private final ConnectionDataSourceFactory dataSourceFactory;
+    private final SqlDialectRegistry dialectRegistry;
+
+    public DbSessionFactory(
+            DataSource bootstrapDataSource,
+            SqlDialect bootstrapDialect,
+            ConnectionProfileService connectionProfileService,
+            ConnectionDataSourceFactory dataSourceFactory,
+            SqlDialectRegistry dialectRegistry
+    ) {
+        this.bootstrapDataSource = Objects.requireNonNull(bootstrapDataSource);
+        this.bootstrapDialect = Objects.requireNonNull(bootstrapDialect);
+        this.connectionProfileService = Objects.requireNonNull(connectionProfileService);
+        this.dataSourceFactory = Objects.requireNonNull(dataSourceFactory);
+        this.dialectRegistry = Objects.requireNonNull(dialectRegistry);
+    }
+
+    /** Bootstrap DataSource + default dialect (Spring profile). */
+    public DbSession openDefault() {
+        return new DbSession(
+                bootstrapDataSource,
+                bootstrapDialect,
+                null,
+                bootstrapDialect.product(),
+                null
+        );
+    }
+
+    /**
+     * Resolve by optional profile name. Blank/null uses {@link #openDefault()}.
+     */
+    public DbSession open(String connectionProfileName) {
+        if (!StringUtils.hasText(connectionProfileName)) {
+            return openDefault();
+        }
+        String name = connectionProfileName.trim();
+        try {
+            ConnectionProfile profile = connectionProfileService.load(name);
+            if (profile.getType() == ConnectionType.REST) {
+                throw new IllegalArgumentException(
+                        "Connection profile '" + name + "' is REST; select a JDBC/DB2 profile for database operations.");
+            }
+            Map<String, String> credentials = connectionProfileService.loadCredentials(name);
+            DataSource dataSource = dataSourceFactory.create(profile, credentials);
+            SqlDialect dialect = resolveDialect(profile);
+            log.info("Opened DB session for connection profile '{}' (product={})", name, dialect.product());
+            return new DbSession(dataSource, dialect, name, dialect.product(), null);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not load connection profile '" + name + "': " + ex.getMessage(), ex);
+        } catch (IllegalArgumentException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalStateException(
+                    "Could not open database session for connection profile '" + name + "': " + ex.getMessage(),
+                    ex
+            );
+        }
+    }
+
+    private SqlDialect resolveDialect(ConnectionProfile profile) {
+        DatabaseProduct fromUrl = SqlDialectRegistry.detectProduct(profile.getEndpoint());
+        if (fromUrl != DatabaseProduct.GENERIC_JDBC) {
+            return dialectRegistry.get(fromUrl);
+        }
+        if (profile.getType() == ConnectionType.DB2_400) {
+            return dialectRegistry.get(DatabaseProduct.DB2_I);
+        }
+        return dialectRegistry.get(DatabaseProduct.GENERIC_JDBC);
+    }
+}

--- a/src/main/java/com/zeus/upload/service/DdlService.java
+++ b/src/main/java/com/zeus/upload/service/DdlService.java
@@ -23,16 +23,21 @@ public class DdlService {
     public String createTableSql(String library, String table, List<ColumnProposal> columns) {
         List<String> definitions = new ArrayList<>();
         Set<String> used = new HashSet<>();
+        int maxLength = sqlDialect.identifierPolicy().maxLength();
 
         for (ColumnProposal column : columns) {
             String finalName = columnNameSanitizer.uniquify(
-                    columnNameSanitizer.sanitizeBase(column.getFinalName()),
+                    columnNameSanitizer.sanitizeBase(column.getFinalName(), sqlDialect.identifierPolicy()),
                     used,
-                    ColumnNameSanitizer.MAX_COLUMN_LENGTH
+                    maxLength
             );
             column.setFinalName(finalName);
             definitions.add(sqlDialect.quoteIdentifier(finalName) + " "
-                    + resolveTypeDefinition(column)
+                    + sqlDialect.columnTypeDefinition(
+                            column.getSqlType(),
+                            column.getLength(),
+                            column.getPrecision(),
+                            column.getScale())
                     + (column.isNullable() ? "" : " NOT NULL"));
         }
 
@@ -46,32 +51,7 @@ public class DdlService {
     public String insertSql(String library, String table, List<ColumnProposal> columns) {
         List<String> names = columns.stream()
                 .map(ColumnProposal::getFinalName)
-                .map(sqlDialect::quoteIdentifier)
                 .toList();
-        String placeholders = String.join(", ", columns.stream().map(c -> "?").toList());
-        return "INSERT INTO " + sqlDialect.qualifyTable(library, table)
-                + " (" + String.join(", ", names) + ") VALUES (" + placeholders + ")";
-    }
-
-    private String resolveTypeDefinition(ColumnProposal column) {
-        String type = column.getSqlType().toUpperCase();
-        return switch (type) {
-            case "INTEGER" -> "INTEGER";
-            case "BIGINT" -> "BIGINT";
-            case "DATE" -> "DATE";
-            case "TIMESTAMP" -> "TIMESTAMP";
-            case "DECIMAL" -> {
-                int precision = column.getPrecision() == null ? 15 : Math.max(1, Math.min(31, column.getPrecision()));
-                int scale = column.getScale() == null ? 2 : Math.max(0, Math.min(31, column.getScale()));
-                if (scale >= precision) {
-                    scale = precision - 1;
-                }
-                yield "DECIMAL(" + precision + "," + scale + ")";
-            }
-            default -> {
-                int length = column.getLength() == null ? 255 : Math.max(1, Math.min(4000, column.getLength()));
-                yield "VARCHAR(" + length + ")";
-            }
-        };
+        return sqlDialect.buildInsertSql(library, table, names);
     }
 }

--- a/src/main/java/com/zeus/upload/service/ImportService.java
+++ b/src/main/java/com/zeus/upload/service/ImportService.java
@@ -8,8 +8,9 @@ import com.zeus.upload.domain.ImportRequest;
 import com.zeus.upload.domain.ImportResult;
 import com.zeus.upload.domain.ParseError;
 import com.zeus.upload.domain.ParsedCsv;
-import com.zeus.upload.sql.MergeSqlBuilder;
 import com.zeus.upload.sql.SqlDialect;
+import com.zeus.upload.sql.UpsertSql;
+import com.zeus.upload.util.ColumnNameSanitizer;
 import java.math.BigDecimal;
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
@@ -31,6 +32,7 @@ import java.util.Set;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -39,13 +41,15 @@ public class ImportService {
 
     private static final Logger log = LoggerFactory.getLogger(ImportService.class);
 
+    private final DbSessionFactory dbSessionFactory;
+    private final ColumnNameSanitizer columnNameSanitizer;
     private final DataSource dataSource;
     private final DdlService ddlService;
     private final TypeInferenceService typeInferenceService;
     private final AppProperties appProperties;
     private final SqlDialect sqlDialect;
-    private final MergeSqlBuilder mergeSqlBuilder;
 
+    /** Unit-test / simple construction without profile sessions. */
     public ImportService(
             DataSource dataSource,
             DdlService ddlService,
@@ -53,29 +57,50 @@ public class ImportService {
             AppProperties appProperties,
             SqlDialect sqlDialect
     ) {
+        this(null, new ColumnNameSanitizer(), dataSource, ddlService, typeInferenceService, appProperties, sqlDialect);
+    }
+
+    @Autowired
+    public ImportService(
+            DbSessionFactory dbSessionFactory,
+            ColumnNameSanitizer columnNameSanitizer,
+            DataSource dataSource,
+            DdlService ddlService,
+            TypeInferenceService typeInferenceService,
+            AppProperties appProperties,
+            SqlDialect sqlDialect
+    ) {
+        this.dbSessionFactory = dbSessionFactory;
+        this.columnNameSanitizer = columnNameSanitizer == null ? new ColumnNameSanitizer() : columnNameSanitizer;
         this.dataSource = dataSource;
         this.ddlService = ddlService;
         this.typeInferenceService = typeInferenceService;
         this.appProperties = appProperties;
         this.sqlDialect = sqlDialect;
-        this.mergeSqlBuilder = new MergeSqlBuilder(sqlDialect);
     }
 
     public ImportResult importCsv(ImportRequest request, ParsedCsv parsedCsv) {
-        return importCsv(request, parsedCsv, request.isDryRun());
+        try (DbSession session = openSession(request == null ? null : request.getConnectionProfileName())) {
+            return doImportCsv(session, request, parsedCsv, request != null && request.isDryRun());
+        } catch (IllegalArgumentException | IllegalStateException ex) {
+            return ImportResult.failure(ex.getMessage(), "", List.of(new ParseError(0, "", "", ex.getMessage())));
+        }
     }
 
-    private ImportResult importCsv(ImportRequest request, ParsedCsv parsedCsv, boolean dryRun) {
+    private ImportResult doImportCsv(DbSession session, ImportRequest request, ParsedCsv parsedCsv, boolean dryRun) {
         List<ParseError> errors = new ArrayList<>();
-        String createSql = ddlService.createTableSql(request.getLibrary(), request.getTableName(), request.getColumns());
-        String insertSql = ddlService.insertSql(request.getLibrary(), request.getTableName(), request.getColumns());
+        DdlService ddl = ddlFor(session);
+        String createSql = ddl.createTableSql(request.getLibrary(), request.getTableName(), request.getColumns());
+        String insertSql = ddl.insertSql(request.getLibrary(), request.getTableName(), request.getColumns());
 
-        try (Connection connection = dataSource.getConnection()) {
+        try (Connection connection = session.dataSource().getConnection()) {
             connection.setAutoCommit(false);
+
+            ensureSchemaExists(connection, session.dialect(), request.getLibrary());
 
             if (request.isDropAndRecreate()) {
                 try (PreparedStatement drop = connection.prepareStatement(
-                        ddlService.dropTableSql(request.getLibrary(), request.getTableName()))) {
+                        ddl.dropTableSql(request.getLibrary(), request.getTableName()))) {
                     drop.executeUpdate();
                 } catch (SQLException ex) {
                     log.info("DROP TABLE ignored: {}", ex.getMessage());
@@ -113,10 +138,38 @@ public class ImportService {
             List<DbColumnMeta> dbColumns,
             List<ColumnMapping> mappings
     ) {
-        return importIntoExistingTable(library, tableName, csv, dbColumns, mappings, false);
+        return importIntoExistingTable(null, library, tableName, csv, dbColumns, mappings, false);
     }
 
     public ImportResult importIntoExistingTable(
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            boolean dryRun
+    ) {
+        return importIntoExistingTable(null, library, tableName, csv, dbColumns, mappings, dryRun);
+    }
+
+    public ImportResult importIntoExistingTable(
+            String connectionProfileName,
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            boolean dryRun
+    ) {
+        try (DbSession session = openSession(connectionProfileName)) {
+            return doImportIntoExistingTable(session, library, tableName, csv, dbColumns, mappings, dryRun);
+        } catch (IllegalArgumentException | IllegalStateException ex) {
+            return ImportResult.failure(ex.getMessage(), "", List.of(new ParseError(0, "", "", ex.getMessage())));
+        }
+    }
+
+    private ImportResult doImportIntoExistingTable(
+            DbSession session,
             String library,
             String tableName,
             ParsedCsv csv,
@@ -149,9 +202,9 @@ public class ImportService {
             return ImportResult.failure("Import aborted due to invalid mappings.", "", errors);
         }
 
-        String insertSql = buildInsertSql(library, tableName, effectiveMappings);
+        String insertSql = buildInsertSql(session.dialect(), library, tableName, effectiveMappings);
 
-        try (Connection connection = dataSource.getConnection()) {
+        try (Connection connection = session.dataSource().getConnection()) {
             connection.setAutoCommit(false);
             int insertedRows = executeExistingTableInserts(connection, insertSql, effectiveMappings, csv.getRows(), errors);
             if (!errors.isEmpty()) {
@@ -180,10 +233,40 @@ public class ImportService {
             List<ColumnMapping> mappings,
             List<String> keyColumns
     ) {
-        return upsertIntoExistingTable(library, tableName, csv, dbColumns, mappings, keyColumns, false);
+        return upsertIntoExistingTable(null, library, tableName, csv, dbColumns, mappings, keyColumns, false);
     }
 
     public ImportResult updateIntoExistingTable(
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns,
+            boolean dryRun
+    ) {
+        return updateIntoExistingTable(null, library, tableName, csv, dbColumns, mappings, keyColumns, dryRun);
+    }
+
+    public ImportResult updateIntoExistingTable(
+            String connectionProfileName,
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns,
+            boolean dryRun
+    ) {
+        try (DbSession session = openSession(connectionProfileName)) {
+            return doUpdateIntoExistingTable(session, library, tableName, csv, dbColumns, mappings, keyColumns, dryRun);
+        } catch (IllegalArgumentException | IllegalStateException ex) {
+            return ImportResult.failure(ex.getMessage(), "", List.of(new ParseError(0, "", "", ex.getMessage())));
+        }
+    }
+
+    private ImportResult doUpdateIntoExistingTable(
+            DbSession session,
             String library,
             String tableName,
             ParsedCsv csv,
@@ -209,8 +292,8 @@ public class ImportService {
                     List.of(new ParseError(0, "", "", "Map at least one non-key column for updates.")));
         }
 
-        sql = buildUpdateSql(library, tableName, updateMappings, keyMappings);
-        try (Connection connection = dataSource.getConnection()) {
+        sql = buildUpdateSql(session.dialect(), library, tableName, updateMappings, keyMappings);
+        try (Connection connection = session.dataSource().getConnection()) {
             connection.setAutoCommit(false);
             int affectedRows = executeKeyedRows(connection, sql, updateMappings, keyMappings, csv.getRows(), errors);
             if (!errors.isEmpty()) {
@@ -240,6 +323,36 @@ public class ImportService {
             List<String> keyColumns,
             boolean dryRun
     ) {
+        return deleteFromExistingTable(null, library, tableName, csv, dbColumns, mappings, keyColumns, dryRun);
+    }
+
+    public ImportResult deleteFromExistingTable(
+            String connectionProfileName,
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns,
+            boolean dryRun
+    ) {
+        try (DbSession session = openSession(connectionProfileName)) {
+            return doDeleteFromExistingTable(session, library, tableName, csv, dbColumns, mappings, keyColumns, dryRun);
+        } catch (IllegalArgumentException | IllegalStateException ex) {
+            return ImportResult.failure(ex.getMessage(), "", List.of(new ParseError(0, "", "", ex.getMessage())));
+        }
+    }
+
+    private ImportResult doDeleteFromExistingTable(
+            DbSession session,
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns,
+            boolean dryRun
+    ) {
         List<ColumnMapping> effectiveMappings = determineEffectiveMappings(mappings);
         List<String> keys = normalizeSelectedKeys(keyColumns);
         String sql = "";
@@ -249,8 +362,8 @@ public class ImportService {
         }
 
         List<ColumnMapping> keyMappings = mappingsForKeys(effectiveMappings, keys);
-        sql = buildDeleteSql(library, tableName, keyMappings);
-        try (Connection connection = dataSource.getConnection()) {
+        sql = buildDeleteSql(session.dialect(), library, tableName, keyMappings);
+        try (Connection connection = session.dataSource().getConnection()) {
             connection.setAutoCommit(false);
             int affectedRows = executeKeyedRows(connection, sql, keyMappings, List.of(), csv.getRows(), errors);
             if (!errors.isEmpty()) {
@@ -309,22 +422,27 @@ public class ImportService {
         return mappings.stream().filter(mapping -> containsNormalized(keys, mapping.getTargetColumn())).toList();
     }
 
-    private String buildUpdateSql(String library, String tableName, List<ColumnMapping> updates, List<ColumnMapping> keys) {
-        String assignments = updates.stream()
-                .map(mapping -> sqlDialect.quoteIdentifier(mapping.getTargetColumn()) + " = ?")
-                .collect(java.util.stream.Collectors.joining(", "));
-        return "UPDATE " + sqlDialect.qualifyTable(library, tableName) + " SET " + assignments
-                + " WHERE " + whereClause(keys);
+    private String buildUpdateSql(
+            SqlDialect dialect,
+            String library,
+            String tableName,
+            List<ColumnMapping> updates,
+            List<ColumnMapping> keys
+    ) {
+        return dialect.buildUpdateSql(
+                library,
+                tableName,
+                updates.stream().map(ColumnMapping::getTargetColumn).toList(),
+                keys.stream().map(ColumnMapping::getTargetColumn).toList()
+        );
     }
 
-    private String buildDeleteSql(String library, String tableName, List<ColumnMapping> keys) {
-        return "DELETE FROM " + sqlDialect.qualifyTable(library, tableName) + " WHERE " + whereClause(keys);
-    }
-
-    private String whereClause(List<ColumnMapping> keys) {
-        return keys.stream()
-                .map(mapping -> sqlDialect.quoteIdentifier(mapping.getTargetColumn()) + " = ?")
-                .collect(java.util.stream.Collectors.joining(" AND "));
+    private String buildDeleteSql(SqlDialect dialect, String library, String tableName, List<ColumnMapping> keys) {
+        return dialect.buildDeleteSql(
+                library,
+                tableName,
+                keys.stream().map(ColumnMapping::getTargetColumn).toList()
+        );
     }
 
     private int executeKeyedRows(
@@ -365,6 +483,36 @@ public class ImportService {
     }
 
     public ImportResult upsertIntoExistingTable(
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns,
+            boolean dryRun
+    ) {
+        return upsertIntoExistingTable(null, library, tableName, csv, dbColumns, mappings, keyColumns, dryRun);
+    }
+
+    public ImportResult upsertIntoExistingTable(
+            String connectionProfileName,
+            String library,
+            String tableName,
+            ParsedCsv csv,
+            List<DbColumnMeta> dbColumns,
+            List<ColumnMapping> mappings,
+            List<String> keyColumns,
+            boolean dryRun
+    ) {
+        try (DbSession session = openSession(connectionProfileName)) {
+            return doUpsertIntoExistingTable(session, library, tableName, csv, dbColumns, mappings, keyColumns, dryRun);
+        } catch (IllegalArgumentException | IllegalStateException ex) {
+            return ImportResult.failure(ex.getMessage(), "", List.of(new ParseError(0, "", "", ex.getMessage())));
+        }
+    }
+
+    private ImportResult doUpsertIntoExistingTable(
+            DbSession session,
             String library,
             String tableName,
             ParsedCsv csv,
@@ -433,15 +581,17 @@ public class ImportService {
             );
         }
 
-        String mergeSql;
+        String mergeSql = "";
         try {
-            mergeSql = mergeSqlBuilder.buildDb2MergeSql(library, tableName, insertColumns, updateColumns, effectiveKeys);
-        } catch (IllegalArgumentException ex) {
+            UpsertSql upsertSql = session.dialect().buildUpsertSql(
+                    library, tableName, insertColumns, updateColumns, effectiveKeys);
+            mergeSql = upsertSql.sql();
+        } catch (IllegalArgumentException | UnsupportedOperationException ex) {
             return ImportResult.failure("Import aborted due to invalid upsert configuration.", "",
                     List.of(new ParseError(0, "", "", ex.getMessage())));
         }
 
-        try (Connection connection = dataSource.getConnection()) {
+        try (Connection connection = session.dataSource().getConnection()) {
             connection.setAutoCommit(false);
             int processedRows = executeMergeRows(connection, mergeSql, effectiveMappings, insertColumns, csv.getRows(), errors);
             if (!errors.isEmpty()) {
@@ -463,13 +613,28 @@ public class ImportService {
     }
 
     String buildInsertSql(String library, String tableName, List<ColumnMapping> mappings) {
+        return buildInsertSql(sqlDialect, library, tableName, mappings);
+    }
+
+    String buildInsertSql(SqlDialect dialect, String library, String tableName, List<ColumnMapping> mappings) {
         List<String> targetColumns = mappings.stream()
                 .map(ColumnMapping::getTargetColumn)
-                .map(sqlDialect::quoteIdentifier)
                 .toList();
-        String placeholders = String.join(", ", mappings.stream().map(m -> "?").toList());
-        return "INSERT INTO " + sqlDialect.qualifyTable(library, tableName)
-                + " (" + String.join(", ", targetColumns) + ") VALUES (" + placeholders + ")";
+        return dialect.buildInsertSql(library, tableName, targetColumns);
+    }
+
+    private DbSession openSession(String connectionProfileName) {
+        if (dbSessionFactory != null) {
+            return dbSessionFactory.open(connectionProfileName);
+        }
+        return new DbSession(dataSource, sqlDialect, null, sqlDialect.product(), null);
+    }
+
+    private DdlService ddlFor(DbSession session) {
+        if (session.isBootstrap() && ddlService != null && session.dialect() == sqlDialect) {
+            return ddlService;
+        }
+        return new DdlService(columnNameSanitizer, session.dialect());
     }
 
     private int executeInserts(
@@ -796,5 +961,23 @@ public class ImportService {
 
     private String normalizeColumnName(String value) {
         return value == null ? "" : value.trim().toUpperCase(Locale.ROOT);
+    }
+
+    /**
+     * On H2 (local/test) create missing schemas so CREATE TABLE works without
+     * a pre-provisioned library. On IBM i this is a no-op.
+     */
+    private void ensureSchemaExists(Connection connection, SqlDialect dialect, String library) throws SQLException {
+        if (!dialect.supportsSchemaAutoCreate() || !StringUtils.hasText(library)) {
+            return;
+        }
+        String schemaSql = dialect.createSchemaSql(library);
+        if (!StringUtils.hasText(schemaSql)) {
+            return;
+        }
+        try (PreparedStatement statement = connection.prepareStatement(schemaSql)) {
+            statement.executeUpdate();
+            log.debug("Ensured schema/library exists: {}", library);
+        }
     }
 }

--- a/src/main/java/com/zeus/upload/service/JdbcMetadataService.java
+++ b/src/main/java/com/zeus/upload/service/JdbcMetadataService.java
@@ -12,7 +12,6 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -26,20 +25,26 @@ public class JdbcMetadataService implements MetadataService {
             .comparing((DbColumnMeta c) -> c.getOrdinalPosition() == null ? Integer.MAX_VALUE : c.getOrdinalPosition())
             .thenComparing(c -> c.getColumnName() == null ? "" : c.getColumnName());
 
-    private final DataSource dataSource;
+    private final DbSessionFactory dbSessionFactory;
 
-    public JdbcMetadataService(DataSource dataSource) {
-        this.dataSource = dataSource;
+    public JdbcMetadataService(DbSessionFactory dbSessionFactory) {
+        this.dbSessionFactory = dbSessionFactory;
     }
 
     @Override
     public List<DbTableRef> listTables(String library) {
+        return listTables(library, null);
+    }
+
+    @Override
+    public List<DbTableRef> listTables(String library, String connectionProfileName) {
         String normalizedLibrary = MetadataNormalizationUtil.normalizeLibrary(library);
         if (normalizedLibrary.isEmpty()) {
             return List.of();
         }
 
-        try (Connection connection = dataSource.getConnection()) {
+        try (DbSession session = dbSessionFactory.open(connectionProfileName);
+             Connection connection = session.dataSource().getConnection()) {
             DatabaseMetaData metadata = connection.getMetaData();
             List<DbTableRef> result = fetchTables(metadata, normalizedLibrary, false);
 
@@ -48,7 +53,8 @@ public class JdbcMetadataService implements MetadataService {
             }
 
             if (result.isEmpty()) {
-                log.warn("No metadata tables found for library {}", normalizedLibrary);
+                log.warn("No metadata tables found for library {} (connection={})",
+                        normalizedLibrary, session.connectionProfileName());
             }
             return result;
         } catch (SQLException ex) {
@@ -59,13 +65,19 @@ public class JdbcMetadataService implements MetadataService {
 
     @Override
     public List<DbColumnMeta> listColumns(String library, String tableName) {
+        return listColumns(library, tableName, null);
+    }
+
+    @Override
+    public List<DbColumnMeta> listColumns(String library, String tableName, String connectionProfileName) {
         String normalizedLibrary = MetadataNormalizationUtil.normalizeLibrary(library);
         String normalizedTable = MetadataNormalizationUtil.normalizeTable(tableName);
         if (normalizedLibrary.isEmpty() || normalizedTable.isEmpty()) {
             return List.of();
         }
 
-        try (Connection connection = dataSource.getConnection()) {
+        try (DbSession session = dbSessionFactory.open(connectionProfileName);
+             Connection connection = session.dataSource().getConnection()) {
             DatabaseMetaData metadata = connection.getMetaData();
             List<DbColumnMeta> columns = new ArrayList<>();
             try (ResultSet resultSet = metadata.getColumns(null, normalizedLibrary, normalizedTable, "%")) {
@@ -95,7 +107,8 @@ public class JdbcMetadataService implements MetadataService {
             }
 
             if (columns.isEmpty()) {
-                log.warn("No metadata columns found for {}.{}", normalizedLibrary, normalizedTable);
+                log.warn("No metadata columns found for {}.{} (connection={})",
+                        normalizedLibrary, normalizedTable, session.connectionProfileName());
                 return List.of();
             }
 

--- a/src/main/java/com/zeus/upload/service/MetadataService.java
+++ b/src/main/java/com/zeus/upload/service/MetadataService.java
@@ -8,5 +8,17 @@ public interface MetadataService {
 
     List<DbTableRef> listTables(String library);
 
+    /**
+     * List tables using an optional named connection profile (JDBC/DB2).
+     * Blank profile uses the bootstrap DataSource.
+     */
+    default List<DbTableRef> listTables(String library, String connectionProfileName) {
+        return listTables(library);
+    }
+
     List<DbColumnMeta> listColumns(String library, String tableName);
+
+    default List<DbColumnMeta> listColumns(String library, String tableName, String connectionProfileName) {
+        return listColumns(library, tableName);
+    }
 }

--- a/src/main/java/com/zeus/upload/sql/AbstractSqlDialect.java
+++ b/src/main/java/com/zeus/upload/sql/AbstractSqlDialect.java
@@ -1,0 +1,18 @@
+package com.zeus.upload.sql;
+
+/**
+ * Shared quoting helpers for dialects that use double-quoted identifiers.
+ */
+public abstract class AbstractSqlDialect implements SqlDialect {
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        String normalized = normalizeIdentifier(identifier);
+        return "\"" + normalized.replace("\"", "\"\"") + "\"";
+    }
+
+    @Override
+    public String qualifyTable(String libraryOrSchema, String table) {
+        return quoteIdentifier(libraryOrSchema) + "." + quoteIdentifier(table);
+    }
+}

--- a/src/main/java/com/zeus/upload/sql/DatabaseProduct.java
+++ b/src/main/java/com/zeus/upload/sql/DatabaseProduct.java
@@ -1,0 +1,20 @@
+package com.zeus.upload.sql;
+
+/**
+ * Supported database products for dialect selection.
+ * Independent of GUI {@code ConnectionType}; map connection endpoints to a product via
+ * {@link SqlDialectRegistry}.
+ */
+public enum DatabaseProduct {
+    /** IBM i DB2/400 (jt400). First-class production target. */
+    DB2_I,
+    /** Embedded H2 (local/dev/test, often MODE=DB2). */
+    H2,
+    /** PostgreSQL. */
+    POSTGRES,
+    /**
+     * Unknown or not yet specialized JDBC product.
+     * Portable DML only; upsert is fail-closed.
+     */
+    GENERIC_JDBC
+}

--- a/src/main/java/com/zeus/upload/sql/Db2iDialect.java
+++ b/src/main/java/com/zeus/upload/sql/Db2iDialect.java
@@ -1,17 +1,38 @@
 package com.zeus.upload.sql;
 
-import com.zeus.upload.util.Db2IdentifierUtil;
+/**
+ * IBM i DB2/400 dialect. Libraries are not auto-created; they must exist on the system.
+ * Upsert uses classic DB2 MERGE … USING (VALUES …) syntax.
+ */
+public class Db2iDialect extends AbstractSqlDialect {
 
-public class Db2iDialect implements SqlDialect {
+    private final MergeSqlBuilder mergeSqlBuilder = new MergeSqlBuilder(this);
 
     @Override
-    public String quoteIdentifier(String identifier) {
-        String sanitized = Db2IdentifierUtil.sanitizeIdentifier(identifier);
-        return "\"" + sanitized.replace("\"", "\"\"") + "\"";
+    public DatabaseProduct product() {
+        return DatabaseProduct.DB2_I;
     }
 
     @Override
-    public String qualifyTable(String libraryOrSchema, String table) {
-        return quoteIdentifier(libraryOrSchema) + "." + quoteIdentifier(table);
+    public IdentifierPolicy identifierPolicy() {
+        return IdentifierPolicy.ibmISystemNames();
+    }
+
+    @Override
+    public UpsertStrategy upsertStrategy() {
+        return UpsertStrategy.DB2_MERGE_VALUES;
+    }
+
+    @Override
+    public UpsertSql buildUpsertSql(
+            String libraryOrSchema,
+            String table,
+            java.util.List<String> insertColumns,
+            java.util.List<String> updateColumns,
+            java.util.List<String> keyColumns
+    ) {
+        String sql = mergeSqlBuilder.buildDb2MergeSql(
+                libraryOrSchema, table, insertColumns, updateColumns, keyColumns);
+        return new UpsertSql(sql, UpsertStrategy.DB2_MERGE_VALUES);
     }
 }

--- a/src/main/java/com/zeus/upload/sql/GenericJdbcDialect.java
+++ b/src/main/java/com/zeus/upload/sql/GenericJdbcDialect.java
@@ -1,0 +1,36 @@
+package com.zeus.upload.sql;
+
+/**
+ * Fail-closed dialect for unrecognized JDBC products.
+ * Supports portable INSERT/UPDATE/DELETE; upsert is unsupported.
+ */
+public class GenericJdbcDialect extends AbstractSqlDialect {
+
+    @Override
+    public DatabaseProduct product() {
+        return DatabaseProduct.GENERIC_JDBC;
+    }
+
+    @Override
+    public IdentifierPolicy identifierPolicy() {
+        return IdentifierPolicy.genericJdbc();
+    }
+
+    @Override
+    public UpsertStrategy upsertStrategy() {
+        return UpsertStrategy.UNSUPPORTED;
+    }
+
+    @Override
+    public UpsertSql buildUpsertSql(
+            String libraryOrSchema,
+            String table,
+            java.util.List<String> insertColumns,
+            java.util.List<String> updateColumns,
+            java.util.List<String> keyColumns
+    ) {
+        throw new UnsupportedOperationException(
+                "Upsert is not supported for GENERIC_JDBC. Add a product-specific SqlDialect."
+        );
+    }
+}

--- a/src/main/java/com/zeus/upload/sql/H2Dialect.java
+++ b/src/main/java/com/zeus/upload/sql/H2Dialect.java
@@ -1,17 +1,43 @@
 package com.zeus.upload.sql;
 
-import com.zeus.upload.util.Db2IdentifierUtil;
-
-public class H2Dialect implements SqlDialect {
+/**
+ * H2 dialect for local development and automated tests (typically MODE=DB2).
+ * Identifier policy mirrors IBM i create-table rules for predictable offline work.
+ * Upsert is intentionally unsupported until a proven H2-compatible strategy is added.
+ */
+public class H2Dialect extends AbstractSqlDialect {
 
     @Override
-    public String quoteIdentifier(String identifier) {
-        String sanitized = Db2IdentifierUtil.sanitizeIdentifier(identifier);
-        return "\"" + sanitized.replace("\"", "\"\"") + "\"";
+    public DatabaseProduct product() {
+        return DatabaseProduct.H2;
     }
 
     @Override
-    public String qualifyTable(String libraryOrSchema, String table) {
-        return quoteIdentifier(libraryOrSchema) + "." + quoteIdentifier(table);
+    public IdentifierPolicy identifierPolicy() {
+        return IdentifierPolicy.h2Db2Compat();
+    }
+
+    @Override
+    public String createSchemaSql(String libraryOrSchema) {
+        return "CREATE SCHEMA IF NOT EXISTS " + quoteIdentifier(libraryOrSchema);
+    }
+
+    @Override
+    public UpsertStrategy upsertStrategy() {
+        return UpsertStrategy.UNSUPPORTED;
+    }
+
+    @Override
+    public UpsertSql buildUpsertSql(
+            String libraryOrSchema,
+            String table,
+            java.util.List<String> insertColumns,
+            java.util.List<String> updateColumns,
+            java.util.List<String> keyColumns
+    ) {
+        throw new UnsupportedOperationException(
+                "Upsert is not supported for H2 in this version. "
+                        + "Use INSERT/UPDATE/DELETE, or run against IBM i (DB2_I) for MERGE upsert."
+        );
     }
 }

--- a/src/main/java/com/zeus/upload/sql/IdentifierPolicy.java
+++ b/src/main/java/com/zeus/upload/sql/IdentifierPolicy.java
@@ -1,0 +1,61 @@
+package com.zeus.upload.sql;
+
+/**
+ * Rules for sanitizing identifiers when creating or quoting table/column names.
+ */
+public final class IdentifierPolicy {
+
+    private final int maxLength;
+    private final boolean forceUpperCase;
+    private final String emptyFallback;
+    private final String leadingDigitPrefix;
+
+    public IdentifierPolicy(int maxLength, boolean forceUpperCase, String emptyFallback, String leadingDigitPrefix) {
+        if (maxLength < 1) {
+            throw new IllegalArgumentException("maxLength must be >= 1");
+        }
+        this.maxLength = maxLength;
+        this.forceUpperCase = forceUpperCase;
+        this.emptyFallback = emptyFallback == null || emptyFallback.isBlank() ? "COL" : emptyFallback;
+        this.leadingDigitPrefix = leadingDigitPrefix == null || leadingDigitPrefix.isBlank() ? "C_" : leadingDigitPrefix;
+    }
+
+    /**
+     * IBM i system-name style: upper case, max 10 for created columns.
+     * Leading non-letter prefix {@code T_} matches historic {@code Db2IdentifierUtil} quoting.
+     */
+    public static IdentifierPolicy ibmISystemNames() {
+        return new IdentifierPolicy(10, true, "COL", "T_");
+    }
+
+    /** H2 in DB2-compat mode: keep IBM i-like names for predictable local tests. */
+    public static IdentifierPolicy h2Db2Compat() {
+        return ibmISystemNames();
+    }
+
+    /** PostgreSQL: longer identifiers, still uppercased for app consistency. */
+    public static IdentifierPolicy postgres() {
+        return new IdentifierPolicy(63, true, "COL", "C_");
+    }
+
+    /** Conservative generic JDBC defaults. */
+    public static IdentifierPolicy genericJdbc() {
+        return new IdentifierPolicy(30, true, "COL", "C_");
+    }
+
+    public int maxLength() {
+        return maxLength;
+    }
+
+    public boolean forceUpperCase() {
+        return forceUpperCase;
+    }
+
+    public String emptyFallback() {
+        return emptyFallback;
+    }
+
+    public String leadingDigitPrefix() {
+        return leadingDigitPrefix;
+    }
+}

--- a/src/main/java/com/zeus/upload/sql/MergeSqlBuilder.java
+++ b/src/main/java/com/zeus/upload/sql/MergeSqlBuilder.java
@@ -6,6 +6,11 @@ import java.util.List;
 import java.util.Set;
 import org.springframework.util.StringUtils;
 
+/**
+ * Builds IBM i / DB2-style MERGE … USING (VALUES …) statements.
+ * Prefer calling {@link SqlDialect#buildUpsertSql} from application code;
+ * this helper remains for {@link Db2iDialect} and unit tests.
+ */
 public class MergeSqlBuilder {
 
     private final SqlDialect sqlDialect;

--- a/src/main/java/com/zeus/upload/sql/PostgresDialect.java
+++ b/src/main/java/com/zeus/upload/sql/PostgresDialect.java
@@ -1,0 +1,79 @@
+package com.zeus.upload.sql;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * PostgreSQL dialect scaffold. Portable DML is available; upsert uses ON CONFLICT.
+ * Runtime driver/DataSource selection per connection profile is a follow-up.
+ */
+public class PostgresDialect extends AbstractSqlDialect {
+
+    @Override
+    public DatabaseProduct product() {
+        return DatabaseProduct.POSTGRES;
+    }
+
+    @Override
+    public IdentifierPolicy identifierPolicy() {
+        return IdentifierPolicy.postgres();
+    }
+
+    @Override
+    public String createSchemaSql(String libraryOrSchema) {
+        return "CREATE SCHEMA IF NOT EXISTS " + quoteIdentifier(libraryOrSchema);
+    }
+
+    @Override
+    public int maxDecimalPrecision() {
+        return 38;
+    }
+
+    @Override
+    public int maxDecimalScale() {
+        return 38;
+    }
+
+    @Override
+    public int maxVarcharLength() {
+        return 10_485_760;
+    }
+
+    @Override
+    public UpsertStrategy upsertStrategy() {
+        return UpsertStrategy.POSTGRES_ON_CONFLICT;
+    }
+
+    @Override
+    public UpsertSql buildUpsertSql(
+            String libraryOrSchema,
+            String table,
+            List<String> insertColumns,
+            List<String> updateColumns,
+            List<String> keyColumns
+    ) {
+        if (insertColumns == null || insertColumns.isEmpty()) {
+            throw new IllegalArgumentException("At least one insert column is required for upsert.");
+        }
+        if (keyColumns == null || keyColumns.isEmpty()) {
+            throw new IllegalArgumentException("At least one key column is required for upsert.");
+        }
+        if (updateColumns == null || updateColumns.isEmpty()) {
+            throw new IllegalArgumentException("At least one non-key update column is required for upsert.");
+        }
+
+        List<String> quotedInsert = quoteColumns(insertColumns);
+        List<String> quotedKeys = quoteColumns(keyColumns);
+        List<String> quotedUpdates = quoteColumns(updateColumns);
+        String placeholders = quotedInsert.stream().map(c -> "?").collect(Collectors.joining(", "));
+        String conflict = String.join(", ", quotedKeys);
+        String setClause = quotedUpdates.stream()
+                .map(col -> col + " = EXCLUDED." + col)
+                .collect(Collectors.joining(", "));
+
+        String sql = "INSERT INTO " + qualifyTable(libraryOrSchema, table)
+                + " (" + String.join(", ", quotedInsert) + ") VALUES (" + placeholders + ") "
+                + "ON CONFLICT (" + conflict + ") DO UPDATE SET " + setClause;
+        return new UpsertSql(sql, UpsertStrategy.POSTGRES_ON_CONFLICT);
+    }
+}

--- a/src/main/java/com/zeus/upload/sql/SqlDialect.java
+++ b/src/main/java/com/zeus/upload/sql/SqlDialect.java
@@ -1,8 +1,161 @@
 package com.zeus.upload.sql;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+/**
+ * Database-specific SQL helpers. Implementations must never embed credentials;
+ * they only shape SQL for the active engine.
+ */
 public interface SqlDialect {
+
+    DatabaseProduct product();
+
+    IdentifierPolicy identifierPolicy();
 
     String quoteIdentifier(String identifier);
 
     String qualifyTable(String libraryOrSchema, String table);
+
+    /**
+     * Optional DDL to create a schema/library. {@code null} when the engine
+     * expects schemas to exist already (IBM i libraries).
+     */
+    default String createSchemaSql(String libraryOrSchema) {
+        return null;
+    }
+
+    default boolean supportsSchemaAutoCreate() {
+        return createSchemaSql("X") != null;
+    }
+
+    /**
+     * Normalize a raw identifier according to this dialect's policy
+     * (case, charset, empty fallback) without length truncation.
+     */
+    default String normalizeIdentifier(String raw) {
+        IdentifierPolicy policy = identifierPolicy();
+        String value = raw == null ? "" : raw.trim();
+        if (policy.forceUpperCase()) {
+            value = value.toUpperCase(Locale.ROOT);
+        }
+        value = value.replaceAll("[^A-Za-z0-9_]", "_");
+        value = value.replaceAll("_+", "_");
+        value = value.replaceAll("^_+", "");
+        value = value.replaceAll("_+$", "");
+        if (value.isBlank()) {
+            value = policy.emptyFallback();
+        }
+        if (policy.forceUpperCase()) {
+            value = value.toUpperCase(Locale.ROOT);
+        }
+        if (!Character.isLetter(value.charAt(0))) {
+            value = policy.leadingDigitPrefix() + value;
+            if (policy.forceUpperCase()) {
+                value = value.toUpperCase(Locale.ROOT);
+            }
+        }
+        return value;
+    }
+
+    /**
+     * SQL type fragment for CREATE TABLE column definitions, e.g. {@code VARCHAR(64)}.
+     */
+    default String columnTypeDefinition(String sqlType, Integer length, Integer precision, Integer scale) {
+        String type = sqlType == null ? "VARCHAR" : sqlType.toUpperCase(Locale.ROOT);
+        return switch (type) {
+            case "INTEGER" -> "INTEGER";
+            case "BIGINT" -> "BIGINT";
+            case "DATE" -> "DATE";
+            case "TIMESTAMP" -> "TIMESTAMP";
+            case "DECIMAL" -> {
+                int p = precision == null ? 15 : Math.max(1, Math.min(maxDecimalPrecision(), precision));
+                int s = scale == null ? 2 : Math.max(0, Math.min(maxDecimalScale(), scale));
+                if (s >= p) {
+                    s = Math.max(0, p - 1);
+                }
+                yield "DECIMAL(" + p + "," + s + ")";
+            }
+            default -> {
+                int len = length == null ? 255 : Math.max(1, Math.min(maxVarcharLength(), length));
+                yield "VARCHAR(" + len + ")";
+            }
+        };
+    }
+
+    default int maxDecimalPrecision() {
+        return 31;
+    }
+
+    default int maxDecimalScale() {
+        return 31;
+    }
+
+    default int maxVarcharLength() {
+        return 4000;
+    }
+
+    default String buildInsertSql(String libraryOrSchema, String table, List<String> columns) {
+        List<String> quoted = quoteColumns(columns);
+        String placeholders = quoted.stream().map(c -> "?").collect(Collectors.joining(", "));
+        return "INSERT INTO " + qualifyTable(libraryOrSchema, table)
+                + " (" + String.join(", ", quoted) + ") VALUES (" + placeholders + ")";
+    }
+
+    default String buildUpdateSql(
+            String libraryOrSchema,
+            String table,
+            List<String> updateColumns,
+            List<String> keyColumns
+    ) {
+        String assignments = quoteColumns(updateColumns).stream()
+                .map(col -> col + " = ?")
+                .collect(Collectors.joining(", "));
+        return "UPDATE " + qualifyTable(libraryOrSchema, table)
+                + " SET " + assignments
+                + " WHERE " + whereEquals(keyColumns);
+    }
+
+    default String buildDeleteSql(String libraryOrSchema, String table, List<String> keyColumns) {
+        return "DELETE FROM " + qualifyTable(libraryOrSchema, table)
+                + " WHERE " + whereEquals(keyColumns);
+    }
+
+    /**
+     * Build product-specific upsert SQL. Dialects that do not support upsert
+     * must throw {@link UnsupportedOperationException} or return strategy
+     * {@link UpsertStrategy#UNSUPPORTED} — prefer throwing with a clear message.
+     */
+    UpsertSql buildUpsertSql(
+            String libraryOrSchema,
+            String table,
+            List<String> insertColumns,
+            List<String> updateColumns,
+            List<String> keyColumns
+    );
+
+    default UpsertStrategy upsertStrategy() {
+        return UpsertStrategy.UNSUPPORTED;
+    }
+
+    default String whereEquals(List<String> keyColumns) {
+        return quoteColumns(keyColumns).stream()
+                .map(col -> col + " = ?")
+                .collect(Collectors.joining(" AND "));
+    }
+
+    default List<String> quoteColumns(List<String> columns) {
+        List<String> quoted = new ArrayList<>();
+        if (columns == null) {
+            return quoted;
+        }
+        for (String column : columns) {
+            if (column != null && !column.isBlank()) {
+                quoted.add(quoteIdentifier(column));
+            }
+        }
+        return quoted;
+    }
 }

--- a/src/main/java/com/zeus/upload/sql/SqlDialectRegistry.java
+++ b/src/main/java/com/zeus/upload/sql/SqlDialectRegistry.java
@@ -1,0 +1,92 @@
+package com.zeus.upload.sql;
+
+import com.zeus.upload.domain.ConnectionType;
+import java.util.EnumMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.util.StringUtils;
+
+/**
+ * Resolves {@link SqlDialect} instances by product, connection type, or JDBC URL.
+ * Does not open connections or store credentials.
+ */
+public class SqlDialectRegistry {
+
+    private final Map<DatabaseProduct, SqlDialect> dialects;
+
+    public SqlDialectRegistry(Map<DatabaseProduct, SqlDialect> dialects) {
+        this.dialects = new EnumMap<>(DatabaseProduct.class);
+        Objects.requireNonNull(dialects, "dialects").forEach((product, dialect) -> {
+            if (dialect != null) {
+                this.dialects.put(product, dialect);
+            }
+        });
+        if (!this.dialects.containsKey(DatabaseProduct.DB2_I)) {
+            this.dialects.put(DatabaseProduct.DB2_I, new Db2iDialect());
+        }
+        if (!this.dialects.containsKey(DatabaseProduct.H2)) {
+            this.dialects.put(DatabaseProduct.H2, new H2Dialect());
+        }
+        if (!this.dialects.containsKey(DatabaseProduct.POSTGRES)) {
+            this.dialects.put(DatabaseProduct.POSTGRES, new PostgresDialect());
+        }
+        if (!this.dialects.containsKey(DatabaseProduct.GENERIC_JDBC)) {
+            this.dialects.put(DatabaseProduct.GENERIC_JDBC, new GenericJdbcDialect());
+        }
+    }
+
+    public static SqlDialectRegistry createDefault() {
+        Map<DatabaseProduct, SqlDialect> map = new EnumMap<>(DatabaseProduct.class);
+        map.put(DatabaseProduct.DB2_I, new Db2iDialect());
+        map.put(DatabaseProduct.H2, new H2Dialect());
+        map.put(DatabaseProduct.POSTGRES, new PostgresDialect());
+        map.put(DatabaseProduct.GENERIC_JDBC, new GenericJdbcDialect());
+        return new SqlDialectRegistry(map);
+    }
+
+    public SqlDialect get(DatabaseProduct product) {
+        DatabaseProduct key = product == null ? DatabaseProduct.GENERIC_JDBC : product;
+        SqlDialect dialect = dialects.get(key);
+        if (dialect == null) {
+            return dialects.get(DatabaseProduct.GENERIC_JDBC);
+        }
+        return dialect;
+    }
+
+    public SqlDialect resolveFromJdbcUrl(String jdbcUrl) {
+        return get(detectProduct(jdbcUrl));
+    }
+
+    public SqlDialect resolveFromConnectionType(ConnectionType type) {
+        if (type == ConnectionType.DB2_400) {
+            return get(DatabaseProduct.DB2_I);
+        }
+        return get(DatabaseProduct.GENERIC_JDBC);
+    }
+
+    /**
+     * Heuristic product detection from JDBC URL. Does not validate reachability.
+     */
+    public static DatabaseProduct detectProduct(String jdbcUrl) {
+        if (!StringUtils.hasText(jdbcUrl)) {
+            return DatabaseProduct.GENERIC_JDBC;
+        }
+        String url = jdbcUrl.trim().toLowerCase(Locale.ROOT);
+        if (url.startsWith("jdbc:as400:") || url.startsWith("jdbc:db2:")) {
+            // jdbc:db2: often LUW; treat classic as400 as DB2_I. For pure LUW URLs
+            // without as400 we still map to DB2_I dialect (MERGE-compatible enough).
+            if (url.startsWith("jdbc:as400:")) {
+                return DatabaseProduct.DB2_I;
+            }
+            return DatabaseProduct.DB2_I;
+        }
+        if (url.startsWith("jdbc:h2:")) {
+            return DatabaseProduct.H2;
+        }
+        if (url.startsWith("jdbc:postgresql:") || url.startsWith("jdbc:pgsql:")) {
+            return DatabaseProduct.POSTGRES;
+        }
+        return DatabaseProduct.GENERIC_JDBC;
+    }
+}

--- a/src/main/java/com/zeus/upload/sql/UpsertSql.java
+++ b/src/main/java/com/zeus/upload/sql/UpsertSql.java
@@ -1,0 +1,25 @@
+package com.zeus.upload.sql;
+
+import java.util.Objects;
+
+/**
+ * Generated upsert statement plus strategy metadata (dry-run / UI).
+ */
+public final class UpsertSql {
+
+    private final String sql;
+    private final UpsertStrategy strategy;
+
+    public UpsertSql(String sql, UpsertStrategy strategy) {
+        this.sql = Objects.requireNonNull(sql, "sql");
+        this.strategy = Objects.requireNonNull(strategy, "strategy");
+    }
+
+    public String sql() {
+        return sql;
+    }
+
+    public UpsertStrategy strategy() {
+        return strategy;
+    }
+}

--- a/src/main/java/com/zeus/upload/sql/UpsertStrategy.java
+++ b/src/main/java/com/zeus/upload/sql/UpsertStrategy.java
@@ -1,0 +1,13 @@
+package com.zeus.upload.sql;
+
+/**
+ * How a dialect implements upsert. Services must not hardcode product SQL.
+ */
+public enum UpsertStrategy {
+    /** IBM i style: MERGE INTO … USING (VALUES (…)) AS S(…). */
+    DB2_MERGE_VALUES,
+    /** PostgreSQL style: INSERT … ON CONFLICT (…) DO UPDATE. */
+    POSTGRES_ON_CONFLICT,
+    /** Dialect does not support upsert; callers must fail closed. */
+    UNSUPPORTED
+}

--- a/src/main/java/com/zeus/upload/util/ColumnNameSanitizer.java
+++ b/src/main/java/com/zeus/upload/util/ColumnNameSanitizer.java
@@ -1,31 +1,56 @@
 package com.zeus.upload.util;
 
+import com.zeus.upload.sql.IdentifierPolicy;
+import java.util.Locale;
 import java.util.Set;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ColumnNameSanitizer {
 
+    /**
+     * Default max length for IBM i system-style names when no dialect policy is supplied.
+     * Prefer {@link IdentifierPolicy#maxLength()} from the active {@code SqlDialect}.
+     */
     public static final int MAX_COLUMN_LENGTH = 10;
 
     public String sanitizeBase(String input) {
-        String value = input == null ? "" : input.trim().toUpperCase();
-        value = value.replaceAll("[^A-Z0-9_]", "_");
+        return sanitizeBase(input, IdentifierPolicy.ibmISystemNames());
+    }
+
+    public String sanitizeBase(String input, IdentifierPolicy policy) {
+        IdentifierPolicy effective = policy == null ? IdentifierPolicy.ibmISystemNames() : policy;
+        String value = input == null ? "" : input.trim();
+        if (effective.forceUpperCase()) {
+            value = value.toUpperCase(Locale.ROOT);
+        }
+        value = value.replaceAll("[^A-Za-z0-9_]", "_");
         value = value.replaceAll("_+", "_");
         value = value.replaceAll("^_+", "");
         value = value.replaceAll("_+$", "");
 
         if (value.isBlank()) {
-            value = "COL";
+            value = effective.emptyFallback();
+        }
+        if (effective.forceUpperCase()) {
+            value = value.toUpperCase(Locale.ROOT);
         }
         if (!Character.isLetter(value.charAt(0))) {
-            value = "C_" + value;
+            value = effective.leadingDigitPrefix() + value;
+            if (effective.forceUpperCase()) {
+                value = value.toUpperCase(Locale.ROOT);
+            }
         }
         return value;
     }
 
     public String sanitizeColumnName(String input) {
         return enforceLengthWithHash(sanitizeBase(input), MAX_COLUMN_LENGTH);
+    }
+
+    public String sanitizeColumnName(String input, IdentifierPolicy policy) {
+        IdentifierPolicy effective = policy == null ? IdentifierPolicy.ibmISystemNames() : policy;
+        return enforceLengthWithHash(sanitizeBase(input, effective), effective.maxLength());
     }
 
     public String uniquify(String sanitizedBase, Set<String> used, int maxLength) {
@@ -44,7 +69,7 @@ public class ColumnNameSanitizer {
             return value;
         }
         int suffixLength = Math.min(3, maxLength - 1);
-        String hash = Integer.toHexString(value.hashCode()).toUpperCase().replace("-", "A");
+        String hash = Integer.toHexString(value.hashCode()).toUpperCase(Locale.ROOT).replace("-", "A");
         if (hash.length() > suffixLength) {
             hash = hash.substring(0, suffixLength);
         } else if (hash.length() < suffixLength) {

--- a/src/main/java/com/zeus/upload/util/Db2IdentifierUtil.java
+++ b/src/main/java/com/zeus/upload/util/Db2IdentifierUtil.java
@@ -1,5 +1,10 @@
 package com.zeus.upload.util;
 
+/**
+ * @deprecated Prefer {@link com.zeus.upload.sql.SqlDialect#normalizeIdentifier(String)}
+ * and {@link com.zeus.upload.sql.IdentifierPolicy} for dialect-aware rules.
+ */
+@Deprecated(forRemoval = false)
 public final class Db2IdentifierUtil {
 
     private Db2IdentifierUtil() {

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,36 @@
+# Local development profile: embedded H2 (DB2 compatibility mode).
+# Activate with: mvn -Plocal spring-boot:run
+# or:            mvn spring-boot:run -Dspring-boot.run.profiles=local
+#
+# No IBM i required. Database files live under .local/ (gitignored).
+# Do not put real production credentials into this file or commit secrets.
+
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    # File-backed H2 so data survives restarts; MODE=DB2 mimics IBM i identifier behaviour.
+    url: jdbc:h2:file:./.local/h2/zeus;MODE=DB2;AUTO_SERVER=TRUE;DATABASE_TO_UPPER=true;DB_CLOSE_DELAY=-1;DEFAULT_NULL_ORDERING=HIGH
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+      settings:
+        web-allow-others: false
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema-local.sql
+      continue-on-error: true
+
+app:
+  default-library: TESTLIB
+  # Encrypted connection profiles stay outside the repo.
+  connection-profile-directory: .local/connections
+  # Local-only dummy master key (32 zero bytes, Base64). Override via ZEUS_CONNECTION_MASTER_KEY for real local profiles.
+  connection-master-key: ${ZEUS_CONNECTION_MASTER_KEY:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}
+
+logging:
+  level:
+    com.zeus.upload: DEBUG

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,9 +1,10 @@
 spring:
   datasource:
-    driver-class-name: com.ibm.as400.access.AS400JDBCDriver
-    url: jdbc:as400://system/bib;translate binary=true
-    username: user
-    password: pass
+    # Prefer environment variables / secret store. Never commit real IBM i credentials.
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER:com.ibm.as400.access.AS400JDBCDriver}
+    url: ${SPRING_DATASOURCE_URL:jdbc:as400://localhost/}
+    username: ${SPRING_DATASOURCE_USERNAME:}
+    password: ${SPRING_DATASOURCE_PASSWORD:}
 
   servlet:
     multipart:
@@ -11,11 +12,11 @@ spring:
       max-request-size: 50MB
 
 app:
-  default-library: BIB
+  default-library: ${APP_DEFAULT_LIBRARY:BIB}
   sample-rows: 200
   batch-size: 500
   profile-directory: profiles
-  connection-profile-directory: connections
+  connection-profile-directory: ${APP_CONNECTION_PROFILE_DIRECTORY:connections}
   connection-master-key: ${ZEUS_CONNECTION_MASTER_KEY:}
 
 logging:

--- a/src/main/resources/schema-local.sql
+++ b/src/main/resources/schema-local.sql
@@ -1,0 +1,3 @@
+-- Bootstrap schemas for local H2 (library == schema, IBM i style).
+CREATE SCHEMA IF NOT EXISTS "TESTLIB";
+CREATE SCHEMA IF NOT EXISTS "BIB";

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -52,6 +52,20 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="mb-3">
+                            <label for="connectionProfileName" class="form-label">Database connection</label>
+                            <select class="form-select" id="connectionProfileName" name="connectionProfileName">
+                                <option value="">Default (application DataSource)</option>
+                                <option th:each="conn : ${jdbcConnections}"
+                                        th:value="${conn.name}"
+                                        th:text="${conn.name + ' — ' + conn.endpoint}"
+                                        th:selected="${importRequest.connectionProfileName == conn.name}"></option>
+                            </select>
+                            <div class="form-text">
+                                Optional named profile from <a th:href="@{/connections}">Verbindungen</a>.
+                                Secrets stay encrypted; never enter passwords here.
+                            </div>
+                        </div>
                         <div class="row">
                             <div class="col-md-6 mb-3">
                                 <label for="library" class="form-label">Library (Schema)</label>
@@ -92,6 +106,7 @@
 <script>
     (() => {
         const libraryInput = document.getElementById("library");
+        const connectionSelect = document.getElementById("connectionProfileName");
         const useExistingTable = document.getElementById("useExistingTable");
         const existingTableSelect = document.getElementById("existingTableSelect");
         const status = document.getElementById("existingTableStatus");
@@ -132,7 +147,12 @@
 
             status.textContent = "Loading tables...";
             try {
-                const response = await fetch(`/meta/tables?library=${encodeURIComponent(library)}`);
+                let url = `/meta/tables?library=${encodeURIComponent(library)}`;
+                const connection = connectionSelect && connectionSelect.value ? connectionSelect.value.trim() : "";
+                if (connection) {
+                    url += `&connectionProfileName=${encodeURIComponent(connection)}`;
+                }
+                const response = await fetch(url);
                 if (!response.ok) {
                     throw new Error("Metadata endpoint returned " + response.status);
                 }

--- a/src/main/resources/templates/preview.html
+++ b/src/main/resources/templates/preview.html
@@ -38,6 +38,7 @@
     <form th:action="@{/import}" th:object="${importRequest}" method="post">
         <input type="hidden" th:field="*{useExistingTable}">
         <input type="hidden" th:field="*{existingTableName}">
+        <input type="hidden" th:field="*{connectionProfileName}">
         <input type="hidden" th:field="*{csvDelimiter}">
         <input type="hidden" th:field="*{csvEncoding}">
         <input type="hidden" th:field="*{csvQuote}">

--- a/src/test/java/com/zeus/upload/controller/UploadControllerExistingTableTest.java
+++ b/src/test/java/com/zeus/upload/controller/UploadControllerExistingTableTest.java
@@ -15,6 +15,7 @@ import com.zeus.upload.domain.DbColumnMeta;
 import com.zeus.upload.domain.ParsedCsv;
 import com.zeus.upload.flow.FlowConfigurationFactory;
 import com.zeus.upload.flow.FlowExecutionService;
+import com.zeus.upload.service.ConnectionProfileService;
 import com.zeus.upload.service.CsvParsingService;
 import com.zeus.upload.service.MappingService;
 import com.zeus.upload.service.MetadataService;
@@ -50,6 +51,9 @@ class UploadControllerExistingTableTest {
     @MockBean
     private FlowExecutionService flowExecutionService;
 
+    @MockBean
+    private ConnectionProfileService connectionProfileService;
+
     @Test
     void uploadShouldRenderPreviewWithMappingsForExistingTableMode() throws Exception {
         MockMultipartFile file = new MockMultipartFile(
@@ -65,9 +69,10 @@ class UploadControllerExistingTableTest {
         List<ColumnMapping> mappings = List.of(mapping("first_name", 0, "FIRST_NAME"));
 
         when(csvParsingService.parse(any())).thenReturn(parsedCsv);
-        when(metadataService.listColumns("BIB", "PERSON")).thenReturn(dbColumns);
+        when(metadataService.listColumns("BIB", "PERSON", null)).thenReturn(dbColumns);
         when(mappingService.autoMap(any(ParsedCsv.class), anyList())).thenReturn(mappings);
         when(appProperties.getDefaultLibrary()).thenReturn("BIB");
+        when(connectionProfileService.list()).thenReturn(List.of());
 
         mockMvc.perform(multipart("/upload")
                         .file(file)

--- a/src/test/java/com/zeus/upload/it/H2CrudLifecycleIntegrationTest.java
+++ b/src/test/java/com/zeus/upload/it/H2CrudLifecycleIntegrationTest.java
@@ -1,0 +1,231 @@
+package com.zeus.upload.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.connector.db.DbTableSourceConnector;
+import com.zeus.upload.domain.ColumnMapping;
+import com.zeus.upload.domain.ColumnProposal;
+import com.zeus.upload.domain.DbColumnMeta;
+import com.zeus.upload.domain.DbTableRef;
+import com.zeus.upload.domain.ImportRequest;
+import com.zeus.upload.domain.ImportResult;
+import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.flow.DataRecord;
+import com.zeus.upload.flow.DbTableSourceConfiguration;
+import com.zeus.upload.service.ImportService;
+import com.zeus.upload.service.MetadataService;
+import com.zeus.upload.sql.SqlDialect;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * End-to-end proof that CREATE TABLE, INSERT, SELECT, UPDATE and DELETE work
+ * against the local H2 database without IBM i.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class H2CrudLifecycleIntegrationTest {
+
+    private static final String LIBRARY = "TESTLIB";
+    private static final String TABLE = "H2_CRUD_LIFECYCLE";
+
+    @Autowired
+    private ImportService importService;
+
+    @Autowired
+    private MetadataService metadataService;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private SqlDialect sqlDialect;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanTable() {
+        jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS \"TESTLIB\"");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS \"TESTLIB\".\"H2_CRUD_LIFECYCLE\"");
+    }
+
+    @Test
+    void createInsertSelectUpdateDeleteRoundTrip() {
+        // --- CREATE TABLE + INSERT ---
+        ImportRequest createRequest = new ImportRequest();
+        createRequest.setLibrary(LIBRARY);
+        createRequest.setTableName(TABLE);
+        createRequest.setDropAndRecreate(true);
+        createRequest.setColumns(List.of(
+                proposal("ID", "INTEGER", false),
+                proposal("NAME", "VARCHAR", true),
+                proposal("AMOUNT", "DECIMAL", true)
+        ));
+        createRequest.getColumns().get(2).setPrecision(10);
+        createRequest.getColumns().get(2).setScale(2);
+        createRequest.getColumns().get(1).setLength(64);
+
+        ParsedCsv insertCsv = rowsCsv(
+                List.of("id", "name", "amount"),
+                List.of(
+                        List.of("1", "Alice", "10.50"),
+                        List.of("2", "Bob", "20.00"),
+                        List.of("3", "Charlie", "30.25")
+                )
+        );
+
+        ImportResult createResult = importService.importCsv(createRequest, insertCsv);
+        assertThat(createResult.isSuccess())
+                .as("CREATE+INSERT should succeed: %s", createResult.getMessage())
+                .isTrue();
+        assertThat(createResult.getInsertedRows()).isEqualTo(3);
+        assertThat(createResult.getCreateTableSql()).containsIgnoringCase("CREATE TABLE");
+
+        Integer countAfterInsert = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM \"TESTLIB\".\"H2_CRUD_LIFECYCLE\"", Integer.class);
+        assertThat(countAfterInsert).isEqualTo(3);
+
+        // --- SELECT (source connector) ---
+        List<DataRecord> selected = new DbTableSourceConnector(
+                dataSource,
+                sqlDialect,
+                new DbTableSourceConfiguration(LIBRARY, TABLE, List.of("ID", "NAME", "AMOUNT"))
+        ).read().toList();
+
+        assertThat(selected).hasSize(3);
+        assertThat(selected.stream().map(r -> String.valueOf(r.get("NAME"))).toList())
+                .containsExactlyInAnyOrder("Alice", "Bob", "Charlie");
+
+        // --- Metadata SELECT (list tables / columns) ---
+        List<DbTableRef> tables = metadataService.listTables(LIBRARY);
+        assertThat(tables.stream().map(DbTableRef::getTableName).toList())
+                .contains(TABLE);
+
+        List<DbColumnMeta> columns = metadataService.listColumns(LIBRARY, TABLE);
+        assertThat(columns.stream().map(DbColumnMeta::getColumnName).toList())
+                .contains("ID", "NAME", "AMOUNT");
+
+        // --- UPDATE ---
+        List<DbColumnMeta> dbColumns = columns;
+        ParsedCsv updateCsv = rowsCsv(
+                List.of("id", "name"),
+                List.of(List.of("1", "Alicia"))
+        );
+        List<ColumnMapping> updateMappings = List.of(
+                mapping(0, "id", "ID"),
+                mapping(1, "name", "NAME")
+        );
+        ImportResult updateResult = importService.updateIntoExistingTable(
+                LIBRARY, TABLE, updateCsv, dbColumns, updateMappings, List.of("ID"), false);
+        assertThat(updateResult.isSuccess())
+                .as("UPDATE should succeed: %s", updateResult.getMessage())
+                .isTrue();
+
+        String updatedName = jdbcTemplate.queryForObject(
+                "SELECT \"NAME\" FROM \"TESTLIB\".\"H2_CRUD_LIFECYCLE\" WHERE \"ID\" = 1",
+                String.class);
+        assertThat(updatedName).isEqualTo("Alicia");
+
+        // --- DELETE ---
+        ParsedCsv deleteCsv = rowsCsv(List.of("id"), List.of(List.of("2")));
+        List<ColumnMapping> deleteMappings = List.of(mapping(0, "id", "ID"));
+        ImportResult deleteResult = importService.deleteFromExistingTable(
+                LIBRARY, TABLE, deleteCsv, dbColumns, deleteMappings, List.of("ID"), false);
+        assertThat(deleteResult.isSuccess())
+                .as("DELETE should succeed: %s", deleteResult.getMessage())
+                .isTrue();
+
+        Integer countAfterDelete = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM \"TESTLIB\".\"H2_CRUD_LIFECYCLE\"", Integer.class);
+        assertThat(countAfterDelete).isEqualTo(2);
+
+        Integer remainingBob = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM \"TESTLIB\".\"H2_CRUD_LIFECYCLE\" WHERE \"ID\" = 2",
+                Integer.class);
+        assertThat(remainingBob).isZero();
+
+        // --- INSERT into existing table ---
+        ParsedCsv extraInsert = rowsCsv(
+                List.of("id", "name", "amount"),
+                List.of(List.of("4", "Dana", "40.00"))
+        );
+        List<ColumnMapping> insertMappings = List.of(
+                mapping(0, "id", "ID"),
+                mapping(1, "name", "NAME"),
+                mapping(2, "amount", "AMOUNT")
+        );
+        ImportResult insertExisting = importService.importIntoExistingTable(
+                LIBRARY, TABLE, extraInsert, dbColumns, insertMappings, false);
+        assertThat(insertExisting.isSuccess())
+                .as("INSERT existing should succeed: %s", insertExisting.getMessage())
+                .isTrue();
+        assertThat(insertExisting.getInsertedRows()).isEqualTo(1);
+
+        Integer finalCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM \"TESTLIB\".\"H2_CRUD_LIFECYCLE\"", Integer.class);
+        assertThat(finalCount).isEqualTo(3);
+    }
+
+    @Test
+    void createTableAutoCreatesMissingSchemaOnH2() {
+        String library = "AUTO_SCHEMA_LIB";
+        String table = "H2_AUTO_SCHEMA";
+        // Drop only if the schema already exists (H2 rejects DROP TABLE on missing schema).
+        try {
+            jdbcTemplate.execute("DROP SCHEMA IF EXISTS \"AUTO_SCHEMA_LIB\" CASCADE");
+        } catch (Exception ignored) {
+            // ignore if dialect/version does not support this form
+        }
+
+        ImportRequest request = new ImportRequest();
+        request.setLibrary(library);
+        request.setTableName(table);
+        request.setColumns(List.of(proposal("ID", "INTEGER", false), proposal("LABEL", "VARCHAR", true)));
+        request.getColumns().get(1).setLength(32);
+
+        ParsedCsv csv = rowsCsv(List.of("id", "label"), List.of(List.of("1", "ok")));
+        ImportResult result = importService.importCsv(request, csv);
+
+        assertThat(result.isSuccess())
+                .as("Schema auto-create + CREATE TABLE should work: %s", result.getMessage())
+                .isTrue();
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM \"AUTO_SCHEMA_LIB\".\"H2_AUTO_SCHEMA\"", Integer.class);
+        assertThat(count).isEqualTo(1);
+    }
+
+    private static ColumnProposal proposal(String name, String sqlType, boolean nullable) {
+        ColumnProposal proposal = new ColumnProposal();
+        proposal.setIndex(0);
+        proposal.setOriginalName(name);
+        proposal.setSanitizedName(name);
+        proposal.setFinalName(name);
+        proposal.setDetectedType(sqlType);
+        proposal.setSqlType(sqlType);
+        proposal.setNullable(nullable);
+        return proposal;
+    }
+
+    private static ParsedCsv rowsCsv(List<String> headers, List<List<String>> rows) {
+        ParsedCsv csv = new ParsedCsv();
+        csv.getOriginalHeaders().addAll(headers);
+        csv.getRows().addAll(rows);
+        return csv;
+    }
+
+    private static ColumnMapping mapping(int csvIndex, String csvColumn, String targetColumn) {
+        ColumnMapping mapping = new ColumnMapping();
+        mapping.setCsvIndex(csvIndex);
+        mapping.setCsvColumn(csvColumn);
+        mapping.setTargetColumn(targetColumn);
+        mapping.setIgnored(false);
+        return mapping;
+    }
+}

--- a/src/test/java/com/zeus/upload/it/NamedConnectionProfileIntegrationTest.java
+++ b/src/test/java/com/zeus/upload/it/NamedConnectionProfileIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.zeus.upload.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.domain.ColumnProposal;
+import com.zeus.upload.domain.ConnectionProfileRequest;
+import com.zeus.upload.domain.ConnectionType;
+import com.zeus.upload.domain.ImportRequest;
+import com.zeus.upload.domain.ImportResult;
+import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.service.ConnectionProfileService;
+import com.zeus.upload.service.ImportService;
+import com.zeus.upload.service.MetadataService;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Verifies imports can target a named connection profile (separate H2 URL)
+ * while the bootstrap DataSource remains the default Spring pool.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class NamedConnectionProfileIntegrationTest {
+
+    private static final String PROFILE = "h2-named-it";
+    private static final String NAMED_URL =
+            "jdbc:h2:mem:zeus_named_profile_it;MODE=DB2;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=true";
+
+    @Autowired
+    private ConnectionProfileService connectionProfileService;
+
+    @Autowired
+    private ImportService importService;
+
+    @Autowired
+    private MetadataService metadataService;
+
+    @Test
+    void importUsesNamedConnectionProfileNotOnlyBootstrap() throws Exception {
+        ConnectionProfileRequest request = new ConnectionProfileRequest();
+        request.setName(PROFILE);
+        request.setType(ConnectionType.DB2_400);
+        request.setEndpoint(NAMED_URL);
+        request.setDescription("integration named H2");
+        request.setCredentials(Map.of("username", "sa", "secret", ""));
+        connectionProfileService.save(request);
+
+        ImportRequest importRequest = new ImportRequest();
+        importRequest.setLibrary("NAMEDLIB");
+        importRequest.setTableName("NAMED_IMPORT");
+        importRequest.setConnectionProfileName(PROFILE);
+        importRequest.setDropAndRecreate(true);
+        importRequest.setColumns(List.of(
+                proposal("ID", "INTEGER"),
+                proposal("NAME", "VARCHAR")
+        ));
+        importRequest.getColumns().get(1).setLength(64);
+
+        ParsedCsv csv = new ParsedCsv();
+        csv.getOriginalHeaders().addAll(List.of("id", "name"));
+        csv.getRows().add(List.of("1", "Named"));
+
+        ImportResult result = importService.importCsv(importRequest, csv);
+        assertThat(result.isSuccess()).as(result.getMessage()).isTrue();
+        assertThat(result.getInsertedRows()).isEqualTo(1);
+
+        // Data must exist on the named DB, not only conceptually.
+        DriverManagerDataSource namedDs = new DriverManagerDataSource();
+        namedDs.setUrl(NAMED_URL);
+        namedDs.setUsername("sa");
+        namedDs.setPassword("");
+        namedDs.setDriverClassName("org.h2.Driver");
+        JdbcTemplate namedJdbc = new JdbcTemplate(namedDs);
+        Integer count = namedJdbc.queryForObject(
+                "SELECT COUNT(*) FROM \"NAMEDLIB\".\"NAMED_IMPORT\"", Integer.class);
+        assertThat(count).isEqualTo(1);
+
+        assertThat(metadataService.listTables("NAMEDLIB", PROFILE).stream()
+                .map(ref -> ref.getTableName()).toList())
+                .contains("NAMED_IMPORT");
+    }
+
+    private static ColumnProposal proposal(String name, String type) {
+        ColumnProposal p = new ColumnProposal();
+        p.setIndex(0);
+        p.setOriginalName(name);
+        p.setSanitizedName(name);
+        p.setFinalName(name);
+        p.setSqlType(type);
+        p.setDetectedType(type);
+        p.setNullable(true);
+        return p;
+    }
+}

--- a/src/test/java/com/zeus/upload/service/ConnectionDataSourceFactoryTest.java
+++ b/src/test/java/com/zeus/upload/service/ConnectionDataSourceFactoryTest.java
@@ -1,0 +1,44 @@
+package com.zeus.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.zeus.upload.domain.ConnectionProfile;
+import com.zeus.upload.domain.ConnectionType;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+class ConnectionDataSourceFactoryTest {
+
+    private final ConnectionDataSourceFactory factory = new ConnectionDataSourceFactory();
+
+    @Test
+    void buildsJdbcDataSourceFromProfileCredentials() {
+        ConnectionProfile profile = new ConnectionProfile(
+                "h2-local", ConnectionType.DB2_400, "jdbc:h2:mem:factory_test", null, true, null);
+        DriverManagerDataSource ds = (DriverManagerDataSource) factory.create(
+                profile, Map.of("username", "sa", "secret", ""));
+
+        assertThat(ds.getUrl()).isEqualTo("jdbc:h2:mem:factory_test");
+        assertThat(ds.getUsername()).isEqualTo("sa");
+        assertThat(ConnectionDataSourceFactory.resolveDriverClass(ds.getUrl())).isEqualTo("org.h2.Driver");
+    }
+
+    @Test
+    void rejectsRestProfiles() {
+        ConnectionProfile profile = new ConnectionProfile(
+                "api", ConnectionType.REST, "https://example.com", null, true, null);
+        assertThatThrownBy(() -> factory.create(profile, Map.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("REST");
+    }
+
+    @Test
+    void resolvesDriversFromUrl() {
+        assertThat(ConnectionDataSourceFactory.resolveDriverClass("jdbc:as400://h/l"))
+                .isEqualTo("com.ibm.as400.access.AS400JDBCDriver");
+        assertThat(ConnectionDataSourceFactory.resolveDriverClass("jdbc:postgresql://h/db"))
+                .isEqualTo("org.postgresql.Driver");
+    }
+}

--- a/src/test/java/com/zeus/upload/sql/Db2iDialectTest.java
+++ b/src/test/java/com/zeus/upload/sql/Db2iDialectTest.java
@@ -1,0 +1,52 @@
+package com.zeus.upload.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class Db2iDialectTest {
+
+    private final Db2iDialect dialect = new Db2iDialect();
+
+    @Test
+    void productAndPolicy() {
+        assertThat(dialect.product()).isEqualTo(DatabaseProduct.DB2_I);
+        assertThat(dialect.identifierPolicy().maxLength()).isEqualTo(10);
+        assertThat(dialect.supportsSchemaAutoCreate()).isFalse();
+        assertThat(dialect.createSchemaSql("BIB")).isNull();
+        assertThat(dialect.upsertStrategy()).isEqualTo(UpsertStrategy.DB2_MERGE_VALUES);
+    }
+
+    @Test
+    void qualifiesLibraryAndTable() {
+        assertThat(dialect.qualifyTable("bib", "person")).isEqualTo("\"BIB\".\"PERSON\"");
+    }
+
+    @Test
+    void columnTypesMatchHistoricDb2Limits() {
+        assertThat(dialect.columnTypeDefinition("DECIMAL", null, 40, 2)).isEqualTo("DECIMAL(31,2)");
+        assertThat(dialect.columnTypeDefinition("VARCHAR", 9000, null, null)).isEqualTo("VARCHAR(4000)");
+        assertThat(dialect.columnTypeDefinition("INTEGER", null, null, null)).isEqualTo("INTEGER");
+    }
+
+    @Test
+    void upsertBuildsStableDb2MergeSql() {
+        UpsertSql upsert = dialect.buildUpsertSql(
+                "bib",
+                "orders",
+                List.of("ID", "NAME", "AMOUNT"),
+                List.of("NAME", "AMOUNT"),
+                List.of("ID")
+        );
+
+        assertThat(upsert.strategy()).isEqualTo(UpsertStrategy.DB2_MERGE_VALUES);
+        assertThat(upsert.sql()).isEqualTo(
+                "MERGE INTO \"BIB\".\"ORDERS\" AS T "
+                        + "USING (VALUES (?, ?, ?)) AS S(\"ID\", \"NAME\", \"AMOUNT\") "
+                        + "ON (T.\"ID\" = S.\"ID\") "
+                        + "WHEN MATCHED THEN UPDATE SET T.\"NAME\" = S.\"NAME\", T.\"AMOUNT\" = S.\"AMOUNT\" "
+                        + "WHEN NOT MATCHED THEN INSERT (\"ID\", \"NAME\", \"AMOUNT\") VALUES (S.\"ID\", S.\"NAME\", S.\"AMOUNT\")"
+        );
+    }
+}

--- a/src/test/java/com/zeus/upload/sql/H2DialectTest.java
+++ b/src/test/java/com/zeus/upload/sql/H2DialectTest.java
@@ -1,0 +1,44 @@
+package com.zeus.upload.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class H2DialectTest {
+
+    private final H2Dialect dialect = new H2Dialect();
+
+    @Test
+    void quotesAndQualifiesIdentifiers() {
+        assertThat(dialect.product()).isEqualTo(DatabaseProduct.H2);
+        assertThat(dialect.quoteIdentifier("testlib")).isEqualTo("\"TESTLIB\"");
+        assertThat(dialect.qualifyTable("testlib", "my_table")).isEqualTo("\"TESTLIB\".\"MY_TABLE\"");
+    }
+
+    @Test
+    void supportsSchemaAutoCreate() {
+        assertThat(dialect.supportsSchemaAutoCreate()).isTrue();
+        assertThat(dialect.createSchemaSql("testlib")).isEqualTo("CREATE SCHEMA IF NOT EXISTS \"TESTLIB\"");
+    }
+
+    @Test
+    void upsertIsFailClosed() {
+        assertThat(dialect.upsertStrategy()).isEqualTo(UpsertStrategy.UNSUPPORTED);
+        assertThatThrownBy(() -> dialect.buildUpsertSql(
+                "TESTLIB", "T", List.of("ID", "NAME"), List.of("NAME"), List.of("ID")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("H2");
+    }
+
+    @Test
+    void portableDmlBuilders() {
+        assertThat(dialect.buildInsertSql("lib", "t", List.of("A", "B")))
+                .isEqualTo("INSERT INTO \"LIB\".\"T\" (\"A\", \"B\") VALUES (?, ?)");
+        assertThat(dialect.buildUpdateSql("lib", "t", List.of("NAME"), List.of("ID")))
+                .isEqualTo("UPDATE \"LIB\".\"T\" SET \"NAME\" = ? WHERE \"ID\" = ?");
+        assertThat(dialect.buildDeleteSql("lib", "t", List.of("ID")))
+                .isEqualTo("DELETE FROM \"LIB\".\"T\" WHERE \"ID\" = ?");
+    }
+}

--- a/src/test/java/com/zeus/upload/sql/PostgresDialectTest.java
+++ b/src/test/java/com/zeus/upload/sql/PostgresDialectTest.java
@@ -1,0 +1,35 @@
+package com.zeus.upload.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PostgresDialectTest {
+
+    private final PostgresDialect dialect = new PostgresDialect();
+
+    @Test
+    void productAndPolicy() {
+        assertThat(dialect.product()).isEqualTo(DatabaseProduct.POSTGRES);
+        assertThat(dialect.identifierPolicy().maxLength()).isEqualTo(63);
+        assertThat(dialect.supportsSchemaAutoCreate()).isTrue();
+        assertThat(dialect.upsertStrategy()).isEqualTo(UpsertStrategy.POSTGRES_ON_CONFLICT);
+    }
+
+    @Test
+    void upsertUsesOnConflict() {
+        UpsertSql upsert = dialect.buildUpsertSql(
+                "public",
+                "orders",
+                List.of("ID", "NAME"),
+                List.of("NAME"),
+                List.of("ID")
+        );
+        assertThat(upsert.strategy()).isEqualTo(UpsertStrategy.POSTGRES_ON_CONFLICT);
+        assertThat(upsert.sql()).isEqualTo(
+                "INSERT INTO \"PUBLIC\".\"ORDERS\" (\"ID\", \"NAME\") VALUES (?, ?) "
+                        + "ON CONFLICT (\"ID\") DO UPDATE SET \"NAME\" = EXCLUDED.\"NAME\""
+        );
+    }
+}

--- a/src/test/java/com/zeus/upload/sql/SqlDialectRegistryTest.java
+++ b/src/test/java/com/zeus/upload/sql/SqlDialectRegistryTest.java
@@ -1,0 +1,34 @@
+package com.zeus.upload.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.domain.ConnectionType;
+import org.junit.jupiter.api.Test;
+
+class SqlDialectRegistryTest {
+
+    private final SqlDialectRegistry registry = SqlDialectRegistry.createDefault();
+
+    @Test
+    void detectsProductsFromJdbcUrl() {
+        assertThat(SqlDialectRegistry.detectProduct("jdbc:as400://host/LIB;translate binary=true"))
+                .isEqualTo(DatabaseProduct.DB2_I);
+        assertThat(SqlDialectRegistry.detectProduct("jdbc:h2:mem:test;MODE=DB2"))
+                .isEqualTo(DatabaseProduct.H2);
+        assertThat(SqlDialectRegistry.detectProduct("jdbc:postgresql://localhost:5432/app"))
+                .isEqualTo(DatabaseProduct.POSTGRES);
+        assertThat(SqlDialectRegistry.detectProduct("jdbc:mysql://localhost/db"))
+                .isEqualTo(DatabaseProduct.GENERIC_JDBC);
+        assertThat(SqlDialectRegistry.detectProduct(null))
+                .isEqualTo(DatabaseProduct.GENERIC_JDBC);
+    }
+
+    @Test
+    void resolvesDialects() {
+        assertThat(registry.resolveFromJdbcUrl("jdbc:as400://x/y").product()).isEqualTo(DatabaseProduct.DB2_I);
+        assertThat(registry.resolveFromJdbcUrl("jdbc:h2:file:./.local/h2/zeus").product()).isEqualTo(DatabaseProduct.H2);
+        assertThat(registry.resolveFromJdbcUrl("jdbc:postgresql://x/y").product()).isEqualTo(DatabaseProduct.POSTGRES);
+        assertThat(registry.resolveFromConnectionType(ConnectionType.DB2_400).product()).isEqualTo(DatabaseProduct.DB2_I);
+        assertThat(registry.resolveFromConnectionType(ConnectionType.REST).product()).isEqualTo(DatabaseProduct.GENERIC_JDBC);
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:zeus_easy_upload_test;MODE=DB2;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=true
+    url: jdbc:h2:mem:zeus_easy_upload_test;MODE=DB2;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=true;DEFAULT_NULL_ORDERING=HIGH
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -9,5 +9,7 @@ spring:
       mode: never
 
 app:
+  default-library: TESTLIB
   connection-profile-directory: ${java.io.tmpdir}/zeus-test-connections
+  # Test-only dummy key (not a production secret).
   connection-master-key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=


### PR DESCRIPTION
## Summary
- Local H2 development profile (`mvn -Plocal`) with gitignored `.local/` data and env-based secrets hygiene
- Expanded `SqlDialect` layer (DB2 i, H2, Postgres scaffold, registry) without Hibernate/ORM
- Per-connection `DbSession` for named JDBC connection profiles on import, metadata, and DB sources
- Integration tests for H2 CRUD lifecycle and named connection profiles

## Test plan
- [x] `mvn test` (85 tests, 0 failures, 1 skipped)
- [ ] CI green on PR
- [ ] Optional: `mvn -Plocal spring-boot:run` and import via default + named H2 profile
