### PR TITLE
Fix DECIMAL precision for values like 1500.00

### DIFF
--- a/src/main/java/com/zeus/upload/service/TypeInferenceService.java
+++ b/src/main/java/com/zeus/upload/service/TypeInferenceService.java
@@ -158,25 +158,43 @@ public class TypeInferenceService {
         return values.stream().allMatch(value -> parseTimestamp(value) != null);
     }
 
+    /**
+     * Derive DECIMAL(p,s) so that every sample value fits.
+     * Uses max integer digits + max fractional digits across samples.
+     * Note: {@link BigDecimal#stripTrailingZeros()} is intentionally not used —
+     * it turns {@code 1500.00} into {@code 1.5E+3} and underestimates precision.
+     */
     private int[] calculatePrecisionScale(List<String> values) {
-        int precision = 1;
-        int scale = 0;
+        int maxIntegerDigits = 1;
+        int maxScale = 0;
         for (String value : values) {
-            BigDecimal decimal = new BigDecimal(value.replace(',', '.').trim());
-            decimal = decimal.stripTrailingZeros();
-            int valuePrecision = decimal.precision();
-            int valueScale = Math.max(decimal.scale(), 0);
-            precision = Math.max(precision, valuePrecision);
-            scale = Math.max(scale, valueScale);
-        }
-        precision = Math.max(precision, scale + 1);
-        if (precision > 31) {
-            precision = 31;
-            if (scale >= precision) {
-                scale = precision - 1;
+            BigDecimal decimal = new BigDecimal(value.replace(',', '.').trim()).abs();
+            int scale = decimal.scale();
+            int precision = decimal.precision();
+            int integerDigits;
+            if (scale < 0) {
+                // e.g. 1.5E+3 → scale -2: all digits are before the decimal point
+                integerDigits = precision - scale;
+                scale = 0;
+            } else {
+                integerDigits = precision - scale;
+                if (integerDigits < 1) {
+                    integerDigits = 1;
+                }
             }
+            maxIntegerDigits = Math.max(maxIntegerDigits, integerDigits);
+            maxScale = Math.max(maxScale, scale);
         }
-        return new int[]{precision, scale};
+        int precision = maxIntegerDigits + maxScale;
+        // small headroom so slightly larger values still fit
+        precision = Math.min(31, precision + 1);
+        if (precision < maxScale + 1) {
+            precision = maxScale + 1;
+        }
+        if (maxScale >= precision) {
+            maxScale = precision - 1;
+        }
+        return new int[]{precision, maxScale};
     }
 
     private int calculateVarcharLength(int maxLength) {

--- a/src/test/java/com/zeus/upload/service/TypeInferenceServiceTest.java
+++ b/src/test/java/com/zeus/upload/service/TypeInferenceServiceTest.java
@@ -31,6 +31,18 @@ class TypeInferenceServiceTest {
     }
 
     @Test
+    void shouldSizeDecimalToFitLargestIntegerPartIncludingTrailingZeros() {
+        // Regression: stripTrailingZeros used to turn 1500.00 into 1.5E+3 and yield DECIMAL(5,2).
+        ColumnProposal proposal = service.inferColumn(
+                0, "amount", "AMOUNT", List.of("123.45", "99,90", "1500.00", "-12.50"));
+        assertThat(proposal.getSqlType()).isEqualTo("DECIMAL");
+        assertThat(proposal.getScale()).isEqualTo(2);
+        // 1500.00 needs 4 integer digits + scale 2 => at least DECIMAL(6,2); headroom may add 1
+        assertThat(proposal.getPrecision()).isGreaterThanOrEqualTo(6);
+        assertThat(proposal.getPrecision() - proposal.getScale()).isGreaterThanOrEqualTo(4);
+    }
+
+    @Test
     void shouldInferDate() {
         ColumnProposal proposal = service.inferColumn(0, "d", "D", List.of("2025-01-01", "02.01.2025", "03/01/2025"));
         assertThat(proposal.getSqlType()).isEqualTo("DATE");


### PR DESCRIPTION
## Summary
- DECIMAL type inference under-sized columns (e.g. `1500.00` → `DECIMAL(5,2)`) because `stripTrailingZeros()` produced scientific notation
- Now sizes by max integer digits + max scale (+1 headroom)

## Test plan
- [x] Regression test for 1500.00 sample set
- [x] TypeInference / H2 import tests