### PR TITLE
Add REST connection tests and PostgreSQL JDBC support

### DIFF
--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -94,7 +94,9 @@ mvn spring-boot:run
 - DB2-style `MERGE ... USING (VALUES ...)` (upsert) is **not** supported on the H2 dialect; UPDATE/INSERT/DELETE paths are preferred for local work. Upsert remains IBM i (and PostgreSQL `ON CONFLICT`) oriented.
 - Schema/libraries: H2 auto-creates missing schemas on CREATE TABLE; IBM i libraries must already exist.
 - Multi-DB direction: expand `SqlDialect` / `SqlDialectRegistry` (not Hibernate). See [architecture/sql-dialects.md](architecture/sql-dialects.md).
-- Named JDBC connection profiles (type DB2_400, endpoint `jdbc:…`) can target
-  a separate DataSource per import/metadata call. Create them under
+- Named JDBC connection profiles (`DB2_400` / `POSTGRES`, endpoint `jdbc:…`) can
+  target a separate pooled DataSource per import/metadata call. Create them under
   `/connections` with credentials encrypted; pick them on the import form.
-  Example local profile endpoint: same H2 URL as `application-local.yaml` or a second mem/file URL.
+  Example local H2 profile: same URL as `application-local.yaml` or a second mem/file URL.
+  PostgreSQL: type `POSTGRES`, endpoint `jdbc:postgresql://localhost:5432/db` (driver included).
+- **Verbindung testen** on `/connections` works for JDBC and REST profiles.

--- a/docs/architecture/connection-profiles.md
+++ b/docs/architecture/connection-profiles.md
@@ -1,8 +1,9 @@
 # Connection Profiles and GUI Configuration
 
 The GUI now provides `/connections` for managing provider-neutral connection
-profiles. A profile currently contains a safe name, type (`DB2_400` or `REST`),
-endpoint URL, description and optional credentials.
+profiles. A profile currently contains a safe name, type
+(`DB2_400`, `POSTGRES`, or `REST`), endpoint URL, description and optional
+credentials.
 
 ## Secret handling
 
@@ -33,7 +34,7 @@ must be backed up and rotated through an explicit migration process.
 - `GET /api/connections/{name}` — load metadata without secrets
 - `POST /api/connections` — validate and save a profile
 - `DELETE /api/connections/{name}` — delete a profile
-- `POST /api/connections/{name}/test` — JDBC connectivity test (no secrets in response)
+- `POST /api/connections/{name}/test` — connectivity test for JDBC **or REST** (no secrets in response)
 
 An empty credential field in the GUI preserves an existing encrypted secret.
 Endpoint URLs must not contain embedded credentials or URI fragments. JDBC
@@ -56,10 +57,17 @@ import profiles, job payloads, logs and API responses.
 
 ### Database product mapping (dialect registry)
 
-`ConnectionType.DB2_400` maps to `DatabaseProduct.DB2_I` via
-`SqlDialectRegistry.resolveFromConnectionType`. JDBC endpoints can also be
-classified with `SqlDialectRegistry.detectProduct(jdbcUrl)`
+`ConnectionType` → product mapping via `SqlDialectRegistry.resolveFromConnectionType`:
+
+| Type | Product |
+|------|---------|
+| `DB2_400` | `DB2_I` |
+| `POSTGRES` | `POSTGRES` |
+| `REST` | n/a (not JDBC) |
+
+JDBC URLs are also classified with `detectProduct`
 (`jdbc:as400:` → DB2_I, `jdbc:h2:` → H2, `jdbc:postgresql:` → POSTGRES).
+The PostgreSQL JDBC driver is on the runtime classpath for named Postgres profiles.
 
 ### Per-connection DataSource (runtime)
 
@@ -80,7 +88,16 @@ Resolution flow:
 2. Named profile → decrypt credentials → `ConnectionPoolCache.getOrCreate`
    → small **Hikari** pool (max 5) keyed by profile fingerprint
    → dialect from JDBC URL (fallback connection type)
-3. REST profiles are rejected for JDBC operations
+3. REST profiles are rejected for JDBC import sessions (use the REST test instead)
+
+### REST connection test
+
+`POST /api/connections/{name}/test` for type `REST`:
+
+- HTTP GET with 10s timeout, redirects disabled
+- Auth: Basic when `username`+`secret` are set; Bearer when only `secret`/`token` is set
+- Success: HTTP 2xx/3xx; 401/403 reported as reachable but auth failed
+- Endpoint must be http(s) without embedded credentials
 
 ### Pool cache
 

--- a/docs/architecture/sql-dialects.md
+++ b/docs/architecture/sql-dialects.md
@@ -10,7 +10,7 @@ Hibernate entities; dialects own product-specific SQL.
 |-------------------|---------|------------------|--------|
 | `DB2_I` | `Db2iDialect` | `jdbc:as400://…` | `MERGE … USING (VALUES …)` |
 | `H2` | `H2Dialect` | `jdbc:h2:…` | unsupported (use INSERT/UPDATE/DELETE) |
-| `POSTGRES` | `PostgresDialect` | `jdbc:postgresql://…` | `INSERT … ON CONFLICT` |
+| `POSTGRES` | `PostgresDialect` | `jdbc:postgresql://…` (driver on runtime classpath) | `INSERT … ON CONFLICT` |
 | `GENERIC_JDBC` | `GenericJdbcDialect` | other `jdbc:…` | unsupported |
 
 IBM i remains **first-class**. Local development and CI use H2 (`local` / `test` profiles).

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <!-- Optional JDBC target for ConnectionType.POSTGRES / jdbc:postgresql: profiles. -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/zeus/upload/controller/UploadController.java
+++ b/src/main/java/com/zeus/upload/controller/UploadController.java
@@ -256,7 +256,7 @@ public class UploadController {
     private List<ConnectionProfile> listJdbcConnections() {
         try {
             return connectionProfileService.list().stream()
-                    .filter(profile -> profile.getType() == ConnectionType.DB2_400)
+                    .filter(profile -> profile.getType() != null && profile.getType().isJdbc())
                     .toList();
         } catch (IOException ex) {
             log.warn("Could not list connection profiles: {}", ex.getMessage());

--- a/src/main/java/com/zeus/upload/domain/ConnectionType.java
+++ b/src/main/java/com/zeus/upload/domain/ConnectionType.java
@@ -1,6 +1,14 @@
 package com.zeus.upload.domain;
 
 public enum ConnectionType {
+    /** IBM i DB2/400 (jt400 JDBC). */
     DB2_400,
-    REST
+    /** PostgreSQL JDBC. */
+    POSTGRES,
+    /** HTTP(S) REST API. */
+    REST;
+
+    public boolean isJdbc() {
+        return this == DB2_400 || this == POSTGRES;
+    }
 }

--- a/src/main/java/com/zeus/upload/service/ConnectionDataSourceFactory.java
+++ b/src/main/java/com/zeus/upload/service/ConnectionDataSourceFactory.java
@@ -75,9 +75,9 @@ public class ConnectionDataSourceFactory {
 
     private ResolvedJdbc resolve(ConnectionProfile profile, Map<String, String> credentials) {
         Objects.requireNonNull(profile, "profile");
-        if (profile.getType() == ConnectionType.REST) {
+        if (profile.getType() == null || !profile.getType().isJdbc()) {
             throw new IllegalArgumentException(
-                    "Connection profile '" + profile.getName() + "' is REST and cannot be used as a JDBC DataSource.");
+                    "Connection profile '" + profile.getName() + "' is not a JDBC profile and cannot be used as a DataSource.");
         }
         String url = profile.getEndpoint() == null ? "" : profile.getEndpoint().trim();
         if (!StringUtils.hasText(url) || !url.toLowerCase(Locale.ROOT).startsWith("jdbc:")) {

--- a/src/main/java/com/zeus/upload/service/ConnectionProfileService.java
+++ b/src/main/java/com/zeus/upload/service/ConnectionProfileService.java
@@ -157,6 +157,15 @@ public class ConnectionProfileService {
                     && !("http".equalsIgnoreCase(endpoint.getScheme()) || "https".equalsIgnoreCase(endpoint.getScheme()))) {
                 throw new IllegalArgumentException("REST connections require an HTTP(S) endpoint");
             }
+            if (request.getType() != null && request.getType().isJdbc()
+                    && !endpointValue.toLowerCase().startsWith("jdbc:")) {
+                throw new IllegalArgumentException("JDBC connections require a jdbc: endpoint URL");
+            }
+            if (request.getType() == com.zeus.upload.domain.ConnectionType.POSTGRES
+                    && !(endpointValue.toLowerCase().startsWith("jdbc:postgresql:")
+                    || endpointValue.toLowerCase().startsWith("jdbc:pgsql:"))) {
+                throw new IllegalArgumentException("POSTGRES connections require a jdbc:postgresql: endpoint URL");
+            }
         } catch (IllegalArgumentException ex) {
             throw new IllegalArgumentException("Connection endpoint is invalid", ex);
         }

--- a/src/main/java/com/zeus/upload/service/ConnectionTestService.java
+++ b/src/main/java/com/zeus/upload/service/ConnectionTestService.java
@@ -6,27 +6,55 @@ import com.zeus.upload.domain.ConnectionType;
 import com.zeus.upload.sql.DatabaseProduct;
 import com.zeus.upload.sql.SqlDialectRegistry;
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 /**
  * Tests named connection profiles without returning secrets.
+ * Supports JDBC/DB2/PostgreSQL sessions and lightweight REST HTTP checks.
  */
 @Service
 public class ConnectionTestService {
 
     private static final Logger log = LoggerFactory.getLogger(ConnectionTestService.class);
+    private static final Duration REST_TIMEOUT = Duration.ofSeconds(10);
 
     private final ConnectionProfileService profileService;
     private final DbSessionFactory dbSessionFactory;
+    private final HttpClient httpClient;
 
+    @Autowired
     public ConnectionTestService(ConnectionProfileService profileService, DbSessionFactory dbSessionFactory) {
+        this(profileService, dbSessionFactory, HttpClient.newBuilder()
+                .connectTimeout(REST_TIMEOUT)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build());
+    }
+
+    /** Package-visible for tests that inject a custom {@link HttpClient}. */
+    ConnectionTestService(
+            ConnectionProfileService profileService,
+            DbSessionFactory dbSessionFactory,
+            HttpClient httpClient
+    ) {
         this.profileService = profileService;
         this.dbSessionFactory = dbSessionFactory;
+        this.httpClient = httpClient;
     }
 
     public ConnectionTestResult test(String connectionName) {
@@ -34,35 +62,9 @@ public class ConnectionTestService {
         try {
             ConnectionProfile profile = profileService.load(connectionName);
             if (profile.getType() == ConnectionType.REST) {
-                return ConnectionTestResult.failure(
-                        profile.getName(),
-                        ConnectionType.REST,
-                        DatabaseProduct.GENERIC_JDBC,
-                        "REST connection tests are not implemented yet. Use a JDBC/DB2 profile.",
-                        System.currentTimeMillis() - started
-                );
+                return testRest(profile, started);
             }
-
-            DatabaseProduct product = SqlDialectRegistry.detectProduct(profile.getEndpoint());
-            if (product == DatabaseProduct.GENERIC_JDBC && profile.getType() == ConnectionType.DB2_400) {
-                product = DatabaseProduct.DB2_I;
-            }
-
-            try (DbSession session = dbSessionFactory.open(profile.getName());
-                 Connection connection = session.dataSource().getConnection()) {
-                DatabaseMetaData meta = connection.getMetaData();
-                String productName = safe(meta.getDatabaseProductName()) + " " + safe(meta.getDatabaseProductVersion());
-                boolean valid = connection.isValid(5);
-                long duration = System.currentTimeMillis() - started;
-                if (!valid) {
-                    return ConnectionTestResult.failure(
-                            profile.getName(), profile.getType(), session.product(),
-                            "Driver reported connection as not valid.", duration);
-                }
-                log.info("Connection test OK for profile '{}' product={}", profile.getName(), session.product());
-                return ConnectionTestResult.ok(
-                        profile.getName(), profile.getType(), session.product(), productName.trim(), duration);
-            }
+            return testJdbc(profile, started);
         } catch (NoSuchFileException ex) {
             return ConnectionTestResult.failure(
                     connectionName, null, null, "Connection profile not found.", System.currentTimeMillis() - started);
@@ -80,11 +82,136 @@ public class ConnectionTestService {
         }
     }
 
+    private ConnectionTestResult testJdbc(ConnectionProfile profile, long started) {
+        try (DbSession session = dbSessionFactory.open(profile.getName());
+             Connection connection = session.dataSource().getConnection()) {
+            DatabaseMetaData meta = connection.getMetaData();
+            String productName = (safe(meta.getDatabaseProductName()) + " " + safe(meta.getDatabaseProductVersion())).trim();
+            boolean valid = connection.isValid(5);
+            long duration = System.currentTimeMillis() - started;
+            if (!valid) {
+                return ConnectionTestResult.failure(
+                        profile.getName(), profile.getType(), session.product(),
+                        "Driver reported connection as not valid.", duration);
+            }
+            log.info("JDBC connection test OK for profile '{}' product={}", profile.getName(), session.product());
+            return ConnectionTestResult.ok(
+                    profile.getName(), profile.getType(), session.product(), productName, duration);
+        } catch (Exception ex) {
+            log.warn("JDBC connection test failed for profile '{}': {}", profile.getName(), sanitize(ex.getMessage()));
+            DatabaseProduct product = SqlDialectRegistry.detectProduct(profile.getEndpoint());
+            return ConnectionTestResult.failure(
+                    profile.getName(), profile.getType(), product,
+                    "Connection failed: " + sanitize(ex.getMessage()),
+                    System.currentTimeMillis() - started);
+        }
+    }
+
+    private ConnectionTestResult testRest(ConnectionProfile profile, long started) {
+        try {
+            Map<String, String> credentials = profileService.loadCredentials(profile.getName());
+            URI endpoint = URI.create(profile.getEndpoint().trim());
+            validateRestEndpoint(endpoint);
+
+            HttpRequest.Builder builder = HttpRequest.newBuilder(endpoint)
+                    .timeout(REST_TIMEOUT)
+                    .GET()
+                    .header("Accept", "*/*")
+                    .header("User-Agent", "zeus-easy-upload-connection-test");
+
+            String authorization = buildAuthorizationHeader(credentials);
+            if (authorization != null) {
+                builder.header("Authorization", authorization);
+            }
+
+            HttpResponse<Void> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.discarding());
+            int status = response.statusCode();
+            long duration = System.currentTimeMillis() - started;
+            String statusLabel = "HTTP " + status;
+
+            if (status >= 200 && status <= 399) {
+                log.info("REST connection test OK for profile '{}' status={}", profile.getName(), status);
+                return ConnectionTestResult.ok(
+                        profile.getName(), ConnectionType.REST, null, statusLabel, duration);
+            }
+            if (status == 401 || status == 403) {
+                return ConnectionTestResult.failure(
+                        profile.getName(), ConnectionType.REST, null,
+                        "Endpoint reachable but authentication failed (" + statusLabel + ").",
+                        duration);
+            }
+            return ConnectionTestResult.failure(
+                    profile.getName(), ConnectionType.REST, null,
+                    "Unexpected response status " + statusLabel + ".",
+                    duration);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return ConnectionTestResult.failure(
+                    profile.getName(), ConnectionType.REST, null,
+                    "REST connection test was interrupted.",
+                    System.currentTimeMillis() - started);
+        } catch (Exception ex) {
+            log.warn("REST connection test failed for profile '{}': {}", profile.getName(), sanitize(ex.getMessage()));
+            return ConnectionTestResult.failure(
+                    profile.getName(), ConnectionType.REST, null,
+                    "REST connection failed: " + sanitize(ex.getMessage()),
+                    System.currentTimeMillis() - started);
+        }
+    }
+
+    static void validateRestEndpoint(URI endpoint) {
+        if (endpoint == null || endpoint.getScheme() == null) {
+            throw new IllegalArgumentException("REST endpoint is invalid.");
+        }
+        String scheme = endpoint.getScheme().toLowerCase(Locale.ROOT);
+        if (!"http".equals(scheme) && !"https".equals(scheme)) {
+            throw new IllegalArgumentException("REST connections require an HTTP(S) endpoint.");
+        }
+        if (endpoint.getUserInfo() != null || endpoint.getFragment() != null) {
+            throw new IllegalArgumentException("REST endpoint must not contain credentials or fragments.");
+        }
+        if (!StringUtils.hasText(endpoint.getHost())) {
+            throw new IllegalArgumentException("REST endpoint host is required.");
+        }
+    }
+
+    /**
+     * Basic when username+secret present; Bearer when only secret is present.
+     */
+    static String buildAuthorizationHeader(Map<String, String> credentials) {
+        if (credentials == null || credentials.isEmpty()) {
+            return null;
+        }
+        String username = firstNonBlank(credentials, "username", "user");
+        String secret = firstNonBlank(credentials, "secret", "password", "token");
+        if (!StringUtils.hasText(secret) && !StringUtils.hasText(username)) {
+            return null;
+        }
+        if (StringUtils.hasText(username) && StringUtils.hasText(secret)) {
+            String basic = username + ":" + secret;
+            return "Basic " + Base64.getEncoder().encodeToString(basic.getBytes(StandardCharsets.UTF_8));
+        }
+        if (StringUtils.hasText(secret)) {
+            return "Bearer " + secret;
+        }
+        return null;
+    }
+
+    private static String firstNonBlank(Map<String, String> map, String... keys) {
+        for (String key : keys) {
+            String value = map.get(key);
+            if (StringUtils.hasText(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
     private static String safe(String value) {
         return value == null ? "" : value;
     }
 
-    /** Strip likely credential fragments from driver error messages. */
+    /** Strip likely credential fragments from error messages. */
     static String sanitize(String message) {
         if (message == null || message.isBlank()) {
             return "unknown error";
@@ -92,7 +219,9 @@ public class ConnectionTestService {
         String cleaned = message
                 .replaceAll("(?i)password\\s*=\\s*[^;\\s]+", "password=***")
                 .replaceAll("(?i)pwd\\s*=\\s*[^;\\s]+", "pwd=***")
-                .replaceAll("(?i)user(?:name)?\\s*=\\s*[^;\\s]+", "user=***");
+                .replaceAll("(?i)user(?:name)?\\s*=\\s*[^;\\s]+", "user=***")
+                .replaceAll("(?i)Bearer\\s+[A-Za-z0-9._\\-]+", "Bearer ***")
+                .replaceAll("(?i)Basic\\s+[A-Za-z0-9+/=]+", "Basic ***");
         if (cleaned.length() > 400) {
             cleaned = cleaned.substring(0, 400) + "…";
         }

--- a/src/main/java/com/zeus/upload/service/DbSessionFactory.java
+++ b/src/main/java/com/zeus/upload/service/DbSessionFactory.java
@@ -1,7 +1,6 @@
 package com.zeus.upload.service;
 
 import com.zeus.upload.domain.ConnectionProfile;
-import com.zeus.upload.domain.ConnectionType;
 import com.zeus.upload.sql.DatabaseProduct;
 import com.zeus.upload.sql.SqlDialect;
 import com.zeus.upload.sql.SqlDialectRegistry;
@@ -66,9 +65,9 @@ public class DbSessionFactory {
         String name = connectionProfileName.trim();
         try {
             ConnectionProfile profile = connectionProfileService.load(name);
-            if (profile.getType() == ConnectionType.REST) {
+            if (profile.getType() == null || !profile.getType().isJdbc()) {
                 throw new IllegalArgumentException(
-                        "Connection profile '" + name + "' is REST; select a JDBC/DB2 profile for database operations.");
+                        "Connection profile '" + name + "' is not a JDBC profile; select DB2_400 or POSTGRES.");
             }
             Map<String, String> credentials = connectionProfileService.loadCredentials(name);
             DataSource dataSource = connectionPoolCache.getOrCreate(profile, credentials);
@@ -93,9 +92,6 @@ public class DbSessionFactory {
         if (fromUrl != DatabaseProduct.GENERIC_JDBC) {
             return dialectRegistry.get(fromUrl);
         }
-        if (profile.getType() == ConnectionType.DB2_400) {
-            return dialectRegistry.get(DatabaseProduct.DB2_I);
-        }
-        return dialectRegistry.get(DatabaseProduct.GENERIC_JDBC);
+        return dialectRegistry.resolveFromConnectionType(profile.getType());
     }
 }

--- a/src/main/java/com/zeus/upload/sql/SqlDialectRegistry.java
+++ b/src/main/java/com/zeus/upload/sql/SqlDialectRegistry.java
@@ -59,10 +59,14 @@ public class SqlDialectRegistry {
     }
 
     public SqlDialect resolveFromConnectionType(ConnectionType type) {
-        if (type == ConnectionType.DB2_400) {
-            return get(DatabaseProduct.DB2_I);
+        if (type == null) {
+            return get(DatabaseProduct.GENERIC_JDBC);
         }
-        return get(DatabaseProduct.GENERIC_JDBC);
+        return switch (type) {
+            case DB2_400 -> get(DatabaseProduct.DB2_I);
+            case POSTGRES -> get(DatabaseProduct.POSTGRES);
+            case REST -> get(DatabaseProduct.GENERIC_JDBC);
+        };
     }
 
     /**

--- a/src/main/resources/templates/connections.html
+++ b/src/main/resources/templates/connections.html
@@ -53,13 +53,16 @@
                             <div class="col-md-6">
                                 <label for="connectionType" class="form-label">Typ</label>
                                 <select id="connectionType" class="form-select" required>
-                                    <option value="DB2_400">IBM i DB2/400</option>
+                                    <option value="DB2_400">IBM i DB2/400 (JDBC)</option>
+                                    <option value="POSTGRES">PostgreSQL (JDBC)</option>
                                     <option value="REST">REST API</option>
                                 </select>
                             </div>
                             <div class="col-12">
                                 <label for="connectionEndpoint" class="form-label">Verbindungs-URL</label>
-                                <input id="connectionEndpoint" class="form-control" placeholder="jdbc:as400://system/bib oder https://api.example.com" required>
+                                <input id="connectionEndpoint" class="form-control"
+                                       placeholder="jdbc:as400://host/LIB · jdbc:postgresql://host:5432/db · https://api.example.com"
+                                       required>
                             </div>
                             <div class="col-12">
                                 <label for="connectionDescription" class="form-label">Beschreibung</label>

--- a/src/test/java/com/zeus/upload/service/ConnectionDataSourceFactoryTest.java
+++ b/src/test/java/com/zeus/upload/service/ConnectionDataSourceFactoryTest.java
@@ -31,7 +31,7 @@ class ConnectionDataSourceFactoryTest {
                 "api", ConnectionType.REST, "https://example.com", null, true, null);
         assertThatThrownBy(() -> factory.create(profile, Map.of()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("REST");
+                .hasMessageContaining("not a JDBC profile");
     }
 
     @Test

--- a/src/test/java/com/zeus/upload/service/ConnectionTestServiceRestTest.java
+++ b/src/test/java/com/zeus/upload/service/ConnectionTestServiceRestTest.java
@@ -1,0 +1,119 @@
+package com.zeus.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import com.zeus.upload.domain.ConnectionProfileRequest;
+import com.zeus.upload.domain.ConnectionTestResult;
+import com.zeus.upload.domain.ConnectionType;
+import com.zeus.upload.sql.SqlDialectRegistry;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+class ConnectionTestServiceRestTest {
+
+    private static final String MASTER_KEY = Base64.getEncoder().encodeToString(new byte[32]);
+
+    private HttpServer server;
+    private int port;
+    private ConnectionProfileService profiles;
+    private ConnectionTestService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/ok", exchange -> {
+            byte[] body = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/secure", exchange -> {
+            String auth = exchange.getRequestHeaders().getFirst("Authorization");
+            String expected = "Basic " + Base64.getEncoder()
+                    .encodeToString("svc:s3cret".getBytes(StandardCharsets.UTF_8));
+            if (expected.equals(auth)) {
+                exchange.sendResponseHeaders(204, -1);
+            } else {
+                exchange.sendResponseHeaders(401, -1);
+            }
+            exchange.close();
+        });
+        server.setExecutor(Executors.newCachedThreadPool());
+        server.start();
+        port = server.getAddress().getPort();
+
+        var directory = Files.createTempDirectory("zeus-rest-test");
+        var crypto = new ConnectionCryptoService(new ObjectMapper(), MASTER_KEY);
+        profiles = new ConnectionProfileService(new ObjectMapper(), directory, crypto);
+        DataSource bootstrap = new DriverManagerDataSource("jdbc:h2:mem:rest_test_bootstrap;DB_CLOSE_DELAY=-1", "sa", "");
+        var dialect = SqlDialectRegistry.createDefault().get(com.zeus.upload.sql.DatabaseProduct.H2);
+        var sessions = new DbSessionFactory(
+                bootstrap, dialect, profiles, new ConnectionPoolCache(new ConnectionDataSourceFactory()),
+                SqlDialectRegistry.createDefault());
+        service = new ConnectionTestService(profiles, sessions);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void restUnauthenticatedGetSucceeds() throws Exception {
+        saveRest("rest-ok", "http://127.0.0.1:" + port + "/ok", Map.of());
+        ConnectionTestResult result = service.test("rest-ok");
+        assertThat(result.isSuccess()).as(result.getMessage()).isTrue();
+        assertThat(result.getDatabaseProductName()).isEqualTo("HTTP 200");
+        assertThat(result.getType()).isEqualTo(ConnectionType.REST);
+    }
+
+    @Test
+    void restBasicAuthSucceeds() throws Exception {
+        saveRest("rest-basic", "http://127.0.0.1:" + port + "/secure",
+                Map.of("username", "svc", "secret", "s3cret"));
+        ConnectionTestResult result = service.test("rest-basic");
+        assertThat(result.isSuccess()).as(result.getMessage()).isTrue();
+        assertThat(result.getDatabaseProductName()).isEqualTo("HTTP 204");
+    }
+
+    @Test
+    void restAuthFailureIsReportedWithoutSecrets() throws Exception {
+        saveRest("rest-bad-auth", "http://127.0.0.1:" + port + "/secure",
+                Map.of("username", "svc", "secret", "wrong"));
+        ConnectionTestResult result = service.test("rest-bad-auth");
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getMessage()).contains("authentication failed");
+        assertThat(result.getMessage()).doesNotContain("wrong");
+    }
+
+    @Test
+    void buildAuthorizationPrefersBasicThenBearer() {
+        assertThat(ConnectionTestService.buildAuthorizationHeader(Map.of("username", "u", "secret", "p")))
+                .startsWith("Basic ");
+        assertThat(ConnectionTestService.buildAuthorizationHeader(Map.of("secret", "tok")))
+                .isEqualTo("Bearer tok");
+        assertThat(ConnectionTestService.buildAuthorizationHeader(Map.of())).isNull();
+    }
+
+    private void saveRest(String name, String endpoint, Map<String, String> credentials) throws Exception {
+        ConnectionProfileRequest request = new ConnectionProfileRequest();
+        request.setName(name);
+        request.setType(ConnectionType.REST);
+        request.setEndpoint(endpoint);
+        request.setCredentials(credentials);
+        profiles.save(request);
+    }
+}

--- a/src/test/java/com/zeus/upload/sql/SqlDialectRegistryTest.java
+++ b/src/test/java/com/zeus/upload/sql/SqlDialectRegistryTest.java
@@ -29,6 +29,7 @@ class SqlDialectRegistryTest {
         assertThat(registry.resolveFromJdbcUrl("jdbc:h2:file:./.local/h2/zeus").product()).isEqualTo(DatabaseProduct.H2);
         assertThat(registry.resolveFromJdbcUrl("jdbc:postgresql://x/y").product()).isEqualTo(DatabaseProduct.POSTGRES);
         assertThat(registry.resolveFromConnectionType(ConnectionType.DB2_400).product()).isEqualTo(DatabaseProduct.DB2_I);
+        assertThat(registry.resolveFromConnectionType(ConnectionType.POSTGRES).product()).isEqualTo(DatabaseProduct.POSTGRES);
         assertThat(registry.resolveFromConnectionType(ConnectionType.REST).product()).isEqualTo(DatabaseProduct.GENERIC_JDBC);
     }
 }


### PR DESCRIPTION
## Summary
- REST connectivity test via HTTP GET (Basic/Bearer, no secrets in responses)
- `ConnectionType.POSTGRES` + `org.postgresql:postgresql` runtime driver
- Import connection dropdown includes all JDBC profile types
- Docs updated for REST test and Postgres profiles

## Test plan
- [x] `mvn test` (95 tests, 0 failures)
- [ ] CI green