### PR TITLE
Add Hikari connection pool cache per profile

### DIFF
--- a/docs/architecture/connection-profiles.md
+++ b/docs/architecture/connection-profiles.md
@@ -77,9 +77,20 @@ Import, metadata and DB source connectors accept an optional
 Resolution flow:
 
 1. Blank name → Spring bootstrap `DataSource` + default `SqlDialect`
-2. Named profile → decrypt credentials → `ConnectionDataSourceFactory`
-   → `DriverManagerDataSource` → dialect from JDBC URL (fallback connection type)
+2. Named profile → decrypt credentials → `ConnectionPoolCache.getOrCreate`
+   → small **Hikari** pool (max 5) keyed by profile fingerprint
+   → dialect from JDBC URL (fallback connection type)
 3. REST profiles are rejected for JDBC operations
+
+### Pool cache
+
+- `ConnectionPoolCache` reuses pools across import/metadata/test operations
+- Fingerprint = SHA-256 of name, type, endpoint, `updatedAt`, and credentials
+  (digest only — secrets are not stored in the cache key text)
+- Save/delete of a profile invalidates that pool immediately
+- Fingerprint mismatch recreates and closes the previous pool
+- App shutdown (`@PreDestroy`) closes all cached pools
+- Session close does **not** close the shared pool
 
 Credential keys accepted: `username`/`user`, `password`/`secret`. Secrets are
 never logged, never returned by the API and never stored on `ImportRequest`.

--- a/docs/architecture/sql-dialects.md
+++ b/docs/architecture/sql-dialects.md
@@ -29,6 +29,7 @@ IBM i remains **first-class**. Local development and CI use H2 (`local` / `test`
 - `SqlDialectRegistry` for product resolution
 - `DbSessionFactory` opens a `DbSession` (DataSource + dialect) for either
   the bootstrap DS or a named JDBC connection profile
+- Named profiles use `ConnectionPoolCache` (Hikari pools, fingerprint invalidation)
 - `ImportService`, `JdbcMetadataService` and DB source connectors use sessions
 
 Per-connection details: [connection-profiles.md](connection-profiles.md).

--- a/src/main/java/com/zeus/upload/service/ConnectionDataSourceFactory.java
+++ b/src/main/java/com/zeus/upload/service/ConnectionDataSourceFactory.java
@@ -4,6 +4,8 @@ import com.zeus.upload.domain.ConnectionProfile;
 import com.zeus.upload.domain.ConnectionType;
 import com.zeus.upload.sql.DatabaseProduct;
 import com.zeus.upload.sql.SqlDialectRegistry;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -13,13 +15,65 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 /**
- * Builds a non-pooled {@link DataSource} from a connection profile endpoint and
+ * Builds JDBC {@link DataSource} instances from a connection profile endpoint and
  * decrypted credentials. Never logs secrets.
  */
 @Component
 public class ConnectionDataSourceFactory {
 
+    /** Small pools per profile — enough for concurrent jobs without holding many idle connections. */
+    static final int MAX_POOL_SIZE = 5;
+    static final int MIN_IDLE = 0;
+    static final long IDLE_TIMEOUT_MS = 60_000L;
+    static final long MAX_LIFETIME_MS = 300_000L;
+    static final long CONNECTION_TIMEOUT_MS = 15_000L;
+
+    /**
+     * Unpooled DataSource (tests / one-shot use). Prefer {@link #createPooled} for runtime.
+     */
     public DataSource create(ConnectionProfile profile, Map<String, String> credentials) {
+        ResolvedJdbc target = resolve(profile, credentials);
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setUrl(target.url());
+        if (target.username() != null) {
+            dataSource.setUsername(target.username());
+        }
+        if (target.password() != null) {
+            dataSource.setPassword(target.password());
+        }
+        if (target.driverClassName() != null) {
+            dataSource.setDriverClassName(target.driverClassName());
+        }
+        return dataSource;
+    }
+
+    /**
+     * Hikari pool for named profiles. Caller owns lifecycle (via {@link ConnectionPoolCache}).
+     */
+    public HikariDataSource createPooled(ConnectionProfile profile, Map<String, String> credentials) {
+        ResolvedJdbc target = resolve(profile, credentials);
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(target.url());
+        if (target.username() != null) {
+            config.setUsername(target.username());
+        }
+        if (target.password() != null) {
+            config.setPassword(target.password());
+        }
+        if (target.driverClassName() != null) {
+            config.setDriverClassName(target.driverClassName());
+        }
+        config.setPoolName("zeus-profile-" + sanitizePoolName(profile.getName()));
+        config.setMaximumPoolSize(MAX_POOL_SIZE);
+        config.setMinimumIdle(MIN_IDLE);
+        config.setIdleTimeout(IDLE_TIMEOUT_MS);
+        config.setMaxLifetime(MAX_LIFETIME_MS);
+        config.setConnectionTimeout(CONNECTION_TIMEOUT_MS);
+        config.setInitializationFailTimeout(-1);
+        return new HikariDataSource(config);
+    }
+
+    private ResolvedJdbc resolve(ConnectionProfile profile, Map<String, String> credentials) {
         Objects.requireNonNull(profile, "profile");
         if (profile.getType() == ConnectionType.REST) {
             throw new IllegalArgumentException(
@@ -34,21 +88,7 @@ public class ConnectionDataSourceFactory {
         Map<String, String> creds = credentials == null ? Map.of() : credentials;
         String username = firstNonBlank(creds, "username", "user");
         String password = firstNonBlank(creds, "password", "secret");
-
-        DriverManagerDataSource dataSource = new DriverManagerDataSource();
-        dataSource.setUrl(url);
-        if (username != null) {
-            dataSource.setUsername(username);
-        }
-        if (password != null) {
-            dataSource.setPassword(password);
-        }
-
-        String driver = resolveDriverClass(url);
-        if (driver != null) {
-            dataSource.setDriverClassName(driver);
-        }
-        return dataSource;
+        return new ResolvedJdbc(url, username, password, resolveDriverClass(url));
     }
 
     static String resolveDriverClass(String jdbcUrl) {
@@ -61,6 +101,13 @@ public class ConnectionDataSourceFactory {
         };
     }
 
+    private static String sanitizePoolName(String name) {
+        if (!StringUtils.hasText(name)) {
+            return "unknown";
+        }
+        return name.replaceAll("[^A-Za-z0-9_-]", "_");
+    }
+
     private static String firstNonBlank(Map<String, String> map, String... keys) {
         for (String key : keys) {
             String value = map.get(key);
@@ -69,5 +116,8 @@ public class ConnectionDataSourceFactory {
             }
         }
         return null;
+    }
+
+    private record ResolvedJdbc(String url, String username, String password, String driverClassName) {
     }
 }

--- a/src/main/java/com/zeus/upload/service/ConnectionPoolCache.java
+++ b/src/main/java/com/zeus/upload/service/ConnectionPoolCache.java
@@ -1,0 +1,152 @@
+package com.zeus.upload.service;
+
+import com.zeus.upload.domain.ConnectionProfile;
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.annotation.PreDestroy;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Caches small Hikari connection pools per JDBC connection profile.
+ * Pools are reused across import/metadata operations and recreated when the
+ * profile fingerprint (endpoint/type/updatedAt/credentials) changes.
+ * Never logs credentials.
+ */
+@Service
+public class ConnectionPoolCache {
+
+    private static final Logger log = LoggerFactory.getLogger(ConnectionPoolCache.class);
+
+    private final ConnectionDataSourceFactory dataSourceFactory;
+    private final ConcurrentHashMap<String, CachedPool> pools = new ConcurrentHashMap<>();
+
+    public ConnectionPoolCache(ConnectionDataSourceFactory dataSourceFactory) {
+        this.dataSourceFactory = Objects.requireNonNull(dataSourceFactory);
+    }
+
+    /**
+     * Return a pooled DataSource for the profile. Thread-safe; may create a new pool
+     * when the fingerprint differs from the cached entry.
+     */
+    public DataSource getOrCreate(ConnectionProfile profile, Map<String, String> credentials) {
+        Objects.requireNonNull(profile, "profile");
+        String name = profile.getName();
+        if (!StringUtils.hasText(name)) {
+            throw new IllegalArgumentException("Connection profile name must not be blank");
+        }
+        String fingerprint = fingerprint(profile, credentials);
+
+        CachedPool cached = pools.compute(name, (key, existing) -> {
+            if (existing != null && existing.fingerprint().equals(fingerprint) && isRunning(existing.dataSource())) {
+                return existing;
+            }
+            if (existing != null) {
+                log.info("Recreating connection pool for profile '{}' (fingerprint changed or pool closed)", key);
+                closeQuietly(existing.dataSource());
+            } else {
+                log.info("Creating connection pool for profile '{}'", key);
+            }
+            HikariDataSource dataSource = dataSourceFactory.createPooled(profile, credentials);
+            return new CachedPool(fingerprint, dataSource);
+        });
+        return cached.dataSource();
+    }
+
+    public void invalidate(String connectionProfileName) {
+        if (!StringUtils.hasText(connectionProfileName)) {
+            return;
+        }
+        String name = connectionProfileName.trim();
+        CachedPool removed = pools.remove(name);
+        if (removed != null) {
+            log.info("Invalidating connection pool for profile '{}'", name);
+            closeQuietly(removed.dataSource());
+        }
+    }
+
+    public void invalidateAll() {
+        for (String name : pools.keySet()) {
+            invalidate(name);
+        }
+    }
+
+    /** Visible for tests. */
+    int size() {
+        return pools.size();
+    }
+
+    /** Visible for tests. */
+    boolean contains(String connectionProfileName) {
+        return pools.containsKey(connectionProfileName);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        invalidateAll();
+    }
+
+    /**
+     * Stable identity for cache reuse. Includes a digest of credentials so password
+     * rotations force a new pool without storing secrets in the cache key text.
+     */
+    static String fingerprint(ConnectionProfile profile, Map<String, String> credentials) {
+        StringBuilder material = new StringBuilder();
+        material.append(nullToEmpty(profile.getName())).append('\n');
+        material.append(profile.getType() == null ? "" : profile.getType().name()).append('\n');
+        material.append(nullToEmpty(profile.getEndpoint())).append('\n');
+        material.append(nullToEmpty(profile.getUpdatedAt())).append('\n');
+        if (credentials != null && !credentials.isEmpty()) {
+            credentials.entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(entry -> material
+                            .append(nullToEmpty(entry.getKey()))
+                            .append('=')
+                            .append(nullToEmpty(entry.getValue()))
+                            .append('\n'));
+        }
+        return sha256Hex(material.toString());
+    }
+
+    private static boolean isRunning(HikariDataSource dataSource) {
+        return dataSource != null && !dataSource.isClosed();
+    }
+
+    private static void closeQuietly(HikariDataSource dataSource) {
+        if (dataSource == null || dataSource.isClosed()) {
+            return;
+        }
+        try {
+            dataSource.close();
+        } catch (Exception ex) {
+            log.warn("Failed to close connection pool {}: {}", dataSource.getPoolName(), ex.getMessage());
+        }
+    }
+
+    private static String sha256Hex(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException ex) {
+            // Unreachable on standard JVMs; fall back to identity hash without secrets length only.
+            return Integer.toHexString(value.hashCode());
+        }
+    }
+
+    private static String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+
+    private record CachedPool(String fingerprint, HikariDataSource dataSource) {
+    }
+}

--- a/src/main/java/com/zeus/upload/service/ConnectionProfileService.java
+++ b/src/main/java/com/zeus/upload/service/ConnectionProfileService.java
@@ -28,19 +28,34 @@ public class ConnectionProfileService {
     private final ObjectMapper objectMapper;
     private final ConnectionCryptoService cryptoService;
     private final Path connectionDirectory;
+    private final ConnectionPoolCache connectionPoolCache;
 
     @Autowired
-    public ConnectionProfileService(ObjectMapper objectMapper, AppProperties appProperties,
-                                    ConnectionCryptoService cryptoService) {
-        this(objectMapper, Path.of(appProperties.getConnectionProfileDirectory()), cryptoService);
+    public ConnectionProfileService(
+            ObjectMapper objectMapper,
+            AppProperties appProperties,
+            ConnectionCryptoService cryptoService,
+            ConnectionPoolCache connectionPoolCache
+    ) {
+        this(objectMapper, Path.of(appProperties.getConnectionProfileDirectory()), cryptoService, connectionPoolCache);
     }
 
     ConnectionProfileService(ObjectMapper objectMapper, Path connectionDirectory,
                              ConnectionCryptoService cryptoService) {
+        this(objectMapper, connectionDirectory, cryptoService, null);
+    }
+
+    ConnectionProfileService(
+            ObjectMapper objectMapper,
+            Path connectionDirectory,
+            ConnectionCryptoService cryptoService,
+            ConnectionPoolCache connectionPoolCache
+    ) {
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
         this.connectionDirectory = Objects.requireNonNull(connectionDirectory, "connectionDirectory must not be null")
                 .toAbsolutePath().normalize();
         this.cryptoService = Objects.requireNonNull(cryptoService, "cryptoService must not be null");
+        this.connectionPoolCache = connectionPoolCache;
     }
 
     public ConnectionProfile save(ConnectionProfileRequest request) throws IOException {
@@ -73,6 +88,7 @@ public class ConnectionProfileService {
         } finally {
             Files.deleteIfExists(temporary);
         }
+        invalidatePool(safeName);
         return profile;
     }
 
@@ -102,7 +118,15 @@ public class ConnectionProfileService {
     }
 
     public void delete(String name) throws IOException {
-        Files.deleteIfExists(profilePath(validateName(name)));
+        String safeName = validateName(name);
+        Files.deleteIfExists(profilePath(safeName));
+        invalidatePool(safeName);
+    }
+
+    private void invalidatePool(String profileName) {
+        if (connectionPoolCache != null) {
+            connectionPoolCache.invalidate(profileName);
+        }
     }
 
     private StoredConnectionProfile readStored(Path path) throws IOException {

--- a/src/main/java/com/zeus/upload/service/DbSession.java
+++ b/src/main/java/com/zeus/upload/service/DbSession.java
@@ -7,8 +7,9 @@ import javax.sql.DataSource;
 
 /**
  * Resolved JDBC execution context: DataSource + dialect for one import/metadata operation.
- * Does not expose credentials. Close when the operation finishes (profile sessions may
- * own pooled resources; the bootstrap session is a no-op on close).
+ * Does not expose credentials. Close when the operation finishes.
+ * Named profile sessions use a shared pool from {@link ConnectionPoolCache}; session close
+ * does not shut that pool down (closer is null). Bootstrap sessions are also a no-op on close.
  */
 public final class DbSession implements AutoCloseable {
 

--- a/src/main/java/com/zeus/upload/service/DbSessionFactory.java
+++ b/src/main/java/com/zeus/upload/service/DbSessionFactory.java
@@ -16,7 +16,8 @@ import org.springframework.util.StringUtils;
 
 /**
  * Opens {@link DbSession}s against the bootstrap Spring DataSource or a named
- * encrypted connection profile. Credentials never leave this factory.
+ * encrypted connection profile (pooled via {@link ConnectionPoolCache}).
+ * Credentials never leave this factory.
  */
 @Service
 public class DbSessionFactory {
@@ -26,20 +27,20 @@ public class DbSessionFactory {
     private final DataSource bootstrapDataSource;
     private final SqlDialect bootstrapDialect;
     private final ConnectionProfileService connectionProfileService;
-    private final ConnectionDataSourceFactory dataSourceFactory;
+    private final ConnectionPoolCache connectionPoolCache;
     private final SqlDialectRegistry dialectRegistry;
 
     public DbSessionFactory(
             DataSource bootstrapDataSource,
             SqlDialect bootstrapDialect,
             ConnectionProfileService connectionProfileService,
-            ConnectionDataSourceFactory dataSourceFactory,
+            ConnectionPoolCache connectionPoolCache,
             SqlDialectRegistry dialectRegistry
     ) {
         this.bootstrapDataSource = Objects.requireNonNull(bootstrapDataSource);
         this.bootstrapDialect = Objects.requireNonNull(bootstrapDialect);
         this.connectionProfileService = Objects.requireNonNull(connectionProfileService);
-        this.dataSourceFactory = Objects.requireNonNull(dataSourceFactory);
+        this.connectionPoolCache = Objects.requireNonNull(connectionPoolCache);
         this.dialectRegistry = Objects.requireNonNull(dialectRegistry);
     }
 
@@ -56,6 +57,7 @@ public class DbSessionFactory {
 
     /**
      * Resolve by optional profile name. Blank/null uses {@link #openDefault()}.
+     * Named sessions share a cached Hikari pool; session close does not shut the pool down.
      */
     public DbSession open(String connectionProfileName) {
         if (!StringUtils.hasText(connectionProfileName)) {
@@ -69,9 +71,10 @@ public class DbSessionFactory {
                         "Connection profile '" + name + "' is REST; select a JDBC/DB2 profile for database operations.");
             }
             Map<String, String> credentials = connectionProfileService.loadCredentials(name);
-            DataSource dataSource = dataSourceFactory.create(profile, credentials);
+            DataSource dataSource = connectionPoolCache.getOrCreate(profile, credentials);
             SqlDialect dialect = resolveDialect(profile);
-            log.info("Opened DB session for connection profile '{}' (product={})", name, dialect.product());
+            log.debug("Opened DB session for connection profile '{}' (product={}, pooled=true)", name, dialect.product());
+            // closer=null: pool is owned by ConnectionPoolCache, not the session.
             return new DbSession(dataSource, dialect, name, dialect.product(), null);
         } catch (IOException ex) {
             throw new IllegalStateException("Could not load connection profile '" + name + "': " + ex.getMessage(), ex);

--- a/src/test/java/com/zeus/upload/service/ConnectionPoolCacheTest.java
+++ b/src/test/java/com/zeus/upload/service/ConnectionPoolCacheTest.java
@@ -1,0 +1,77 @@
+package com.zeus.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zeus.upload.domain.ConnectionProfile;
+import com.zeus.upload.domain.ConnectionType;
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ConnectionPoolCacheTest {
+
+    private final ConnectionPoolCache cache = new ConnectionPoolCache(new ConnectionDataSourceFactory());
+
+    @AfterEach
+    void tearDown() {
+        cache.invalidateAll();
+    }
+
+    @Test
+    void reusesSamePoolForIdenticalProfileFingerprint() {
+        ConnectionProfile profile = profile("pool-a", "jdbc:h2:mem:pool_cache_a;DB_CLOSE_DELAY=-1", "t1");
+        Map<String, String> credentials = Map.of("username", "sa", "secret", "");
+
+        DataSource first = cache.getOrCreate(profile, credentials);
+        DataSource second = cache.getOrCreate(profile, credentials);
+
+        assertThat(second).isSameAs(first);
+        assertThat(first).isInstanceOf(HikariDataSource.class);
+        assertThat(cache.size()).isEqualTo(1);
+        assertThat(((HikariDataSource) first).getPoolName()).isEqualTo("zeus-profile-pool-a");
+    }
+
+    @Test
+    void recreatesPoolWhenFingerprintChanges() {
+        ConnectionProfile v1 = profile("pool-b", "jdbc:h2:mem:pool_cache_b1;DB_CLOSE_DELAY=-1", "t1");
+        Map<String, String> credentials = Map.of("username", "sa", "secret", "");
+        DataSource first = cache.getOrCreate(v1, credentials);
+
+        ConnectionProfile v2 = profile("pool-b", "jdbc:h2:mem:pool_cache_b2;DB_CLOSE_DELAY=-1", "t2");
+        DataSource second = cache.getOrCreate(v2, credentials);
+
+        assertThat(second).isNotSameAs(first);
+        assertThat(((HikariDataSource) first).isClosed()).isTrue();
+        assertThat(((HikariDataSource) second).isClosed()).isFalse();
+        assertThat(cache.size()).isEqualTo(1);
+    }
+
+    @Test
+    void invalidateClosesAndRemovesPool() {
+        ConnectionProfile profile = profile("pool-c", "jdbc:h2:mem:pool_cache_c;DB_CLOSE_DELAY=-1", "t1");
+        HikariDataSource ds = (HikariDataSource) cache.getOrCreate(profile, Map.of("username", "sa"));
+        assertThat(cache.contains("pool-c")).isTrue();
+
+        cache.invalidate("pool-c");
+
+        assertThat(cache.contains("pool-c")).isFalse();
+        assertThat(ds.isClosed()).isTrue();
+        assertThat(cache.size()).isZero();
+    }
+
+    @Test
+    void fingerprintDiffersWhenCredentialsChange() {
+        ConnectionProfile profile = profile("pool-d", "jdbc:h2:mem:x", "t1");
+        String withSecretA = ConnectionPoolCache.fingerprint(profile, Map.of("secret", "super-secret-alpha"));
+        String withSecretB = ConnectionPoolCache.fingerprint(profile, Map.of("secret", "super-secret-beta"));
+        assertThat(withSecretA).isNotEqualTo(withSecretB);
+        assertThat(withSecretA).doesNotContain("super-secret");
+        assertThat(withSecretB).doesNotContain("super-secret");
+    }
+
+    private static ConnectionProfile profile(String name, String endpoint, String updatedAt) {
+        return new ConnectionProfile(name, ConnectionType.DB2_400, endpoint, null, true, updatedAt);
+    }
+}

--- a/src/test/java/com/zeus/upload/service/ConnectionTestServiceTest.java
+++ b/src/test/java/com/zeus/upload/service/ConnectionTestServiceTest.java
@@ -33,8 +33,9 @@ class ConnectionTestServiceTest {
 
         DataSource bootstrap = new DriverManagerDataSource(url, "sa", "");
         var dialect = SqlDialectRegistry.createDefault().resolveFromJdbcUrl(url);
+        var poolCache = new ConnectionPoolCache(new ConnectionDataSourceFactory());
         var sessions = new DbSessionFactory(
-                bootstrap, dialect, profiles, new ConnectionDataSourceFactory(), SqlDialectRegistry.createDefault());
+                bootstrap, dialect, profiles, poolCache, SqlDialectRegistry.createDefault());
         var service = new ConnectionTestService(profiles, sessions);
 
         ConnectionTestResult result = service.test("h2-test");


### PR DESCRIPTION
## Summary
- `ConnectionPoolCache` holds small Hikari pools (max 5) per named JDBC profile
- Fingerprint (SHA-256 of endpoint/type/updatedAt/credentials) forces rebuild on change
- Save/delete invalidates the pool; `@PreDestroy` closes all pools
- Session close no longer tears down shared pools

## Test plan
- [x] `mvn test` (91 tests, 0 failures)
- [ ] CI green