### PR TITLE
CSV import modes: create vs existing with typed conversion

### DIFF
--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -100,3 +100,5 @@ mvn spring-boot:run
   Example local H2 profile: same URL as `application-local.yaml` or a second mem/file URL.
   PostgreSQL: type `POSTGRES`, endpoint `jdbc:postgresql://localhost:5432/db` (driver included).
 - **Verbindung testen** on `/connections` works for JDBC and REST profiles.
+- CSV import modes: **create table** (type inference + CREATE/INSERT) or **existing table**
+  (auto-map, type preflight on samples, typed INSERT conversion).

--- a/src/main/java/com/zeus/upload/controller/UploadController.java
+++ b/src/main/java/com/zeus/upload/controller/UploadController.java
@@ -141,6 +141,8 @@ public class UploadController {
                         library, existingTableName, request.getConnectionProfileName());
                 List<ColumnMapping> mappings = mappingService.autoMap(parsed, dbColumns);
                 request.setMappings(copyMappings(mappings));
+                MappingValidationResult preflight = mappingService.validate(
+                        parsed, dbColumns, mappings, "INSERT", List.of());
                 previewContext.setDbColumns(dbColumns);
                 previewContext.setMappings(copyMappings(mappings));
                 previewContext.setUseExistingTable(true);
@@ -149,7 +151,11 @@ public class UploadController {
                 previewContext.setKeyColumns(List.of());
                 model.addAttribute("dbColumns", dbColumns);
                 model.addAttribute("mappings", mappings);
+                model.addAttribute("mappingErrors", preflight.getErrors());
+                model.addAttribute("mappingWarnings", preflight.getWarnings());
+                model.addAttribute("importMode", "existing");
             } else {
+                model.addAttribute("importMode", "create");
                 request.setUseExistingTable(false);
                 previewContext.setUseExistingTable(false);
                 previewContext.setExistingTableName(null);

--- a/src/main/java/com/zeus/upload/service/ImportService.java
+++ b/src/main/java/com/zeus/upload/service/ImportService.java
@@ -46,6 +46,7 @@ public class ImportService {
     private final DataSource dataSource;
     private final DdlService ddlService;
     private final TypeInferenceService typeInferenceService;
+    private final ValueConversionService valueConversionService;
     private final AppProperties appProperties;
     private final SqlDialect sqlDialect;
 
@@ -57,7 +58,9 @@ public class ImportService {
             AppProperties appProperties,
             SqlDialect sqlDialect
     ) {
-        this(null, new ColumnNameSanitizer(), dataSource, ddlService, typeInferenceService, appProperties, sqlDialect);
+        this(null, new ColumnNameSanitizer(), dataSource, ddlService, typeInferenceService,
+                typeInferenceService == null ? null : new ValueConversionService(typeInferenceService),
+                appProperties, sqlDialect);
     }
 
     @Autowired
@@ -67,6 +70,7 @@ public class ImportService {
             DataSource dataSource,
             DdlService ddlService,
             TypeInferenceService typeInferenceService,
+            ValueConversionService valueConversionService,
             AppProperties appProperties,
             SqlDialect sqlDialect
     ) {
@@ -75,6 +79,9 @@ public class ImportService {
         this.dataSource = dataSource;
         this.ddlService = ddlService;
         this.typeInferenceService = typeInferenceService;
+        this.valueConversionService = valueConversionService == null && typeInferenceService != null
+                ? new ValueConversionService(typeInferenceService)
+                : valueConversionService;
         this.appProperties = appProperties;
         this.sqlDialect = sqlDialect;
     }
@@ -203,10 +210,12 @@ public class ImportService {
         }
 
         String insertSql = buildInsertSql(session.dialect(), library, tableName, effectiveMappings);
+        Map<String, DbColumnMeta> columnsByName = dbColumnMetaByName(dbColumns);
 
         try (Connection connection = session.dataSource().getConnection()) {
             connection.setAutoCommit(false);
-            int insertedRows = executeExistingTableInserts(connection, insertSql, effectiveMappings, csv.getRows(), errors);
+            int insertedRows = executeExistingTableInserts(
+                    connection, insertSql, effectiveMappings, columnsByName, csv.getRows(), errors);
             if (!errors.isEmpty()) {
                 connection.rollback();
                 throw new ImportException("Import aborted due to insert errors", errors);
@@ -693,6 +702,7 @@ public class ImportService {
             Connection connection,
             String insertSql,
             List<ColumnMapping> mappings,
+            Map<String, DbColumnMeta> columnsByName,
             List<List<String>> rows,
             List<ParseError> errors
     ) throws SQLException {
@@ -703,18 +713,25 @@ public class ImportService {
         try (PreparedStatement statement = connection.prepareStatement(insertSql)) {
             for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
                 List<String> row = rows.get(rowIndex);
-                bindMappedRow(statement, mappings, row);
+                try {
+                    bindMappedRow(statement, mappings, columnsByName, row);
+                } catch (Exception ex) {
+                    errors.add(new ParseError(rowIndex + 2L, "", "", ex.getMessage()));
+                    continue;
+                }
                 statement.addBatch();
                 pendingRows.add(new RowBinding(rowIndex, row));
 
                 if (pendingRows.size() >= batchSize) {
-                    insertedRows += executeBatchWithFallback(statement, connection, insertSql, mappings, pendingRows, errors);
+                    insertedRows += executeBatchWithFallback(
+                            statement, connection, insertSql, mappings, columnsByName, pendingRows, errors);
                     pendingRows.clear();
                 }
             }
 
             if (!pendingRows.isEmpty()) {
-                insertedRows += executeBatchWithFallback(statement, connection, insertSql, mappings, pendingRows, errors);
+                insertedRows += executeBatchWithFallback(
+                        statement, connection, insertSql, mappings, columnsByName, pendingRows, errors);
             }
         }
         return insertedRows;
@@ -725,6 +742,7 @@ public class ImportService {
             Connection connection,
             String insertSql,
             List<ColumnMapping> mappings,
+            Map<String, DbColumnMeta> columnsByName,
             List<RowBinding> pendingRows,
             List<ParseError> errors
     ) throws SQLException {
@@ -733,7 +751,7 @@ public class ImportService {
             return pendingRows.size();
         } catch (BatchUpdateException ex) {
             log.warn("Batch insert failed, falling back to row-by-row execution: {}", ex.getMessage());
-            return executeRowsIndividually(connection, insertSql, mappings, pendingRows, errors);
+            return executeRowsIndividually(connection, insertSql, mappings, columnsByName, pendingRows, errors);
         }
     }
 
@@ -741,6 +759,7 @@ public class ImportService {
             Connection connection,
             String insertSql,
             List<ColumnMapping> mappings,
+            Map<String, DbColumnMeta> columnsByName,
             List<RowBinding> pendingRows,
             List<ParseError> errors
     ) throws SQLException {
@@ -748,7 +767,7 @@ public class ImportService {
         try (PreparedStatement single = connection.prepareStatement(insertSql)) {
             for (RowBinding pendingRow : pendingRows) {
                 try {
-                    bindMappedRow(single, mappings, pendingRow.rowValues());
+                    bindMappedRow(single, mappings, columnsByName, pendingRow.rowValues());
                     single.executeUpdate();
                     inserted++;
                 } catch (Exception ex) {
@@ -797,19 +816,49 @@ public class ImportService {
         return processedRows;
     }
 
-    private void bindMappedRow(PreparedStatement statement, List<ColumnMapping> mappings, List<String> row) throws SQLException {
+    private void bindMappedRow(
+            PreparedStatement statement,
+            List<ColumnMapping> mappings,
+            Map<String, DbColumnMeta> columnsByName,
+            List<String> row
+    ) throws SQLException {
         statement.clearParameters();
         for (int mappingIndex = 0; mappingIndex < mappings.size(); mappingIndex++) {
             ColumnMapping mapping = mappings.get(mappingIndex);
             int csvIndex = mapping.getCsvIndex();
             String value = csvIndex < row.size() ? row.get(csvIndex) : null;
-            String trimmed = value == null ? null : value.trim();
-            if (!StringUtils.hasText(trimmed)) {
-                statement.setNull(mappingIndex + 1, Types.VARCHAR);
+            DbColumnMeta meta = columnsByName == null
+                    ? null
+                    : columnsByName.get(normalizeColumnName(mapping.getTargetColumn()));
+            ValueConversionService.SqlTypeFamily family = valueConversionService == null
+                    ? ValueConversionService.SqlTypeFamily.VARCHAR
+                    : valueConversionService.familyFrom(
+                            meta == null ? null : meta.getTypeName(),
+                            meta == null ? null : meta.getJdbcType());
+            if (valueConversionService != null) {
+                valueConversionService.bind(statement, mappingIndex + 1, value, family);
             } else {
-                statement.setString(mappingIndex + 1, trimmed);
+                String trimmed = value == null ? null : value.trim();
+                if (!StringUtils.hasText(trimmed)) {
+                    statement.setNull(mappingIndex + 1, Types.VARCHAR);
+                } else {
+                    statement.setString(mappingIndex + 1, trimmed);
+                }
             }
         }
+    }
+
+    private Map<String, DbColumnMeta> dbColumnMetaByName(List<DbColumnMeta> dbColumns) {
+        Map<String, DbColumnMeta> map = new LinkedHashMap<>();
+        if (dbColumns == null) {
+            return map;
+        }
+        for (DbColumnMeta column : dbColumns) {
+            if (column != null && StringUtils.hasText(column.getColumnName())) {
+                map.put(normalizeColumnName(column.getColumnName()), column);
+            }
+        }
+        return map;
     }
 
     private void bindMergeRow(
@@ -878,44 +927,20 @@ public class ImportService {
 
     private void bindValue(PreparedStatement statement, int parameterIndex, ColumnProposal column, String rawValue)
             throws SQLException {
-        String trimmed = rawValue == null ? "" : rawValue.trim();
-        if (trimmed.isEmpty()) {
-            statement.setNull(parameterIndex, sqlType(column.getSqlType()));
+        ValueConversionService.SqlTypeFamily family = valueConversionService == null
+                ? ValueConversionService.SqlTypeFamily.VARCHAR
+                : valueConversionService.familyFromSqlType(column.getSqlType());
+        if (valueConversionService != null) {
+            valueConversionService.bind(statement, parameterIndex, rawValue, family);
             return;
         }
-
-        String sqlType = column.getSqlType().toUpperCase();
-        switch (sqlType) {
-            case "INTEGER" -> statement.setInt(parameterIndex, Integer.parseInt(trimmed));
-            case "BIGINT" -> statement.setLong(parameterIndex, Long.parseLong(trimmed));
-            case "DECIMAL" -> statement.setBigDecimal(parameterIndex, new BigDecimal(trimmed.replace(',', '.')));
-            case "DATE" -> {
-                LocalDate date = typeInferenceService.parseDate(trimmed);
-                if (date == null) {
-                    throw new IllegalArgumentException("Invalid date value");
-                }
-                statement.setDate(parameterIndex, Date.valueOf(date));
-            }
-            case "TIMESTAMP" -> {
-                LocalDateTime timestamp = typeInferenceService.parseTimestamp(trimmed);
-                if (timestamp == null) {
-                    throw new IllegalArgumentException("Invalid timestamp value");
-                }
-                statement.setTimestamp(parameterIndex, Timestamp.valueOf(timestamp));
-            }
-            default -> statement.setString(parameterIndex, trimmed);
+        // Fallback for unit tests without conversion service
+        String trimmed = rawValue == null ? "" : rawValue.trim();
+        if (trimmed.isEmpty()) {
+            statement.setNull(parameterIndex, Types.VARCHAR);
+        } else {
+            statement.setString(parameterIndex, trimmed);
         }
-    }
-
-    private int sqlType(String type) {
-        return switch (type.toUpperCase()) {
-            case "INTEGER" -> Types.INTEGER;
-            case "BIGINT" -> Types.BIGINT;
-            case "DECIMAL" -> Types.DECIMAL;
-            case "DATE" -> Types.DATE;
-            case "TIMESTAMP" -> Types.TIMESTAMP;
-            default -> Types.VARCHAR;
-        };
     }
 
     private record RowBinding(int rowIndex, List<String> rowValues) {

--- a/src/main/java/com/zeus/upload/service/MappingService.java
+++ b/src/main/java/com/zeus/upload/service/MappingService.java
@@ -4,6 +4,7 @@ import com.zeus.upload.domain.ColumnMapping;
 import com.zeus.upload.domain.DbColumnMeta;
 import com.zeus.upload.domain.MappingValidationResult;
 import com.zeus.upload.domain.ParsedCsv;
+import com.zeus.upload.service.ValueConversionService.SqlTypeFamily;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -18,6 +19,19 @@ import org.springframework.util.StringUtils;
 
 @Service
 public class MappingService {
+
+    private static final int PREFLIGHT_SAMPLE_ROWS = 50;
+    private static final int MAX_TYPE_WARNINGS_PER_COLUMN = 3;
+
+    private final ValueConversionService valueConversionService;
+
+    public MappingService() {
+        this(new ValueConversionService(new TypeInferenceService()));
+    }
+
+    public MappingService(ValueConversionService valueConversionService) {
+        this.valueConversionService = valueConversionService;
+    }
 
     public List<ColumnMapping> autoMap(ParsedCsv csv, List<DbColumnMeta> dbColumns) {
         List<DbColumnMeta> safeDbColumns = dbColumns == null ? List.of() : dbColumns;
@@ -186,8 +200,82 @@ public class MappingService {
             }
         }
 
+        // Type preflight: try converting sample CSV values to the target DB column type.
+        if (!"DELETE".equalsIgnoreCase(operation)) {
+            validateSampleConversions(csv, safeMappings, byNormalizedName, result);
+        }
+
         result.setValid(result.getErrors().isEmpty());
         return result;
+    }
+
+    private void validateSampleConversions(
+            ParsedCsv csv,
+            List<ColumnMapping> mappings,
+            Map<String, DbColumnMeta> byNormalizedName,
+            MappingValidationResult result
+    ) {
+        if (csv == null || csv.getRows() == null || csv.getRows().isEmpty()) {
+            return;
+        }
+        int sampleLimit = Math.min(PREFLIGHT_SAMPLE_ROWS, csv.getRows().size());
+        for (ColumnMapping mapping : mappings) {
+            if (mapping == null || mapping.isIgnored() || !StringUtils.hasText(mapping.getTargetColumn())) {
+                continue;
+            }
+            DbColumnMeta meta = byNormalizedName.get(normalizeDbKey(mapping.getTargetColumn()));
+            if (meta == null) {
+                continue;
+            }
+            SqlTypeFamily family = valueConversionService.familyFrom(meta.getTypeName(), meta.getJdbcType());
+            int csvIndex = mapping.getCsvIndex();
+            int warningsForColumn = 0;
+            int failures = 0;
+            String firstFailure = null;
+            for (int row = 0; row < sampleLimit; row++) {
+                List<String> values = csv.getRows().get(row);
+                String raw = csvIndex < values.size() ? values.get(csvIndex) : null;
+                if (!StringUtils.hasText(raw == null ? null : raw.trim())) {
+                    if (!meta.isNullable() && !hasDefault(meta.getDefaultValue())) {
+                        failures++;
+                        if (firstFailure == null) {
+                            firstFailure = "empty value not allowed for NOT NULL column";
+                        }
+                    }
+                    continue;
+                }
+                String error = valueConversionService.conversionError(raw, family);
+                if (error != null) {
+                    failures++;
+                    if (firstFailure == null) {
+                        firstFailure = error;
+                    }
+                    if (warningsForColumn < MAX_TYPE_WARNINGS_PER_COLUMN) {
+                        result.getWarnings().add(
+                                "Type preflight: CSV '" + mapping.getCsvColumn() + "' → "
+                                        + meta.getColumnName() + " (" + family + "), sample row "
+                                        + (row + 2) + ": " + error);
+                        warningsForColumn++;
+                    }
+                }
+            }
+            if (failures > 0 && firstFailure != null) {
+                // Soft by default: warnings only. Hard error if majority of samples fail.
+                if (failures * 2 >= sampleLimit) {
+                    result.getErrors().add(
+                            "Type conversion likely fails for '" + mapping.getCsvColumn() + "' → "
+                                    + meta.getColumnName() + " (" + family + "): " + firstFailure
+                                    + " (" + failures + "/" + sampleLimit + " sample values).");
+                }
+            }
+            if (StringUtils.hasText(mapping.getNote()) && mapping.getNote().contains("unmapped")) {
+                continue;
+            }
+            if (mapping.getNote() == null || mapping.getNote().isBlank()) {
+                mapping.setNote("Target type: " + family
+                        + (meta.getTypeName() == null ? "" : " (" + meta.getTypeName() + ")"));
+            }
+        }
     }
 
     private boolean hasDefault(String defaultValue) {

--- a/src/main/java/com/zeus/upload/service/ValueConversionService.java
+++ b/src/main/java/com/zeus/upload/service/ValueConversionService.java
@@ -1,0 +1,158 @@
+package com.zeus.upload.service;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Locale;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Converts CSV string cells to JDBC values for CREATE and existing-table imports.
+ * Shared by {@link ImportService} (binding) and {@link MappingService} (preflight).
+ */
+@Service
+public class ValueConversionService {
+
+    public enum SqlTypeFamily {
+        INTEGER,
+        BIGINT,
+        DECIMAL,
+        DATE,
+        TIMESTAMP,
+        VARCHAR
+    }
+
+    private final TypeInferenceService typeInferenceService;
+
+    public ValueConversionService(TypeInferenceService typeInferenceService) {
+        this.typeInferenceService = typeInferenceService;
+    }
+
+    public SqlTypeFamily familyFromSqlType(String sqlType) {
+        return familyFrom(sqlType, null);
+    }
+
+    public SqlTypeFamily familyFrom(String typeName, Integer jdbcType) {
+        String upper = typeName == null ? "" : typeName.trim().toUpperCase(Locale.ROOT);
+        if (upper.contains("BIGINT") || upper.contains("INT8") || (jdbcType != null && jdbcType == Types.BIGINT)) {
+            return SqlTypeFamily.BIGINT;
+        }
+        if (upper.contains("INT") || upper.contains("SMALLINT") || upper.equals("SERIAL")
+                || (jdbcType != null && (jdbcType == Types.INTEGER || jdbcType == Types.SMALLINT || jdbcType == Types.TINYINT))) {
+            return SqlTypeFamily.INTEGER;
+        }
+        if (upper.contains("DEC") || upper.contains("NUMERIC") || upper.contains("NUMBER")
+                || (jdbcType != null && (jdbcType == Types.DECIMAL || jdbcType == Types.NUMERIC))) {
+            return SqlTypeFamily.DECIMAL;
+        }
+        if (upper.contains("TIMESTAMP") || upper.contains("DATETIME")
+                || (jdbcType != null && jdbcType == Types.TIMESTAMP)) {
+            return SqlTypeFamily.TIMESTAMP;
+        }
+        if (upper.equals("DATE") || (jdbcType != null && jdbcType == Types.DATE)) {
+            return SqlTypeFamily.DATE;
+        }
+        return SqlTypeFamily.VARCHAR;
+    }
+
+    /**
+     * @return null when conversion succeeds (including blank → NULL), otherwise error text
+     */
+    public String conversionError(String rawValue, SqlTypeFamily family) {
+        try {
+            convert(rawValue, family);
+            return null;
+        } catch (IllegalArgumentException ex) {
+            return ex.getMessage();
+        }
+    }
+
+    public Object convert(String rawValue, SqlTypeFamily family) {
+        String trimmed = rawValue == null ? "" : rawValue.trim();
+        if (!StringUtils.hasText(trimmed)) {
+            return null;
+        }
+        return switch (family == null ? SqlTypeFamily.VARCHAR : family) {
+            case INTEGER -> {
+                try {
+                    yield Integer.parseInt(trimmed);
+                } catch (NumberFormatException ex) {
+                    throw new IllegalArgumentException("Invalid INTEGER value: '" + trimmed + "'");
+                }
+            }
+            case BIGINT -> {
+                try {
+                    yield Long.parseLong(trimmed);
+                } catch (NumberFormatException ex) {
+                    throw new IllegalArgumentException("Invalid BIGINT value: '" + trimmed + "'");
+                }
+            }
+            case DECIMAL -> {
+                try {
+                    yield new BigDecimal(trimmed.replace(',', '.'));
+                } catch (NumberFormatException ex) {
+                    throw new IllegalArgumentException("Invalid DECIMAL value: '" + trimmed + "'");
+                }
+            }
+            case DATE -> {
+                LocalDate date = typeInferenceService.parseDate(trimmed);
+                if (date == null) {
+                    throw new IllegalArgumentException("Invalid DATE value: '" + trimmed + "'");
+                }
+                yield date;
+            }
+            case TIMESTAMP -> {
+                LocalDateTime timestamp = typeInferenceService.parseTimestamp(trimmed);
+                if (timestamp == null) {
+                    // allow date-only as midnight timestamp
+                    LocalDate date = typeInferenceService.parseDate(trimmed);
+                    if (date == null) {
+                        throw new IllegalArgumentException("Invalid TIMESTAMP value: '" + trimmed + "'");
+                    }
+                    yield date.atStartOfDay();
+                }
+                yield timestamp;
+            }
+            case VARCHAR -> trimmed;
+        };
+    }
+
+    public void bind(PreparedStatement statement, int parameterIndex, String rawValue, SqlTypeFamily family)
+            throws SQLException {
+        Object value;
+        try {
+            value = convert(rawValue, family);
+        } catch (IllegalArgumentException ex) {
+            throw new SQLException(ex.getMessage(), ex);
+        }
+        if (value == null) {
+            statement.setNull(parameterIndex, jdbcType(family));
+            return;
+        }
+        switch (family == null ? SqlTypeFamily.VARCHAR : family) {
+            case INTEGER -> statement.setInt(parameterIndex, (Integer) value);
+            case BIGINT -> statement.setLong(parameterIndex, (Long) value);
+            case DECIMAL -> statement.setBigDecimal(parameterIndex, (BigDecimal) value);
+            case DATE -> statement.setDate(parameterIndex, Date.valueOf((LocalDate) value));
+            case TIMESTAMP -> statement.setTimestamp(parameterIndex, Timestamp.valueOf((LocalDateTime) value));
+            case VARCHAR -> statement.setString(parameterIndex, (String) value);
+        }
+    }
+
+    public int jdbcType(SqlTypeFamily family) {
+        return switch (family == null ? SqlTypeFamily.VARCHAR : family) {
+            case INTEGER -> Types.INTEGER;
+            case BIGINT -> Types.BIGINT;
+            case DECIMAL -> Types.DECIMAL;
+            case DATE -> Types.DATE;
+            case TIMESTAMP -> Types.TIMESTAMP;
+            case VARCHAR -> Types.VARCHAR;
+        };
+    }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -14,7 +14,7 @@
         <div class="col-lg-8">
             <div class="card shadow-sm">
                 <div class="card-header">
-                    <h4 class="mb-0">CSV Upload for IBM i DB2/400</h4>
+                    <h4 class="mb-0">CSV Import</h4>
                 </div>
                 <div class="card-body">
                     <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
@@ -22,6 +22,26 @@
                         <div class="mb-3">
                             <label for="file" class="form-label">CSV File</label>
                             <input class="form-control" id="file" name="file" type="file" accept=".csv,text/csv" required>
+                        </div>
+                        <div class="card border-0 bg-light mb-4">
+                            <div class="card-body">
+                                <h6 class="mb-3">Import mode</h6>
+                                <div class="form-check">
+                                    <input class="form-check-input" type="radio" name="importMode" id="modeCreate"
+                                           value="create" checked>
+                                    <label class="form-check-label" for="modeCreate">
+                                        <strong>Neue Tabelle anlegen</strong> — Typen vorschlagen, CREATE TABLE + INSERT
+                                    </label>
+                                </div>
+                                <div class="form-check mt-2">
+                                    <input class="form-check-input" type="radio" name="importMode" id="modeExisting"
+                                           value="existing">
+                                    <label class="form-check-label" for="modeExisting">
+                                        <strong>In vorhandene Tabelle schreiben</strong> — Spalten mappen, typisiert INSERT
+                                    </label>
+                                </div>
+                                <input type="hidden" name="useExistingTable" id="useExistingTable" value="false">
+                            </div>
                         </div>
                         <div class="card border-0 bg-light mb-4">
                             <div class="card-body">
@@ -71,22 +91,18 @@
                                 <label for="library" class="form-label">Library (Schema)</label>
                                 <input class="form-control" id="library" name="library" th:value="${importRequest.library}" required>
                             </div>
-                            <div class="col-md-6 mb-3">
-                                <label for="tableName" class="form-label">Table Name</label>
-                                <input class="form-control" id="tableName" name="tableName" th:value="${importRequest.tableName}" required>
+                            <div class="col-md-6 mb-3" id="createTableNameGroup">
+                                <label for="tableName" class="form-label">New table name</label>
+                                <input class="form-control" id="tableName" name="tableName" th:value="${importRequest.tableName}">
                             </div>
                         </div>
-                        <div class="form-check mb-4">
+                        <div class="form-check mb-4" id="dropAndRecreateGroup">
                             <input class="form-check-input" type="checkbox" id="dropAndRecreate" name="dropAndRecreate">
                             <label class="form-check-label" for="dropAndRecreate">Drop table before create</label>
                         </div>
-                        <div class="card border-0 bg-light mb-4">
+                        <div class="card border-0 bg-light mb-4 d-none" id="existingTableGroup">
                             <div class="card-body">
-                                <h6 class="mb-3">Existing table (optional)</h6>
-                                <div class="form-check mb-2">
-                                    <input class="form-check-input" type="checkbox" id="useExistingTable" name="useExistingTable" value="true">
-                                    <label class="form-check-label" for="useExistingTable">Use existing DB2 table metadata</label>
-                                </div>
+                                <h6 class="mb-3">Ziel-Tabelle</h6>
                                 <div class="mb-2">
                                     <label for="existingTableSelect" class="form-label">Existing table</label>
                                     <select class="form-select" id="existingTableSelect" name="existingTableName" disabled>
@@ -110,10 +126,40 @@
         const useExistingTable = document.getElementById("useExistingTable");
         const existingTableSelect = document.getElementById("existingTableSelect");
         const status = document.getElementById("existingTableStatus");
+        const modeCreate = document.getElementById("modeCreate");
+        const modeExisting = document.getElementById("modeExisting");
+        const createTableNameGroup = document.getElementById("createTableNameGroup");
+        const dropAndRecreateGroup = document.getElementById("dropAndRecreateGroup");
+        const existingTableGroup = document.getElementById("existingTableGroup");
+        const tableNameInput = document.getElementById("tableName");
 
         if (!libraryInput || !useExistingTable || !existingTableSelect || !status) {
             return;
         }
+
+        const isExistingMode = () => modeExisting && modeExisting.checked;
+
+        const applyModeUi = () => {
+            const existing = isExistingMode();
+            useExistingTable.value = existing ? "true" : "false";
+            if (createTableNameGroup) {
+                createTableNameGroup.classList.toggle("d-none", existing);
+            }
+            if (dropAndRecreateGroup) {
+                dropAndRecreateGroup.classList.toggle("d-none", existing);
+            }
+            if (existingTableGroup) {
+                existingTableGroup.classList.toggle("d-none", !existing);
+            }
+            if (tableNameInput) {
+                tableNameInput.required = !existing;
+            }
+            if (existing) {
+                fetchTables();
+            } else {
+                resetSelect("");
+            }
+        };
 
         const resetSelect = (message) => {
             existingTableSelect.innerHTML = "<option value=''>Select table...</option>";
@@ -134,7 +180,7 @@
         };
 
         const fetchTables = async () => {
-            if (!useExistingTable.checked) {
+            if (!isExistingMode()) {
                 resetSelect("");
                 return;
             }
@@ -163,14 +209,25 @@
             }
         };
 
-        useExistingTable.addEventListener("change", fetchTables);
+        if (modeCreate) {
+            modeCreate.addEventListener("change", applyModeUi);
+        }
+        if (modeExisting) {
+            modeExisting.addEventListener("change", applyModeUi);
+        }
         libraryInput.addEventListener("change", () => {
-            if (useExistingTable.checked) {
+            if (isExistingMode()) {
                 fetchTables();
             }
         });
-
-        resetSelect("");
+        if (connectionSelect) {
+            connectionSelect.addEventListener("change", () => {
+                if (isExistingMode()) {
+                    fetchTables();
+                }
+            });
+        }
+        applyModeUi();
     })();
 </script>
 </body>

--- a/src/main/resources/templates/preview.html
+++ b/src/main/resources/templates/preview.html
@@ -62,9 +62,19 @@
                         </div>
                     </div>
                     <div class="col-md-4 d-flex align-items-end mb-3" th:if="${importRequest.useExistingTable}">
-                        <div class="text-muted small">
-                            Existing table import enabled:
-                            <span th:text="${importRequest.library + '.' + importRequest.existingTableName}"></span>
+                        <div class="small">
+                            <span class="badge text-bg-primary">Existing table INSERT</span>
+                            <div class="text-muted mt-1">
+                                Map &amp; insert into
+                                <span th:text="${importRequest.library + '.' + importRequest.existingTableName}"></span>
+                                with typed conversion
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4 d-flex align-items-end mb-3" th:if="${!importRequest.useExistingTable}">
+                        <div class="small">
+                            <span class="badge text-bg-success">Create table + INSERT</span>
+                            <div class="text-muted mt-1">Types inferred from CSV sample</div>
                         </div>
                     </div>
                 </div>

--- a/src/test/java/com/zeus/upload/controller/UploadControllerExistingTableTest.java
+++ b/src/test/java/com/zeus/upload/controller/UploadControllerExistingTableTest.java
@@ -12,6 +12,7 @@ import com.zeus.upload.config.AppProperties;
 import com.zeus.upload.domain.ColumnMapping;
 import com.zeus.upload.domain.ColumnProposal;
 import com.zeus.upload.domain.DbColumnMeta;
+import com.zeus.upload.domain.MappingValidationResult;
 import com.zeus.upload.domain.ParsedCsv;
 import com.zeus.upload.flow.FlowConfigurationFactory;
 import com.zeus.upload.flow.FlowExecutionService;
@@ -68,9 +69,14 @@ class UploadControllerExistingTableTest {
         );
         List<ColumnMapping> mappings = List.of(mapping("first_name", 0, "FIRST_NAME"));
 
+        MappingValidationResult preflight = new MappingValidationResult();
+        preflight.setValid(true);
+
         when(csvParsingService.parse(any())).thenReturn(parsedCsv);
         when(metadataService.listColumns("BIB", "PERSON", null)).thenReturn(dbColumns);
         when(mappingService.autoMap(any(ParsedCsv.class), anyList())).thenReturn(mappings);
+        when(mappingService.validate(any(ParsedCsv.class), anyList(), anyList(), any(), anyList()))
+                .thenReturn(preflight);
         when(appProperties.getDefaultLibrary()).thenReturn("BIB");
         when(connectionProfileService.list()).thenReturn(List.of());
 

--- a/src/test/java/com/zeus/upload/service/MappingServiceTest.java
+++ b/src/test/java/com/zeus/upload/service/MappingServiceTest.java
@@ -11,7 +11,8 @@ import org.junit.jupiter.api.Test;
 
 class MappingServiceTest {
 
-    private final MappingService service = new MappingService();
+    private final MappingService service = new MappingService(
+            new ValueConversionService(new TypeInferenceService()));
 
     @Test
     void shouldMatchNormalizedExactName() {
@@ -129,6 +130,25 @@ class MappingServiceTest {
 
         assertThat(result.isValid()).isFalse();
         assertThat(result.getErrors()).anyMatch(error -> error.contains("must be mapped"));
+    }
+
+    @Test
+    void shouldErrorWhenMostSampleValuesFailTypeConversion() {
+        ParsedCsv csv = new ParsedCsv();
+        csv.getOriginalHeaders().add("amount");
+        csv.getRows().add(List.of("not-a-number"));
+        csv.getRows().add(List.of("still-bad"));
+        csv.getRows().add(List.of("also-bad"));
+        List<DbColumnMeta> dbColumns = List.of(
+                new DbColumnMeta("AMOUNT", "INTEGER", java.sql.Types.INTEGER, 10, 10, 0, true, null, 1)
+        );
+        List<ColumnMapping> mappings = List.of(mapping(0, "amount", "AMOUNT", false));
+
+        MappingValidationResult result = service.validate(csv, dbColumns, mappings, "INSERT", List.of());
+
+        assertThat(result.isValid()).isFalse();
+        assertThat(result.getErrors()).anyMatch(error -> error.contains("Type conversion likely fails"));
+        assertThat(result.getWarnings()).anyMatch(w -> w.contains("Type preflight"));
     }
 
     private ParsedCsv parsedCsvWithHeaders(String... headers) {

--- a/src/test/java/com/zeus/upload/service/ValueConversionServiceTest.java
+++ b/src/test/java/com/zeus/upload/service/ValueConversionServiceTest.java
@@ -1,0 +1,44 @@
+package com.zeus.upload.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.zeus.upload.service.ValueConversionService.SqlTypeFamily;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class ValueConversionServiceTest {
+
+    private final ValueConversionService service = new ValueConversionService(new TypeInferenceService());
+
+    @Test
+    void convertsCoreTypes() {
+        assertThat(service.convert("42", SqlTypeFamily.INTEGER)).isEqualTo(42);
+        assertThat((BigDecimal) service.convert("99,5", SqlTypeFamily.DECIMAL)).isEqualByComparingTo("99.5");
+        assertThat(service.convert("21.01.2025", SqlTypeFamily.DATE)).isEqualTo(LocalDate.of(2025, 1, 21));
+        assertThat(service.convert("  hello ", SqlTypeFamily.VARCHAR)).isEqualTo("hello");
+        assertThat(service.convert("", SqlTypeFamily.INTEGER)).isNull();
+    }
+
+    @Test
+    void rejectsInvalidInteger() {
+        assertThatThrownBy(() -> service.convert("abc", SqlTypeFamily.INTEGER))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("INTEGER");
+    }
+
+    @Test
+    void familyFromDbTypeNames() {
+        assertThat(service.familyFrom("INTEGER", null)).isEqualTo(SqlTypeFamily.INTEGER);
+        assertThat(service.familyFrom("DECIMAL", null)).isEqualTo(SqlTypeFamily.DECIMAL);
+        assertThat(service.familyFrom("VARCHAR", null)).isEqualTo(SqlTypeFamily.VARCHAR);
+        assertThat(service.familyFrom("TIMESTAMP", null)).isEqualTo(SqlTypeFamily.TIMESTAMP);
+    }
+
+    @Test
+    void conversionErrorHelper() {
+        assertThat(service.conversionError("1", SqlTypeFamily.INTEGER)).isNull();
+        assertThat(service.conversionError("x", SqlTypeFamily.INTEGER)).contains("INTEGER");
+    }
+}


### PR DESCRIPTION
## Summary
- Upload UI: explicit **create table** vs **existing table insert** modes
- `ValueConversionService` for INTEGER/DECIMAL/DATE/TIMESTAMP/VARCHAR binding
- Existing-table INSERT uses typed conversion (same as CREATE path)
- Mapping preflight converts sample CSV values against DB column types (warnings + hard errors when most samples fail)
- Preview shows mapping errors/warnings immediately after upload

## Test plan
- [x] `mvn test` (100 tests, 0 failures)
- [ ] CI green
- [ ] Manual: create mode + existing mode with mismatched types shows preflight