### PR TITLE
Add Playwright E2E suite and harden connection test

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,17 @@ benoetigt kein IBM i. Abgedeckt sind u. a.:
 mvn test
 ```
 
+Browser-E2E (Playwright, opt-in — nicht im Default-`mvn test`):
+
+```bash
+# einmalig Chromium installieren
+mvn -DskipTests exec:java -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install chromium"
+# UI-Flows: Create, Drop/Recreate, Existing-Table, Connections
+mvn -Pe2e test
+```
+
+Details: [docs/LOCAL_DEVELOPMENT.md](docs/LOCAL_DEVELOPMENT.md#browser-e2e-playwright).
+
 Optionale Live-Tests gegen IBM i: [docs/IBM_I_INTEGRATION.md](docs/IBM_I_INTEGRATION.md).
 
 ## Screenshots

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -56,7 +56,10 @@ mvn test
 ```
 
 Default unit/integration tests use the `test` Spring profile and an in-memory H2
-database. No IBM i connection is required. Coverage includes:
+database. No IBM i connection is required. Browser E2E tests (`*E2ETest`) are
+**excluded** from the default run so CI stays fast.
+
+Coverage includes:
 
 - CREATE TABLE + batch INSERT (`ImportService`, CSV import)
 - INSERT into existing table
@@ -67,13 +70,45 @@ database. No IBM i connection is required. Coverage includes:
 
 IBM i live tests remain opt-in; see [IBM_I_INTEGRATION.md](IBM_I_INTEGRATION.md).
 
+## Browser E2E (Playwright)
+
+Full UI flows (CSV upload → preview → create/existing import → result, connections
+page including **Verbindung testen** for JDBC H2 and REST self-check) run with
+[Playwright for Java](https://playwright.dev/java/) against an embedded Spring Boot
+server (profile `test` / in-memory H2).
+
+**Why Playwright?** The app is multipage Thymeleaf with file upload, radios,
+checkboxes, and client-side table loading — real browser coverage catches
+session/form wiring that MockMvc does not. Playwright is a better fit here than
+Selenium (less flaky, auto waits, first-class file upload) and stays in the
+Maven/JUnit world (no separate Node e2e project required).
+
+```bash
+# First time only: download Chromium (~150 MB)
+mvn -DskipTests exec:java -Dexec.classpathScope=test \
+  -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install chromium"
+
+# Run only *E2ETest
+mvn -Pe2e test
+```
+
+Optional:
+
+| Env | Effect |
+|-----|--------|
+| `E2E_HEADLESS=false` | Show the browser window |
+| `E2E_SLOW_MO=250` | Slow actions (ms) for debugging |
+
+Test sources: `src/test/java/com/zeus/upload/e2e/`.
+
 ## Profiles at a glance
 
-| Spring profile | Database | Dialect | Typical use |
-|----------------|----------|---------|-------------|
+| Spring / Maven profile | Database | Dialect | Typical use |
+|------------------------|----------|---------|-------------|
 | *(default)* | IBM i via env JDBC settings | `Db2iDialect` | Real system |
 | `local` | File H2 under `.local/h2` | `H2Dialect` | Offline development |
 | `test` | In-memory H2 | `H2Dialect` | `mvn test` |
+| Maven `-Pe2e` | In-memory H2 + Chromium | `H2Dialect` | Browser E2E (`*E2ETest`) |
 | `it` | Env-driven (usually IBM i) | `Db2iDialect` | Optional live IT |
 
 ## Switching back to IBM i

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,9 @@
         <java.version>17</java.version>
         <commons-csv.version>1.14.1</commons-csv.version>
         <jt400.version>21.0.4</jt400.version>
+        <playwright.version>1.51.0</playwright.version>
+        <!-- Default: skip browser E2E (needs Chromium). Enable with -Pe2e -->
+        <e2e.tests.skip>true</e2e.tests.skip>
     </properties>
 
     <dependencies>
@@ -70,6 +73,13 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Browser E2E (Playwright). Used by *E2ETest only; enabled via -Pe2e. -->
+        <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>${playwright.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Runtime scope: used by spring.profiles.active=local and tests; unused against IBM i. -->
         <dependency>
             <groupId>com.h2database</groupId>
@@ -97,6 +107,16 @@
                     <release>${java.version}</release>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Browser E2E is opt-in (profile e2e) — keeps default CI/unit runs fast. -->
+                    <excludes>
+                        <exclude>**/*E2ETest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -121,6 +141,31 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <spring.profiles.active>${spring.profiles.active}</spring.profiles.active>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- Full browser E2E with Playwright against Spring Boot (H2 test profile).
+             First run downloads Chromium. Usage: mvn -Pe2e test -->
+        <profile>
+            <id>e2e</id>
+            <properties>
+                <e2e.tests.skip>false</e2e.tests.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.self="override"/>
+                            <includes>
+                                <include>**/*E2ETest.java</include>
+                            </includes>
+                            <systemPropertyVariables>
+                                <spring.profiles.active>test</spring.profiles.active>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/src/main/java/com/zeus/upload/service/ConnectionProfileService.java
+++ b/src/main/java/com/zeus/upload/service/ConnectionProfileService.java
@@ -7,6 +7,7 @@ import com.zeus.upload.domain.ConnectionProfileRequest;
 import com.zeus.upload.domain.EncryptedConnectionSecrets;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Instant;
@@ -130,6 +131,11 @@ public class ConnectionProfileService {
     }
 
     private StoredConnectionProfile readStored(Path path) throws IOException {
+        if (!Files.isRegularFile(path)) {
+            // Prefer NoSuchFileException so API/test layers can map to HTTP 404 cleanly
+            // (ObjectMapper would throw FileNotFoundException instead).
+            throw new NoSuchFileException(path.toString());
+        }
         return objectMapper.readValue(path.toFile(), StoredConnectionProfile.class);
     }
 

--- a/src/main/java/com/zeus/upload/service/ConnectionTestService.java
+++ b/src/main/java/com/zeus/upload/service/ConnectionTestService.java
@@ -65,13 +65,22 @@ public class ConnectionTestService {
                 return testRest(profile, started);
             }
             return testJdbc(profile, started);
-        } catch (NoSuchFileException ex) {
+        } catch (NoSuchFileException | java.io.FileNotFoundException ex) {
             return ConnectionTestResult.failure(
                     connectionName, null, null, "Connection profile not found.", System.currentTimeMillis() - started);
         } catch (IOException ex) {
+            // Defensive: some IO paths still surface missing files as generic IOException.
+            String detail = sanitize(ex.getMessage());
+            if (detail.toLowerCase(Locale.ROOT).contains("no such file")
+                    || detail.toLowerCase(Locale.ROOT).contains("cannot find")
+                    || detail.toLowerCase(Locale.ROOT).contains("not found")) {
+                return ConnectionTestResult.failure(
+                        connectionName, null, null, "Connection profile not found.",
+                        System.currentTimeMillis() - started);
+            }
             return ConnectionTestResult.failure(
                     connectionName, null, null,
-                    "Could not load connection profile: " + sanitize(ex.getMessage()),
+                    "Could not load connection profile: " + detail,
                     System.currentTimeMillis() - started);
         } catch (Exception ex) {
             log.warn("Connection test failed for profile '{}': {}", connectionName, sanitize(ex.getMessage()));

--- a/src/main/resources/examples/test-import.csv
+++ b/src/main/resources/examples/test-import.csv
@@ -1,0 +1,6 @@
+id;customer_name;amount;quantity;active;booking_date;created_at;note
+1;Alice Meyer;123.45;10;1;2025-01-20;2025-01-20 10:15:30;First order
+2;Bob Schmidt;99,90;3;1;21.01.2025;2025-01-21T11:22:33;Comma decimal
+3;Charlie Weber;;0;0;22/01/2025;2025-01-22 08:00:00;
+4;Dana Braun;1500.00;25;1;2025-02-01;2025-02-01 09:30:00;Bulk order
+5;Eva Klein;-12.50;1;1;05.02.2025;2025-02-05T14:00:00;Credit note

--- a/src/main/resources/static/js/connections.js
+++ b/src/main/resources/static/js/connections.js
@@ -77,8 +77,8 @@
                 })
             });
             if (!response.ok) throw new Error((await response.json().catch(() => ({}))).message || `Speichern fehlgeschlagen (${response.status})`);
-            showStatus('Verbindung verschlüsselt gespeichert.', 'success');
             await loadProfiles();
+            showStatus('Verbindung verschlüsselt gespeichert.', 'success');
         } catch (error) { showStatus(error.message, 'danger'); }
     });
 
@@ -89,6 +89,9 @@
                 showStatus('Bitte zuerst ein gespeichertes Profil laden oder den Namen angeben.', 'warning');
                 return;
             }
+            const previousLabel = testButton.textContent;
+            testButton.disabled = true;
+            testButton.textContent = 'Teste …';
             showStatus('Verbindung wird getestet …', 'info');
             try {
                 const response = await fetch(`/api/connections/${encodeURIComponent(name)}/test`, { method: 'POST' });
@@ -108,6 +111,9 @@
                 }
             } catch (error) {
                 showStatus(error.message, 'danger');
+            } finally {
+                testButton.disabled = false;
+                testButton.textContent = previousLabel || 'Verbindung testen';
             }
         });
     }

--- a/src/test/java/com/zeus/upload/e2e/ConnectionsUiE2ETest.java
+++ b/src/test/java/com/zeus/upload/e2e/ConnectionsUiE2ETest.java
@@ -1,0 +1,242 @@
+package com.zeus.upload.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.AriaRole;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * Browser coverage for the connection profiles page, including the
+ * "Verbindung testen" button against saved JDBC and REST profiles.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ConnectionsUiE2ETest extends PlaywrightE2ESupport {
+
+    private static String h2ProfileName;
+    private static String restProfileName;
+
+    @Test
+    @Order(1)
+    @DisplayName("Connections page loads and shows form with test button")
+    void connectionsPageLoads() {
+        page.navigate(baseUrl() + "/connections");
+        page.waitForSelector("text=Verbindungsprofile");
+        assertThat(page.locator("#connectionForm").isVisible()).isTrue();
+        assertThat(page.locator("#connectionName").isVisible()).isTrue();
+        assertThat(page.locator("#connectionType").isVisible()).isTrue();
+        assertThat(page.locator("#connectionEndpoint").isVisible()).isTrue();
+        assertThat(page.locator("#testConnection").isVisible()).isTrue();
+        assertThat(page.locator("#testConnection").isEnabled()).isTrue();
+        assertThat(page.locator("#saveConnection").isEnabled()).isTrue();
+        // Encryption is configured in test profile with dummy master key
+        assertThat(bodyText()).doesNotContain("Verschlüsselung ist nicht eingerichtet");
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Nav links between Import and Verbindungen work")
+    void navigationWorks() {
+        goHome();
+        // Prefer navbar — the form also links to /connections in help text.
+        page.locator("nav").getByRole(AriaRole.LINK, new Locator.GetByRoleOptions().setName("Verbindungen")).click();
+        page.waitForSelector("text=Verbindungsprofile");
+        page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Zum Import")).click();
+        page.waitForSelector("text=CSV Import");
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Test button without name shows guidance")
+    void testWithoutNameShowsWarning() {
+        page.navigate(baseUrl() + "/connections");
+        page.waitForSelector("#testConnection");
+        page.locator("#newConnection").click();
+        page.locator("#connectionName").fill("");
+        page.locator("#testConnection").click();
+        waitForStatusMatching("Profil", "warning");
+        assertThat(statusText()).containsIgnoringCase("Profil");
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Test unsaved profile name returns not-found warning")
+    void testUnsavedProfileShowsNotFound() {
+        page.navigate(baseUrl() + "/connections");
+        page.waitForSelector("#testConnection");
+        page.locator("#newConnection").click();
+        page.locator("#connectionName").fill("unsaved-profile-" + shortId());
+        page.locator("#connectionEndpoint").fill("jdbc:h2:mem:unused;MODE=DB2");
+        page.locator("#testConnection").click();
+        // Skip the intermediate "Verbindung wird getestet …" info state.
+        waitForStatusMatching("speichern|nicht gefunden", "warning");
+        String status = statusText();
+        assertThat(status).containsAnyOf("nicht gefunden", "zuerst speichern");
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("Save H2 JDBC profile and connection test succeeds")
+    void saveH2ProfileAndTestSucceeds() {
+        h2ProfileName = "e2e-h2-" + shortId();
+        String jdbcUrl = "jdbc:h2:mem:e2e_conn_" + shortId()
+                + ";MODE=DB2;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=true";
+
+        page.navigate(baseUrl() + "/connections");
+        page.waitForSelector("#connectionForm");
+        page.locator("#newConnection").click();
+        page.locator("#connectionName").fill(h2ProfileName);
+        page.locator("#connectionType").selectOption("DB2_400");
+        page.locator("#connectionEndpoint").fill(jdbcUrl);
+        page.locator("#connectionDescription").fill("E2E H2 connection test profile");
+        page.locator("#connectionUsername").fill("sa");
+        page.locator("#connectionSecret").fill("");
+
+        page.locator("#saveConnection").click();
+        waitForProfileInList(h2ProfileName);
+        waitForStatusMatching("gespeichert", "success");
+
+        page.locator("#testConnection").click();
+        waitForStatusMatching("^OK:", "success");
+
+        String status = statusText();
+        assertThat(status).startsWith("OK:");
+        assertThat(status).containsIgnoringCase("Connection successful");
+        assertThat(status).containsIgnoringCase("H2");
+        assertThat(status).contains("ms");
+        // Secrets must never leak into status UI
+        assertThat(status).doesNotContain("password=");
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("Connection test against unreachable JDBC endpoint fails clearly")
+    void testUnreachableJdbcFails() {
+        String name = "e2e-bad-jdbc-" + shortId();
+        // Port 1 should refuse quickly without long DNS waits.
+        String badUrl = "jdbc:h2:tcp://127.0.0.1:1/./e2e_unreachable";
+
+        page.navigate(baseUrl() + "/connections");
+        page.waitForSelector("#connectionForm");
+        page.locator("#newConnection").click();
+        page.locator("#connectionName").fill(name);
+        page.locator("#connectionType").selectOption("DB2_400");
+        page.locator("#connectionEndpoint").fill(badUrl);
+        page.locator("#connectionUsername").fill("sa");
+        page.locator("#connectionSecret").fill("irrelevant");
+
+        page.locator("#saveConnection").click();
+        waitForProfileInList(name);
+        waitForStatusMatching("gespeichert", "success");
+
+        page.locator("#testConnection").click();
+        waitForStatusMatching(".", "danger");
+
+        String status = statusText();
+        assertThat(status).doesNotStartWith("OK:");
+        assertThat(status.toLowerCase()).containsAnyOf("failed", "fehlgeschlagen", "connection");
+        assertThat(status).doesNotContain("irrelevant");
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("Save REST profile pointing at this app and test succeeds")
+    void saveRestProfileAndTestSucceeds() {
+        restProfileName = "e2e-rest-" + shortId();
+        // Hit the running Spring Boot app itself (200 HTML home page).
+        String restUrl = baseUrl() + "/";
+
+        page.navigate(baseUrl() + "/connections");
+        page.waitForSelector("#connectionForm");
+        page.locator("#newConnection").click();
+        page.locator("#connectionName").fill(restProfileName);
+        page.locator("#connectionType").selectOption("REST");
+        page.locator("#connectionEndpoint").fill(restUrl);
+        page.locator("#connectionDescription").fill("E2E REST self-check");
+        page.locator("#connectionUsername").fill("");
+        page.locator("#connectionSecret").fill("");
+
+        page.locator("#saveConnection").click();
+        waitForProfileInList(restProfileName);
+        waitForStatusMatching("gespeichert", "success");
+
+        page.locator("#testConnection").click();
+        waitForStatusMatching("^OK:", "success");
+
+        String status = statusText();
+        assertThat(status).startsWith("OK:");
+        assertThat(status).containsIgnoringCase("HTTP");
+        assertThat(status).contains("ms");
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("Reload saved H2 profile from list and re-test succeeds")
+    void loadSavedProfileFromListAndRetest() {
+        assertThat(h2ProfileName).as("H2 profile from earlier test").isNotBlank();
+
+        page.navigate(baseUrl() + "/connections");
+        waitForProfileInList(h2ProfileName);
+
+        page.locator("#connectionList button").filter(
+                new Locator.FilterOptions().setHasText(h2ProfileName)
+        ).first().click();
+
+        page.waitForFunction(
+                "name => document.getElementById('connectionName')?.value === name",
+                h2ProfileName,
+                new Page.WaitForFunctionOptions().setTimeout(10_000)
+        );
+        // Username/secret stay empty on load (secrets never returned)
+        assertThat(page.locator("#connectionUsername").inputValue()).isEmpty();
+        assertThat(page.locator("#connectionSecret").inputValue()).isEmpty();
+
+        page.locator("#testConnection").click();
+        waitForStatusMatching("^OK:", "success");
+        assertThat(statusText()).startsWith("OK:");
+    }
+
+    private void waitForProfileInList(String profileName) {
+        page.waitForFunction(
+                "name => Array.from(document.querySelectorAll('#connectionList button'))"
+                        + ".some(b => (b.textContent || '').includes(name))",
+                profileName,
+                new Page.WaitForFunctionOptions().setTimeout(15_000)
+        );
+    }
+
+    /**
+     * Wait until {@code #connectionStatus} shows a non-empty message of the given Bootstrap
+     * alert kind and whose text matches {@code textRegex} (case-insensitive).
+     */
+    private void waitForStatusMatching(String textRegex, String alertKind) {
+        page.waitForFunction(
+                "([regex, kind]) => {"
+                        + "  const el = document.getElementById('connectionStatus');"
+                        + "  if (!el || el.classList.contains('d-none')) return false;"
+                        + "  if (!el.classList.contains('alert-' + kind)) return false;"
+                        + "  const text = (el.textContent || '').trim();"
+                        + "  if (!text) return false;"
+                        // Ignore intermediate "testing…" info once replaced by final status.
+                        + "  if (/getestet/i.test(text) && kind !== 'info') return false;"
+                        + "  return new RegExp(regex, 'i').test(text);"
+                        + "}",
+                java.util.List.of(textRegex, alertKind),
+                new Page.WaitForFunctionOptions().setTimeout(25_000)
+        );
+    }
+
+    private String statusText() {
+        return page.locator("#connectionStatus").innerText().trim();
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+}

--- a/src/test/java/com/zeus/upload/e2e/ImportUiE2ETest.java
+++ b/src/test/java/com/zeus/upload/e2e/ImportUiE2ETest.java
@@ -1,0 +1,181 @@
+package com.zeus.upload.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.AriaRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * End-to-end coverage of the main CSV import UI flows against embedded H2.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ImportUiE2ETest extends PlaywrightE2ESupport {
+
+    private static String sharedTable;
+
+    @Test
+    @Order(1)
+    @DisplayName("Home page shows create/existing import modes")
+    void homePageLoads() {
+        goHome();
+        assertThat(page.locator("#modeCreate").isChecked()).isTrue();
+        assertThat(page.locator("#modeExisting").isVisible()).isTrue();
+        assertThat(page.locator("#dropAndRecreate").isVisible()).isTrue();
+        assertThat(page.locator("#library").inputValue()).isEqualToIgnoringCase("TESTLIB");
+        assertThat(page.getByRole(AriaRole.LINK, new Page.GetByRoleOptions().setName("Verbindungen")).count())
+                .isGreaterThan(0);
+        assertThat(page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName("CSV Import")).count())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Create table + import succeeds with typed CSV")
+    void createTableAndImportSuccess() {
+        sharedTable = uniqueTable("E2E_CRT_");
+        goHome();
+
+        page.locator("#file").setInputFiles(simpleCsv());
+        page.locator("#library").fill("TESTLIB");
+        page.locator("#tableName").fill(sharedTable);
+        page.locator("#csvDelimiter").selectOption(";");
+        page.locator("#dropAndRecreate").check();
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Upload and Analyze")).click();
+
+        page.waitForSelector("text=Preview and Mapping");
+        assertThat(bodyText()).contains("Create table + INSERT");
+        assertThat(bodyText()).contains("Column Proposals");
+        assertThat(bodyText()).containsIgnoringCase("AMOUNT");
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Create Table and Import")).click();
+
+        assertResultSuccess();
+        assertThat(bodyText()).containsIgnoringCase("Import successful");
+        assertThat(bodyText()).containsPattern("Inserted Rows:\\s*3");
+        assertThat(bodyText()).containsIgnoringCase("CREATE TABLE");
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Create without drop fails clearly when table already exists")
+    void createWithoutDropShowsFriendlyError() {
+        assertThat(sharedTable).as("previous create must run first").isNotBlank();
+        goHome();
+
+        page.locator("#file").setInputFiles(simpleCsv());
+        page.locator("#library").fill("TESTLIB");
+        page.locator("#tableName").fill(sharedTable);
+        page.locator("#csvDelimiter").selectOption(";");
+        if (page.locator("#dropAndRecreate").isChecked()) {
+            page.locator("#dropAndRecreate").uncheck();
+        }
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Upload and Analyze")).click();
+        page.waitForSelector("text=Preview and Mapping");
+
+        Locator previewDrop = page.locator("input[name='dropAndRecreate']");
+        if (previewDrop.count() > 0 && previewDrop.first().isChecked()) {
+            previewDrop.first().uncheck();
+        }
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Create Table and Import")).click();
+
+        assertResultFailed();
+        String message = bodyText();
+        assertThat(message).containsIgnoringCase("already exists");
+        assertThat(message).containsIgnoringCase("Drop table");
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Drop and recreate re-imports into same table name")
+    void dropAndRecreateSucceeds() {
+        assertThat(sharedTable).isNotBlank();
+        goHome();
+
+        page.locator("#file").setInputFiles(simpleCsv());
+        page.locator("#library").fill("TESTLIB");
+        page.locator("#tableName").fill(sharedTable);
+        page.locator("#csvDelimiter").selectOption(";");
+        page.locator("#dropAndRecreate").check();
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Upload and Analyze")).click();
+        page.waitForSelector("text=Preview and Mapping");
+
+        Locator previewDrop = page.locator("input[name='dropAndRecreate']");
+        if (previewDrop.count() > 0 && !previewDrop.first().isChecked()) {
+            previewDrop.first().check();
+        }
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Create Table and Import")).click();
+
+        assertResultSuccess();
+        assertThat(bodyText()).containsPattern("Inserted Rows:\\s*3");
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("Existing-table mode lists table and inserts more rows")
+    void existingTableInsertSucceeds() {
+        assertThat(sharedTable).isNotBlank();
+        goHome();
+
+        page.locator("#modeExisting").check();
+        page.waitForFunction("() => document.getElementById('useExistingTable')?.value === 'true'");
+
+        page.locator("#file").setInputFiles(simpleCsv());
+        page.locator("#library").fill("TESTLIB");
+        page.locator("#csvDelimiter").selectOption(";");
+
+        page.waitForFunction(
+                "name => { const s = document.getElementById('existingTableSelect'); "
+                        + "return s && !s.disabled && Array.from(s.options).some(o => o.value === name); }",
+                sharedTable,
+                new Page.WaitForFunctionOptions().setTimeout(15_000)
+        );
+        page.locator("#existingTableSelect").selectOption(sharedTable);
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Upload and Analyze")).click();
+
+        page.waitForSelector("text=Preview and Mapping");
+        assertThat(bodyText()).contains("Existing table INSERT");
+        assertThat(bodyText()).contains("Auto-Mapping to Existing Table");
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Execute Operation")).click();
+
+        assertResultSuccess();
+        assertThat(bodyText()).containsPattern("Inserted Rows:\\s*3");
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("Full test-import.csv (decimals/dates) creates successfully")
+    void fullSampleCsvCreateSucceeds() {
+        String table = uniqueTable("E2E_FULL_");
+        goHome();
+
+        page.locator("#file").setInputFiles(sampleCsv());
+        page.locator("#library").fill("TESTLIB");
+        page.locator("#tableName").fill(table);
+        page.locator("#csvDelimiter").selectOption(";");
+        page.locator("#dropAndRecreate").check();
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Upload and Analyze")).click();
+        page.waitForSelector("text=Preview and Mapping");
+
+        assertThat(bodyText()).containsIgnoringCase("AMOUNT");
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Create Table and Import")).click();
+
+        assertResultSuccess();
+        assertThat(bodyText()).containsPattern("Inserted Rows:\\s*5");
+        assertThat(bodyText()).containsIgnoringCase("DECIMAL");
+    }
+}

--- a/src/test/java/com/zeus/upload/e2e/PlaywrightE2ESupport.java
+++ b/src/test/java/com/zeus/upload/e2e/PlaywrightE2ESupport.java
@@ -1,0 +1,117 @@
+package com.zeus.upload.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Shared Playwright + Spring Boot harness for full browser E2E tests.
+ * <p>
+ * Run with: {@code mvn -Pe2e test}
+ * First run downloads Chromium via Playwright.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+abstract class PlaywrightE2ESupport {
+
+    private static Playwright playwright;
+    private static Browser browser;
+
+    @LocalServerPort
+    protected int port;
+
+    protected BrowserContext context;
+    protected Page page;
+
+    @BeforeAll
+    static void startBrowser() {
+        playwright = Playwright.create();
+        boolean headless = !"false".equalsIgnoreCase(System.getenv().getOrDefault("E2E_HEADLESS", "true"));
+        browser = playwright.chromium().launch(new BrowserType.LaunchOptions()
+                .setHeadless(headless)
+                .setSlowMo(Integer.parseInt(System.getenv().getOrDefault("E2E_SLOW_MO", "0"))));
+    }
+
+    @AfterAll
+    static void stopBrowser() {
+        if (browser != null) {
+            browser.close();
+        }
+        if (playwright != null) {
+            playwright.close();
+        }
+    }
+
+    @BeforeEach
+    void openContext() {
+        context = browser.newContext(new Browser.NewContextOptions().setLocale("en-US"));
+        page = context.newPage();
+        page.setDefaultTimeout(20_000);
+    }
+
+    @AfterEach
+    void closeContext() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    protected String baseUrl() {
+        return "http://127.0.0.1:" + port;
+    }
+
+    protected void goHome() {
+        page.navigate(baseUrl() + "/");
+        page.waitForSelector("text=CSV Import");
+    }
+
+    protected Path sampleCsv() {
+        return Paths.get("src/main/resources/examples/test-import.csv").toAbsolutePath();
+    }
+
+    protected Path simpleCsv() {
+        return Paths.get("src/test/resources/e2e/simple-import.csv").toAbsolutePath();
+    }
+
+    protected static String uniqueTable(String prefix) {
+        String suffix = UUID.randomUUID().toString().replace("-", "");
+        // Keep short enough for IBM-i style names (10 chars) used in H2 dialect for columns,
+        // but table names are not truncated to 10 in CREATE — still keep readable.
+        return (prefix + suffix).substring(0, Math.min(18, prefix.length() + suffix.length())).toUpperCase();
+    }
+
+    protected String bodyText() {
+        return page.locator("body").innerText();
+    }
+
+    protected void assertResultSuccess() {
+        page.waitForSelector("text=Import Result");
+        assertThat(page.locator(".alert-success").count()).as("success alert").isGreaterThan(0);
+        assertThat(bodyText()).contains("SUCCESS");
+    }
+
+    protected void assertResultFailed() {
+        page.waitForSelector("text=Import Result");
+        assertThat(page.locator(".alert-danger").count()).as("failure alert").isGreaterThan(0);
+        assertThat(bodyText()).contains("FAILED");
+    }
+
+    protected void clickNav(String linkText) {
+        page.getByRole(com.microsoft.playwright.options.AriaRole.LINK,
+                new com.microsoft.playwright.Page.GetByRoleOptions().setName(linkText)).click();
+    }
+}

--- a/src/test/resources/e2e/simple-import.csv
+++ b/src/test/resources/e2e/simple-import.csv
@@ -1,0 +1,4 @@
+id;name;amount
+1;Alice;10.50
+2;Bob;20.00
+3;Carol;30.25


### PR DESCRIPTION
## Summary
- Add opt-in Playwright browser E2E (`mvn -Pe2e test`) for CSV create/existing import, drop/recreate, and the connections page
- Cover **Verbindung testen**: validation, not-found, successful H2 JDBC, failed unreachable JDBC, REST self-check, reload from list
- Fix missing connection profile mapping to a clean 404 (`NoSuchFileException`) so the UI shows "Profil nicht gefunden"
- UX: disable test button while testing; refresh profile list before save success message
- Docs: README + LOCAL_DEVELOPMENT for Playwright setup

## Test plan
- [x] `mvn -Pe2e test` (14 tests, BUILD SUCCESS)
- [x] Related connection unit/IT tests
- [ ] CI green on PR
