### PR TITLE
Add connection profile JDBC connectivity test

### DIFF
--- a/docs/architecture/connection-profiles.md
+++ b/docs/architecture/connection-profiles.md
@@ -33,6 +33,7 @@ must be backed up and rotated through an explicit migration process.
 - `GET /api/connections/{name}` — load metadata without secrets
 - `POST /api/connections` — validate and save a profile
 - `DELETE /api/connections/{name}` — delete a profile
+- `POST /api/connections/{name}/test` — JDBC connectivity test (no secrets in response)
 
 An empty credential field in the GUI preserves an existing encrypted secret.
 Endpoint URLs must not contain embedded credentials or URI fragments. JDBC

--- a/src/main/java/com/zeus/upload/controller/ConnectionProfileController.java
+++ b/src/main/java/com/zeus/upload/controller/ConnectionProfileController.java
@@ -2,8 +2,10 @@ package com.zeus.upload.controller;
 
 import com.zeus.upload.domain.ConnectionProfile;
 import com.zeus.upload.domain.ConnectionProfileRequest;
+import com.zeus.upload.domain.ConnectionTestResult;
 import com.zeus.upload.service.ConnectionCryptoService;
 import com.zeus.upload.service.ConnectionProfileService;
+import com.zeus.upload.service.ConnectionTestService;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.List;
@@ -24,10 +26,16 @@ public class ConnectionProfileController {
 
     private final ConnectionProfileService profileService;
     private final ConnectionCryptoService cryptoService;
+    private final ConnectionTestService connectionTestService;
 
-    public ConnectionProfileController(ConnectionProfileService profileService, ConnectionCryptoService cryptoService) {
+    public ConnectionProfileController(
+            ConnectionProfileService profileService,
+            ConnectionCryptoService cryptoService,
+            ConnectionTestService connectionTestService
+    ) {
         this.profileService = profileService;
         this.cryptoService = cryptoService;
+        this.connectionTestService = connectionTestService;
     }
 
     @GetMapping
@@ -61,5 +69,17 @@ public class ConnectionProfileController {
     public ResponseEntity<Void> delete(@PathVariable String name) throws IOException {
         profileService.delete(name);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Connectivity check for a saved profile. Secrets are never returned.
+     */
+    @PostMapping("/{name}/test")
+    public ConnectionTestResult test(@PathVariable String name) {
+        ConnectionTestResult result = connectionTestService.test(name);
+        if (!result.isSuccess() && "Connection profile not found.".equals(result.getMessage())) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, result.getMessage());
+        }
+        return result;
     }
 }

--- a/src/main/java/com/zeus/upload/domain/ConnectionTestResult.java
+++ b/src/main/java/com/zeus/upload/domain/ConnectionTestResult.java
@@ -1,0 +1,66 @@
+package com.zeus.upload.domain;
+
+import com.zeus.upload.sql.DatabaseProduct;
+
+/**
+ * Result of a connection profile connectivity test. Never contains secrets.
+ */
+public class ConnectionTestResult {
+
+    private final boolean success;
+    private final String connectionName;
+    private final ConnectionType type;
+    private final DatabaseProduct product;
+    private final String message;
+    private final String databaseProductName;
+    private final long durationMs;
+
+    public ConnectionTestResult(
+            boolean success,
+            String connectionName,
+            ConnectionType type,
+            DatabaseProduct product,
+            String message,
+            String databaseProductName,
+            long durationMs
+    ) {
+        this.success = success;
+        this.connectionName = connectionName;
+        this.type = type;
+        this.product = product;
+        this.message = message;
+        this.databaseProductName = databaseProductName;
+        this.durationMs = durationMs;
+    }
+
+    public static ConnectionTestResult ok(
+            String name,
+            ConnectionType type,
+            DatabaseProduct product,
+            String databaseProductName,
+            long durationMs
+    ) {
+        return new ConnectionTestResult(
+                true, name, type, product,
+                "Connection successful.",
+                databaseProductName, durationMs);
+    }
+
+    public static ConnectionTestResult failure(
+            String name,
+            ConnectionType type,
+            DatabaseProduct product,
+            String message,
+            long durationMs
+    ) {
+        return new ConnectionTestResult(false, name, type, product, message, null, durationMs);
+    }
+
+    public boolean isSuccess() { return success; }
+    public String getConnectionName() { return connectionName; }
+    public ConnectionType getType() { return type; }
+    public DatabaseProduct getProduct() { return product; }
+    public String getMessage() { return message; }
+    public String getDatabaseProductName() { return databaseProductName; }
+    public long getDurationMs() { return durationMs; }
+}

--- a/src/main/java/com/zeus/upload/service/ConnectionTestService.java
+++ b/src/main/java/com/zeus/upload/service/ConnectionTestService.java
@@ -1,0 +1,101 @@
+package com.zeus.upload.service;
+
+import com.zeus.upload.domain.ConnectionProfile;
+import com.zeus.upload.domain.ConnectionTestResult;
+import com.zeus.upload.domain.ConnectionType;
+import com.zeus.upload.sql.DatabaseProduct;
+import com.zeus.upload.sql.SqlDialectRegistry;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Tests named connection profiles without returning secrets.
+ */
+@Service
+public class ConnectionTestService {
+
+    private static final Logger log = LoggerFactory.getLogger(ConnectionTestService.class);
+
+    private final ConnectionProfileService profileService;
+    private final DbSessionFactory dbSessionFactory;
+
+    public ConnectionTestService(ConnectionProfileService profileService, DbSessionFactory dbSessionFactory) {
+        this.profileService = profileService;
+        this.dbSessionFactory = dbSessionFactory;
+    }
+
+    public ConnectionTestResult test(String connectionName) {
+        long started = System.currentTimeMillis();
+        try {
+            ConnectionProfile profile = profileService.load(connectionName);
+            if (profile.getType() == ConnectionType.REST) {
+                return ConnectionTestResult.failure(
+                        profile.getName(),
+                        ConnectionType.REST,
+                        DatabaseProduct.GENERIC_JDBC,
+                        "REST connection tests are not implemented yet. Use a JDBC/DB2 profile.",
+                        System.currentTimeMillis() - started
+                );
+            }
+
+            DatabaseProduct product = SqlDialectRegistry.detectProduct(profile.getEndpoint());
+            if (product == DatabaseProduct.GENERIC_JDBC && profile.getType() == ConnectionType.DB2_400) {
+                product = DatabaseProduct.DB2_I;
+            }
+
+            try (DbSession session = dbSessionFactory.open(profile.getName());
+                 Connection connection = session.dataSource().getConnection()) {
+                DatabaseMetaData meta = connection.getMetaData();
+                String productName = safe(meta.getDatabaseProductName()) + " " + safe(meta.getDatabaseProductVersion());
+                boolean valid = connection.isValid(5);
+                long duration = System.currentTimeMillis() - started;
+                if (!valid) {
+                    return ConnectionTestResult.failure(
+                            profile.getName(), profile.getType(), session.product(),
+                            "Driver reported connection as not valid.", duration);
+                }
+                log.info("Connection test OK for profile '{}' product={}", profile.getName(), session.product());
+                return ConnectionTestResult.ok(
+                        profile.getName(), profile.getType(), session.product(), productName.trim(), duration);
+            }
+        } catch (NoSuchFileException ex) {
+            return ConnectionTestResult.failure(
+                    connectionName, null, null, "Connection profile not found.", System.currentTimeMillis() - started);
+        } catch (IOException ex) {
+            return ConnectionTestResult.failure(
+                    connectionName, null, null,
+                    "Could not load connection profile: " + sanitize(ex.getMessage()),
+                    System.currentTimeMillis() - started);
+        } catch (Exception ex) {
+            log.warn("Connection test failed for profile '{}': {}", connectionName, sanitize(ex.getMessage()));
+            return ConnectionTestResult.failure(
+                    connectionName, null, null,
+                    "Connection failed: " + sanitize(ex.getMessage()),
+                    System.currentTimeMillis() - started);
+        }
+    }
+
+    private static String safe(String value) {
+        return value == null ? "" : value;
+    }
+
+    /** Strip likely credential fragments from driver error messages. */
+    static String sanitize(String message) {
+        if (message == null || message.isBlank()) {
+            return "unknown error";
+        }
+        String cleaned = message
+                .replaceAll("(?i)password\\s*=\\s*[^;\\s]+", "password=***")
+                .replaceAll("(?i)pwd\\s*=\\s*[^;\\s]+", "pwd=***")
+                .replaceAll("(?i)user(?:name)?\\s*=\\s*[^;\\s]+", "user=***");
+        if (cleaned.length() > 400) {
+            cleaned = cleaned.substring(0, 400) + "…";
+        }
+        return cleaned;
+    }
+}

--- a/src/main/resources/static/js/connections.js
+++ b/src/main/resources/static/js/connections.js
@@ -3,6 +3,7 @@
     const list = document.getElementById('connectionList');
     const status = document.getElementById('connectionStatus');
     const newButton = document.getElementById('newConnection');
+    const testButton = document.getElementById('testConnection');
     const fields = {
         name: document.getElementById('connectionName'),
         type: document.getElementById('connectionType'),
@@ -80,6 +81,36 @@
             await loadProfiles();
         } catch (error) { showStatus(error.message, 'danger'); }
     });
+
+    if (testButton) {
+        testButton.addEventListener('click', async () => {
+            const name = fields.name.value.trim();
+            if (!name) {
+                showStatus('Bitte zuerst ein gespeichertes Profil laden oder den Namen angeben.', 'warning');
+                return;
+            }
+            showStatus('Verbindung wird getestet …', 'info');
+            try {
+                const response = await fetch(`/api/connections/${encodeURIComponent(name)}/test`, { method: 'POST' });
+                const body = await response.json().catch(() => ({}));
+                if (response.status === 404) {
+                    showStatus('Profil nicht gefunden. Bitte zuerst speichern.', 'warning');
+                    return;
+                }
+                if (!response.ok) {
+                    throw new Error(body.message || `Test fehlgeschlagen (${response.status})`);
+                }
+                if (body.success) {
+                    const product = body.databaseProductName ? ` (${body.databaseProductName})` : '';
+                    showStatus(`OK: ${body.message}${product} — ${body.durationMs} ms`, 'success');
+                } else {
+                    showStatus(body.message || 'Verbindungstest fehlgeschlagen.', 'danger');
+                }
+            } catch (error) {
+                showStatus(error.message, 'danger');
+            }
+        });
+    }
 
     newButton.addEventListener('click', resetForm);
     loadProfiles().catch(error => showStatus(error.message, 'danger'));

--- a/src/main/resources/templates/connections.html
+++ b/src/main/resources/templates/connections.html
@@ -75,7 +75,8 @@
                                 <div class="form-text">Leer lassen, um das bestehende Secret beizubehalten.</div>
                             </div>
                         </div>
-                        <div class="d-flex justify-content-end mt-4">
+                        <div class="d-flex justify-content-end gap-2 mt-4">
+                            <button id="testConnection" type="button" class="btn btn-outline-primary">Verbindung testen</button>
                             <button id="saveConnection" type="submit" class="btn btn-primary" th:disabled="${!encryptionConfigured}">Verschlüsselt speichern</button>
                         </div>
                     </form>

--- a/src/test/java/com/zeus/upload/service/ConnectionTestServiceTest.java
+++ b/src/test/java/com/zeus/upload/service/ConnectionTestServiceTest.java
@@ -1,0 +1,52 @@
+package com.zeus.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zeus.upload.domain.ConnectionProfileRequest;
+import com.zeus.upload.domain.ConnectionTestResult;
+import com.zeus.upload.domain.ConnectionType;
+import com.zeus.upload.sql.SqlDialectRegistry;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+class ConnectionTestServiceTest {
+
+    private static final String MASTER_KEY = Base64.getEncoder().encodeToString(new byte[32]);
+
+    @Test
+    void testsNamedH2JdbcProfileSuccessfully() throws Exception {
+        var directory = Files.createTempDirectory("zeus-conn-test");
+        var crypto = new ConnectionCryptoService(new ObjectMapper(), MASTER_KEY);
+        var profiles = new ConnectionProfileService(new ObjectMapper(), directory, crypto);
+        String url = "jdbc:h2:mem:conn_test_svc;MODE=DB2;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=true";
+        var request = new ConnectionProfileRequest();
+        request.setName("h2-test");
+        request.setType(ConnectionType.DB2_400);
+        request.setEndpoint(url);
+        request.setCredentials(Map.of("username", "sa", "secret", ""));
+        profiles.save(request);
+
+        DataSource bootstrap = new DriverManagerDataSource(url, "sa", "");
+        var dialect = SqlDialectRegistry.createDefault().resolveFromJdbcUrl(url);
+        var sessions = new DbSessionFactory(
+                bootstrap, dialect, profiles, new ConnectionDataSourceFactory(), SqlDialectRegistry.createDefault());
+        var service = new ConnectionTestService(profiles, sessions);
+
+        ConnectionTestResult result = service.test("h2-test");
+        assertThat(result.isSuccess()).as(result.getMessage()).isTrue();
+        assertThat(result.getDurationMs()).isGreaterThanOrEqualTo(0);
+        assertThat(result.getDatabaseProductName()).containsIgnoringCase("H2");
+    }
+
+    @Test
+    void sanitizeMasksPasswordFragments() {
+        assertThat(ConnectionTestService.sanitize("login failed password=supersecret user=admin"))
+                .doesNotContain("supersecret")
+                .contains("password=***");
+    }
+}


### PR DESCRIPTION
## Summary
- `POST /api/connections/{name}/test` validates JDBC profiles via `DbSession`
- GUI button **Verbindung testen** on `/connections`
- Error messages sanitized (no password fragments); secrets never returned

## Test plan
- [x] `mvn test` (87 tests, 0 failures)
- [ ] CI green