### PR TITLE
Clear handling when CREATE target table already exists

### DIFF
--- a/src/main/java/com/zeus/upload/service/DdlService.java
+++ b/src/main/java/com/zeus/upload/service/DdlService.java
@@ -45,7 +45,14 @@ public class DdlService {
     }
 
     public String dropTableSql(String library, String table) {
-        return "DROP TABLE " + sqlDialect.qualifyTable(library, table);
+        return sqlDialect.dropTableSql(library, table);
+    }
+
+    public String dropTableIfExistsSql(String library, String table) {
+        if (sqlDialect.supportsDropIfExists()) {
+            return sqlDialect.dropTableIfExistsSql(library, table);
+        }
+        return sqlDialect.dropTableSql(library, table);
     }
 
     public String insertSql(String library, String table, List<ColumnProposal> columns) {

--- a/src/main/java/com/zeus/upload/service/ImportService.java
+++ b/src/main/java/com/zeus/upload/service/ImportService.java
@@ -105,10 +105,21 @@ public class ImportService {
 
             ensureSchemaExists(connection, session.dialect(), request.getLibrary());
 
+            boolean exists = tableExists(connection, session.dialect(), request.getLibrary(), request.getTableName());
+            if (exists && !request.isDropAndRecreate()) {
+                String message = "Table "
+                        + request.getLibrary() + "." + request.getTableName()
+                        + " already exists. Enable \"Drop table before create\", "
+                        + "choose another table name, or use import mode \"In vorhandene Tabelle schreiben\".";
+                errors.add(new ParseError(0, request.getTableName(), "", message));
+                return ImportResult.failure(message, createSql, errors);
+            }
+
             if (request.isDropAndRecreate()) {
-                try (PreparedStatement drop = connection.prepareStatement(
-                        ddl.dropTableSql(request.getLibrary(), request.getTableName()))) {
+                String dropSql = ddl.dropTableIfExistsSql(request.getLibrary(), request.getTableName());
+                try (PreparedStatement drop = connection.prepareStatement(dropSql)) {
                     drop.executeUpdate();
+                    log.info("Dropped table {}.{} before recreate", request.getLibrary(), request.getTableName());
                 } catch (SQLException ex) {
                     log.info("DROP TABLE ignored: {}", ex.getMessage());
                 }
@@ -133,8 +144,9 @@ public class ImportService {
         } catch (ImportException ex) {
             return ImportResult.failure(ex.getMessage(), createSql, ex.getErrors());
         } catch (Exception ex) {
-            errors.add(new ParseError(0, "", "", ex.getMessage()));
-            return ImportResult.failure("Import failed: " + ex.getMessage(), createSql, errors);
+            String friendly = friendlyCreateError(ex, request);
+            errors.add(new ParseError(0, "", "", friendly));
+            return ImportResult.failure("Import failed: " + friendly, createSql, errors);
         }
     }
 
@@ -1004,5 +1016,37 @@ public class ImportService {
             statement.executeUpdate();
             log.debug("Ensured schema/library exists: {}", library);
         }
+    }
+
+    private boolean tableExists(Connection connection, SqlDialect dialect, String library, String table)
+            throws SQLException {
+        if (!StringUtils.hasText(library) || !StringUtils.hasText(table)) {
+            return false;
+        }
+        String schema = dialect.normalizeIdentifier(library);
+        String tableName = dialect.normalizeIdentifier(table);
+        java.sql.DatabaseMetaData meta = connection.getMetaData();
+        try (java.sql.ResultSet rs = meta.getTables(null, schema, tableName, new String[]{"TABLE"})) {
+            if (rs.next()) {
+                return true;
+            }
+        }
+        // Some drivers return unquoted/mixed-case names; retry with uppercase pattern.
+        try (java.sql.ResultSet rs = meta.getTables(null, schema.toUpperCase(Locale.ROOT),
+                tableName.toUpperCase(Locale.ROOT), new String[]{"TABLE"})) {
+            return rs.next();
+        }
+    }
+
+    private String friendlyCreateError(Exception ex, ImportRequest request) {
+        String msg = ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage();
+        String lower = msg.toLowerCase(Locale.ROOT);
+        if (lower.contains("already exists") || lower.contains("besteht bereits") || lower.contains("42101")) {
+            return "Table "
+                    + (request == null ? "" : request.getLibrary() + "." + request.getTableName())
+                    + " already exists. Enable \"Drop table before create\", "
+                    + "use another table name, or switch to existing-table import mode. Original: " + msg;
+        }
+        return msg;
     }
 }

--- a/src/main/java/com/zeus/upload/sql/H2Dialect.java
+++ b/src/main/java/com/zeus/upload/sql/H2Dialect.java
@@ -23,6 +23,11 @@ public class H2Dialect extends AbstractSqlDialect {
     }
 
     @Override
+    public boolean supportsDropIfExists() {
+        return true;
+    }
+
+    @Override
     public UpsertStrategy upsertStrategy() {
         return UpsertStrategy.UNSUPPORTED;
     }

--- a/src/main/java/com/zeus/upload/sql/PostgresDialect.java
+++ b/src/main/java/com/zeus/upload/sql/PostgresDialect.java
@@ -25,6 +25,11 @@ public class PostgresDialect extends AbstractSqlDialect {
     }
 
     @Override
+    public boolean supportsDropIfExists() {
+        return true;
+    }
+
+    @Override
     public int maxDecimalPrecision() {
         return 38;
     }

--- a/src/main/java/com/zeus/upload/sql/SqlDialect.java
+++ b/src/main/java/com/zeus/upload/sql/SqlDialect.java
@@ -32,6 +32,22 @@ public interface SqlDialect {
     }
 
     /**
+     * DROP TABLE statement. Dialects that support {@code IF EXISTS} should override.
+     */
+    default String dropTableSql(String libraryOrSchema, String table) {
+        return "DROP TABLE " + qualifyTable(libraryOrSchema, table);
+    }
+
+    default String dropTableIfExistsSql(String libraryOrSchema, String table) {
+        return "DROP TABLE IF EXISTS " + qualifyTable(libraryOrSchema, table);
+    }
+
+    /** Whether {@link #dropTableIfExistsSql} is reliable on this engine. */
+    default boolean supportsDropIfExists() {
+        return false;
+    }
+
+    /**
      * Normalize a raw identifier according to this dialect's policy
      * (case, charset, empty fallback) without length truncation.
      */

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -97,8 +97,13 @@
                             </div>
                         </div>
                         <div class="form-check mb-4" id="dropAndRecreateGroup">
-                            <input class="form-check-input" type="checkbox" id="dropAndRecreate" name="dropAndRecreate">
-                            <label class="form-check-label" for="dropAndRecreate">Drop table before create</label>
+                            <input class="form-check-input" type="checkbox" id="dropAndRecreate" name="dropAndRecreate" value="true">
+                            <label class="form-check-label" for="dropAndRecreate">
+                                Drop table before create
+                                <span class="text-muted small d-block">
+                                    Required if the table name already exists (e.g. re-import into TESTDATA).
+                                </span>
+                            </label>
                         </div>
                         <div class="card border-0 bg-light mb-4 d-none" id="existingTableGroup">
                             <div class="card-body">

--- a/src/test/java/com/zeus/upload/it/H2CrudLifecycleIntegrationTest.java
+++ b/src/test/java/com/zeus/upload/it/H2CrudLifecycleIntegrationTest.java
@@ -174,6 +174,46 @@ class H2CrudLifecycleIntegrationTest {
     }
 
     @Test
+    void createFailsClearlyWhenTableExistsWithoutDropAndRecreate() {
+        ImportRequest first = new ImportRequest();
+        first.setLibrary(LIBRARY);
+        first.setTableName("H2_EXISTS_GUARD");
+        first.setDropAndRecreate(true);
+        first.setColumns(List.of(proposal("ID", "INTEGER", false), proposal("NAME", "VARCHAR", true)));
+        first.getColumns().get(1).setLength(32);
+        ParsedCsv csv = rowsCsv(List.of("id", "name"), List.of(List.of("1", "A")));
+        assertThat(importService.importCsv(first, csv).isSuccess()).isTrue();
+
+        ImportRequest second = new ImportRequest();
+        second.setLibrary(LIBRARY);
+        second.setTableName("H2_EXISTS_GUARD");
+        second.setDropAndRecreate(false);
+        second.setColumns(List.of(proposal("ID", "INTEGER", false), proposal("NAME", "VARCHAR", true)));
+        second.getColumns().get(1).setLength(32);
+
+        ImportResult result = importService.importCsv(second, csv);
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getMessage()).containsIgnoringCase("already exists");
+        assertThat(result.getMessage()).containsIgnoringCase("Drop table");
+    }
+
+    @Test
+    void dropAndRecreateAllowsCreateOnExistingTable() {
+        ImportRequest request = new ImportRequest();
+        request.setLibrary(LIBRARY);
+        request.setTableName("H2_RECREATE_OK");
+        request.setDropAndRecreate(true);
+        request.setColumns(List.of(proposal("ID", "INTEGER", false), proposal("NAME", "VARCHAR", true)));
+        request.getColumns().get(1).setLength(32);
+        ParsedCsv csv = rowsCsv(List.of("id", "name"), List.of(List.of("1", "A"), List.of("2", "B")));
+
+        assertThat(importService.importCsv(request, csv).isSuccess()).isTrue();
+        ImportResult again = importService.importCsv(request, csv);
+        assertThat(again.isSuccess()).as(again.getMessage()).isTrue();
+        assertThat(again.getInsertedRows()).isEqualTo(2);
+    }
+
+    @Test
     void createTableAutoCreatesMissingSchemaOnH2() {
         String library = "AUTO_SCHEMA_LIB";
         String table = "H2_AUTO_SCHEMA";


### PR DESCRIPTION
## Summary
- Fail early with guidance if table exists and drop-and-recreate is off
- DROP TABLE IF EXISTS for H2/Postgres when recreating
- UI hint on the drop checkbox

## Test plan
- [x] H2 lifecycle tests (exists guard + recreate)