### PR TITLE
Integrate UPDATE/DELETE full-stack with typed binds and E2E

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Browser-E2E (Playwright, opt-in — nicht im Default-`mvn test`):
 ```bash
 # einmalig Chromium installieren
 mvn -DskipTests exec:java -Dexec.classpathScope=test -Dexec.mainClass=com.microsoft.playwright.CLI -Dexec.args="install chromium"
-# UI-Flows: Create, Drop/Recreate, Existing-Table, Connections
+# UI-Flows: Create, Drop/Recreate, Existing INSERT/UPDATE/DELETE, Connections
 mvn -Pe2e test
 ```
 

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -72,10 +72,12 @@ IBM i live tests remain opt-in; see [IBM_I_INTEGRATION.md](IBM_I_INTEGRATION.md)
 
 ## Browser E2E (Playwright)
 
-Full UI flows (CSV upload → preview → create/existing import → result, connections
-page including **Verbindung testen** for JDBC H2 and REST self-check) run with
-[Playwright for Java](https://playwright.dev/java/) against an embedded Spring Boot
-server (profile `test` / in-memory H2).
+Full UI flows run with [Playwright for Java](https://playwright.dev/java/) against an
+embedded Spring Boot server (profile `test` / in-memory H2):
+
+- CSV create table + insert, drop/recreate, existing-table insert
+- Existing-table **UPDATE** / **DELETE** (key columns, typed conversion)
+- Connections page including **Verbindung testen** (JDBC H2 + REST self-check)
 
 **Why Playwright?** The app is multipage Thymeleaf with file upload, radios,
 checkboxes, and client-side table loading — real browser coverage catches

--- a/src/main/java/com/zeus/upload/service/ImportService.java
+++ b/src/main/java/com/zeus/upload/service/ImportService.java
@@ -314,9 +314,11 @@ public class ImportService {
         }
 
         sql = buildUpdateSql(session.dialect(), library, tableName, updateMappings, keyMappings);
+        Map<String, DbColumnMeta> columnsByName = dbColumnMetaByName(dbColumns);
         try (Connection connection = session.dataSource().getConnection()) {
             connection.setAutoCommit(false);
-            int affectedRows = executeKeyedRows(connection, sql, updateMappings, keyMappings, csv.getRows(), errors);
+            int affectedRows = executeKeyedRows(
+                    connection, sql, updateMappings, keyMappings, columnsByName, csv.getRows(), errors);
             if (!errors.isEmpty()) {
                 connection.rollback();
                 throw new ImportException("Import aborted due to update errors", errors);
@@ -384,9 +386,12 @@ public class ImportService {
 
         List<ColumnMapping> keyMappings = mappingsForKeys(effectiveMappings, keys);
         sql = buildDeleteSql(session.dialect(), library, tableName, keyMappings);
+        Map<String, DbColumnMeta> columnsByName = dbColumnMetaByName(dbColumns);
         try (Connection connection = session.dataSource().getConnection()) {
             connection.setAutoCommit(false);
-            int affectedRows = executeKeyedRows(connection, sql, keyMappings, List.of(), csv.getRows(), errors);
+            // DELETE SQL only has key predicates; bind keys as "values" with no trailing WHERE params.
+            int affectedRows = executeKeyedRows(
+                    connection, sql, keyMappings, List.of(), columnsByName, csv.getRows(), errors);
             if (!errors.isEmpty()) {
                 connection.rollback();
                 throw new ImportException("Import aborted due to delete errors", errors);
@@ -471,6 +476,7 @@ public class ImportService {
             String sql,
             List<ColumnMapping> valueMappings,
             List<ColumnMapping> keyMappings,
+            Map<String, DbColumnMeta> columnsByName,
             List<List<String>> rows,
             List<ParseError> errors
     ) throws SQLException {
@@ -479,8 +485,9 @@ public class ImportService {
             for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
                 try {
                     statement.clearParameters();
-                    bindMappings(statement, valueMappings, rows.get(rowIndex), 1);
-                    bindMappings(statement, keyMappings, rows.get(rowIndex), valueMappings.size() + 1);
+                    bindTypedMappings(statement, valueMappings, columnsByName, rows.get(rowIndex), 1);
+                    bindTypedMappings(
+                            statement, keyMappings, columnsByName, rows.get(rowIndex), valueMappings.size() + 1);
                     affectedRows += statement.executeUpdate();
                 } catch (Exception ex) {
                     errors.add(new ParseError(rowIndex + 2L, "", "", ex.getMessage()));
@@ -490,15 +497,43 @@ public class ImportService {
         return affectedRows;
     }
 
-    private void bindMappings(PreparedStatement statement, List<ColumnMapping> mappings, List<String> row, int startIndex)
-            throws SQLException {
+    /**
+     * Binds CSV cells to JDBC parameters using the same typed conversion as existing-table INSERT.
+     * Parameter indices are 1-based; {@code startIndex} is the first index for this mapping group
+     * (SET columns first, then WHERE keys for UPDATE).
+     */
+    private void bindTypedMappings(
+            PreparedStatement statement,
+            List<ColumnMapping> mappings,
+            Map<String, DbColumnMeta> columnsByName,
+            List<String> row,
+            int startIndex
+    ) throws SQLException {
+        if (mappings == null || mappings.isEmpty()) {
+            return;
+        }
         for (int index = 0; index < mappings.size(); index++) {
-            int csvIndex = mappings.get(index).getCsvIndex();
+            ColumnMapping mapping = mappings.get(index);
+            int csvIndex = mapping.getCsvIndex();
             String value = csvIndex < row.size() ? row.get(csvIndex) : null;
-            if (!StringUtils.hasText(value)) {
-                statement.setNull(startIndex + index, Types.VARCHAR);
+            DbColumnMeta meta = columnsByName == null
+                    ? null
+                    : columnsByName.get(normalizeColumnName(mapping.getTargetColumn()));
+            ValueConversionService.SqlTypeFamily family = valueConversionService == null
+                    ? ValueConversionService.SqlTypeFamily.VARCHAR
+                    : valueConversionService.familyFrom(
+                            meta == null ? null : meta.getTypeName(),
+                            meta == null ? null : meta.getJdbcType());
+            int parameterIndex = startIndex + index;
+            if (valueConversionService != null) {
+                valueConversionService.bind(statement, parameterIndex, value, family);
             } else {
-                statement.setString(startIndex + index, value.trim());
+                String trimmed = value == null ? null : value.trim();
+                if (!StringUtils.hasText(trimmed)) {
+                    statement.setNull(parameterIndex, Types.VARCHAR);
+                } else {
+                    statement.setString(parameterIndex, trimmed);
+                }
             }
         }
     }

--- a/src/main/resources/templates/preview.html
+++ b/src/main/resources/templates/preview.html
@@ -63,11 +63,11 @@
                     </div>
                     <div class="col-md-4 d-flex align-items-end mb-3" th:if="${importRequest.useExistingTable}">
                         <div class="small">
-                            <span class="badge text-bg-primary">Existing table INSERT</span>
+                            <span class="badge text-bg-primary" id="existingModeBadge">Existing table</span>
                             <div class="text-muted mt-1">
-                                Map &amp; insert into
+                                <span id="existingModeHint">Map columns and run the selected operation.</span>
+                                Target:
                                 <span th:text="${importRequest.library + '.' + importRequest.existingTableName}"></span>
-                                with typed conversion
                             </div>
                         </div>
                     </div>
@@ -266,12 +266,63 @@
     (() => {
         const select = document.getElementById('operationSelect');
         const hidden = document.getElementById('operationValue');
+        const badge = document.getElementById('existingModeBadge');
+        const hint = document.getElementById('existingModeHint');
+        const keyHelp = document.querySelector('label[for="operationSelect"]')?.parentElement?.querySelector('.form-text');
         if (!select || !hidden) return;
+
+        const describe = (op) => {
+            switch ((op || 'INSERT').toUpperCase()) {
+                case 'UPDATE':
+                    return {
+                        badge: 'Existing table UPDATE',
+                        badgeClass: 'text-bg-warning',
+                        hint: 'Keys identify rows; non-key mapped columns are updated.',
+                        keyHelp: 'Select key columns that uniquely identify rows to update.'
+                    };
+                case 'DELETE':
+                    return {
+                        badge: 'Existing table DELETE',
+                        badgeClass: 'text-bg-danger',
+                        hint: 'Only key columns are required; matching rows will be deleted.',
+                        keyHelp: 'Select key columns that uniquely identify rows to delete.'
+                    };
+                case 'UPSERT':
+                    return {
+                        badge: 'Existing table UPSERT',
+                        badgeClass: 'text-bg-info',
+                        hint: 'Insert or merge by key columns (engine-dependent).',
+                        keyHelp: 'Keys define the match for upsert / merge.'
+                    };
+                default:
+                    return {
+                        badge: 'Existing table INSERT',
+                        badgeClass: 'text-bg-primary',
+                        hint: 'Map columns and insert new rows with typed conversion.',
+                        keyHelp: 'Keys are optional for plain INSERT.'
+                    };
+            }
+        };
+
+        const applyOperationUi = () => {
+            const op = select.value || 'INSERT';
+            hidden.value = op;
+            const info = describe(op);
+            if (badge) {
+                badge.textContent = info.badge;
+                badge.className = 'badge ' + info.badgeClass;
+            }
+            if (hint) {
+                hint.textContent = info.hint;
+            }
+            if (keyHelp) {
+                keyHelp.textContent = info.keyHelp;
+            }
+        };
+
         select.value = hidden.value || 'INSERT';
-        select.addEventListener('change', () => {
-            hidden.value = select.value;
-        });
-        hidden.value = select.value;
+        select.addEventListener('change', applyOperationUi);
+        applyOperationUi();
     })();
 </script>
 </body>

--- a/src/main/resources/templates/result.html
+++ b/src/main/resources/templates/result.html
@@ -20,9 +20,13 @@
                         <p class="mb-0" th:text="${result.message}"></p>
                     </div>
 
-                    <p><strong>Inserted Rows:</strong> <span th:text="${result.insertedRows}"></span></p>
-                    <p><strong>DDL:</strong></p>
-                    <pre class="bg-body-secondary p-3 rounded" th:text="${result.createTableSql}"></pre>
+                    <p>
+                        <strong>Rows affected:</strong>
+                        <span id="rowsAffected" th:text="${result.insertedRows}"></span>
+                        <span class="text-muted small ms-1">(insert / update / delete)</span>
+                    </p>
+                    <p><strong>SQL:</strong></p>
+                    <pre id="resultSql" class="bg-body-secondary p-3 rounded" th:text="${result.createTableSql}"></pre>
 
                     <div th:if="${result.errors != null and !result.errors.isEmpty()}">
                         <h5>Errors</h5>

--- a/src/test/java/com/zeus/upload/e2e/ImportUiE2ETest.java
+++ b/src/test/java/com/zeus/upload/e2e/ImportUiE2ETest.java
@@ -12,12 +12,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 /**
- * End-to-end coverage of the main CSV import UI flows against embedded H2.
+ * End-to-end coverage of the main CSV import UI flows against embedded H2,
+ * including full-stack UPDATE and DELETE on existing tables.
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ImportUiE2ETest extends PlaywrightE2ESupport {
 
     private static String sharedTable;
+    /** Dedicated table for UPDATE/DELETE (no duplicate-key inserts). */
+    private static String crudTable;
 
     @Test
     @Order(1)
@@ -58,7 +61,7 @@ class ImportUiE2ETest extends PlaywrightE2ESupport {
 
         assertResultSuccess();
         assertThat(bodyText()).containsIgnoringCase("Import successful");
-        assertThat(bodyText()).containsPattern("Inserted Rows:\\s*3");
+        assertThat(page.locator("#rowsAffected").innerText().trim()).isEqualTo("3");
         assertThat(bodyText()).containsIgnoringCase("CREATE TABLE");
     }
 
@@ -117,7 +120,7 @@ class ImportUiE2ETest extends PlaywrightE2ESupport {
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Create Table and Import")).click();
 
         assertResultSuccess();
-        assertThat(bodyText()).containsPattern("Inserted Rows:\\s*3");
+        assertThat(page.locator("#rowsAffected").innerText().trim()).isEqualTo("3");
     }
 
     @Test
@@ -125,37 +128,86 @@ class ImportUiE2ETest extends PlaywrightE2ESupport {
     @DisplayName("Existing-table mode lists table and inserts more rows")
     void existingTableInsertSucceeds() {
         assertThat(sharedTable).isNotBlank();
-        goHome();
-
-        page.locator("#modeExisting").check();
-        page.waitForFunction("() => document.getElementById('useExistingTable')?.value === 'true'");
-
-        page.locator("#file").setInputFiles(simpleCsv());
-        page.locator("#library").fill("TESTLIB");
-        page.locator("#csvDelimiter").selectOption(";");
-
-        page.waitForFunction(
-                "name => { const s = document.getElementById('existingTableSelect'); "
-                        + "return s && !s.disabled && Array.from(s.options).some(o => o.value === name); }",
-                sharedTable,
-                new Page.WaitForFunctionOptions().setTimeout(15_000)
-        );
-        page.locator("#existingTableSelect").selectOption(sharedTable);
-
-        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Upload and Analyze")).click();
-
-        page.waitForSelector("text=Preview and Mapping");
-        assertThat(bodyText()).contains("Existing table INSERT");
-        assertThat(bodyText()).contains("Auto-Mapping to Existing Table");
-
+        openExistingPreview(sharedTable, simpleCsv());
+        assertThat(page.locator("#existingModeBadge").innerText()).containsIgnoringCase("INSERT");
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Execute Operation")).click();
-
         assertResultSuccess();
-        assertThat(bodyText()).containsPattern("Inserted Rows:\\s*3");
+        assertThat(bodyText()).containsIgnoringCase("Import successful");
+        assertThat(page.locator("#rowsAffected").innerText().trim()).isEqualTo("3");
     }
 
     @Test
     @Order(6)
+    @DisplayName("Seed dedicated table for UPDATE/DELETE lifecycle")
+    void seedCrudTableForUpdateDelete() {
+        crudTable = uniqueTable("E2E_CRUD_");
+        uploadCreateTable(crudTable, simpleCsv());
+        assertThat(page.locator("#rowsAffected").innerText().trim()).isEqualTo("3");
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("Existing-table UPDATE by key changes rows")
+    void existingTableUpdateSucceeds() {
+        assertThat(crudTable).as("seedCrudTableForUpdateDelete must run first").isNotBlank();
+
+        openExistingPreview(crudTable, updateCsv());
+        page.locator("#operationSelect").selectOption("UPDATE");
+        page.waitForFunction("() => document.getElementById('operationValue')?.value === 'UPDATE'");
+        assertThat(page.locator("#existingModeBadge").innerText()).containsIgnoringCase("UPDATE");
+        page.locator("select[name='keyColumns']").selectOption("ID");
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Execute Operation")).click();
+
+        assertResultSuccess();
+        assertThat(bodyText()).containsIgnoringCase("Update successful");
+        assertThat(page.locator("#rowsAffected").innerText().trim()).isEqualTo("2");
+        assertThat(page.locator("#resultSql").innerText()).containsIgnoringCase("UPDATE");
+        assertThat(page.locator("#resultSql").innerText()).containsIgnoringCase("WHERE");
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("Existing-table DELETE by key removes matching rows")
+    void existingTableDeleteSucceeds() {
+        assertThat(crudTable).isNotBlank();
+
+        openExistingPreview(crudTable, deleteCsv());
+        page.locator("#operationSelect").selectOption("DELETE");
+        page.waitForFunction("() => document.getElementById('operationValue')?.value === 'DELETE'");
+        assertThat(page.locator("#existingModeBadge").innerText()).containsIgnoringCase("DELETE");
+        page.locator("select[name='keyColumns']").selectOption("ID");
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Execute Operation")).click();
+
+        assertResultSuccess();
+        assertThat(bodyText()).containsIgnoringCase("Delete successful");
+        assertThat(page.locator("#rowsAffected").innerText().trim()).isEqualTo("1");
+        assertThat(page.locator("#resultSql").innerText()).containsIgnoringCase("DELETE");
+    }
+
+    @Test
+    @Order(9)
+    @DisplayName("UPDATE without key columns stays on preview with error")
+    void updateWithoutKeysShowsValidationError() {
+        assertThat(crudTable).isNotBlank();
+
+        openExistingPreview(crudTable, updateCsv());
+        page.locator("#operationSelect").selectOption("UPDATE");
+        page.waitForFunction("() => document.getElementById('operationValue')?.value === 'UPDATE'");
+        page.locator("select[name='keyColumns']").evaluate(
+                "el => { Array.from(el.options).forEach(o => o.selected = false); el.dispatchEvent(new Event('change')); }"
+        );
+
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Execute Operation")).click();
+
+        page.waitForSelector("text=Preview and Mapping");
+        assertThat(bodyText()).containsAnyOf("key column", "Key column", "key columns");
+        assertThat(page.locator("text=Import Result").count()).isZero();
+    }
+
+    @Test
+    @Order(10)
     @DisplayName("Full test-import.csv (decimals/dates) creates successfully")
     void fullSampleCsvCreateSucceeds() {
         String table = uniqueTable("E2E_FULL_");
@@ -175,7 +227,26 @@ class ImportUiE2ETest extends PlaywrightE2ESupport {
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Create Table and Import")).click();
 
         assertResultSuccess();
-        assertThat(bodyText()).containsPattern("Inserted Rows:\\s*5");
+        assertThat(page.locator("#rowsAffected").innerText().trim()).isEqualTo("5");
         assertThat(bodyText()).containsIgnoringCase("DECIMAL");
+    }
+
+    private void openExistingPreview(String tableName, java.nio.file.Path csv) {
+        goHome();
+        page.locator("#modeExisting").check();
+        page.waitForFunction("() => document.getElementById('useExistingTable')?.value === 'true'");
+        page.locator("#file").setInputFiles(csv);
+        page.locator("#library").fill("TESTLIB");
+        page.locator("#csvDelimiter").selectOption(";");
+        page.waitForFunction(
+                "name => { const s = document.getElementById('existingTableSelect'); "
+                        + "return s && !s.disabled && Array.from(s.options).some(o => o.value === name); }",
+                tableName,
+                new Page.WaitForFunctionOptions().setTimeout(15_000)
+        );
+        page.locator("#existingTableSelect").selectOption(tableName);
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Upload and Analyze")).click();
+        page.waitForSelector("text=Preview and Mapping");
+        assertThat(bodyText()).contains("Auto-Mapping to Existing Table");
     }
 }

--- a/src/test/java/com/zeus/upload/e2e/PlaywrightE2ESupport.java
+++ b/src/test/java/com/zeus/upload/e2e/PlaywrightE2ESupport.java
@@ -87,6 +87,59 @@ abstract class PlaywrightE2ESupport {
         return Paths.get("src/test/resources/e2e/simple-import.csv").toAbsolutePath();
     }
 
+    protected Path updateCsv() {
+        return Paths.get("src/test/resources/e2e/update-import.csv").toAbsolutePath();
+    }
+
+    protected Path deleteCsv() {
+        return Paths.get("src/test/resources/e2e/delete-import.csv").toAbsolutePath();
+    }
+
+    protected void uploadCreateTable(String tableName, Path csv) {
+        goHome();
+        page.locator("#file").setInputFiles(csv);
+        page.locator("#library").fill("TESTLIB");
+        page.locator("#tableName").fill(tableName);
+        page.locator("#csvDelimiter").selectOption(";");
+        page.locator("#dropAndRecreate").check();
+        page.getByRole(com.microsoft.playwright.options.AriaRole.BUTTON,
+                new Page.GetByRoleOptions().setName("Upload and Analyze")).click();
+        page.waitForSelector("text=Preview and Mapping");
+        page.getByRole(com.microsoft.playwright.options.AriaRole.BUTTON,
+                new Page.GetByRoleOptions().setName("Create Table and Import")).click();
+        assertResultSuccess();
+    }
+
+    protected void uploadExistingOperation(String tableName, Path csv, String operation, String... keyColumns) {
+        goHome();
+        page.locator("#modeExisting").check();
+        page.waitForFunction("() => document.getElementById('useExistingTable')?.value === 'true'");
+        page.locator("#file").setInputFiles(csv);
+        page.locator("#library").fill("TESTLIB");
+        page.locator("#csvDelimiter").selectOption(";");
+        page.waitForFunction(
+                "name => { const s = document.getElementById('existingTableSelect'); "
+                        + "return s && !s.disabled && Array.from(s.options).some(o => o.value === name); }",
+                tableName,
+                new Page.WaitForFunctionOptions().setTimeout(15_000)
+        );
+        page.locator("#existingTableSelect").selectOption(tableName);
+        page.getByRole(com.microsoft.playwright.options.AriaRole.BUTTON,
+                new Page.GetByRoleOptions().setName("Upload and Analyze")).click();
+        page.waitForSelector("text=Preview and Mapping");
+        page.locator("#operationSelect").selectOption(operation);
+        page.waitForFunction(
+                "op => document.getElementById('operationValue')?.value === op",
+                operation,
+                new Page.WaitForFunctionOptions().setTimeout(5_000)
+        );
+        if (keyColumns != null && keyColumns.length > 0) {
+            page.locator("select[name='keyColumns']").selectOption(keyColumns);
+        }
+        page.getByRole(com.microsoft.playwright.options.AriaRole.BUTTON,
+                new Page.GetByRoleOptions().setName("Execute Operation")).click();
+    }
+
     protected static String uniqueTable(String prefix) {
         String suffix = UUID.randomUUID().toString().replace("-", "");
         // Keep short enough for IBM-i style names (10 chars) used in H2 dialect for columns,

--- a/src/test/java/com/zeus/upload/flow/FlowConfigurationFactoryTest.java
+++ b/src/test/java/com/zeus/upload/flow/FlowConfigurationFactoryTest.java
@@ -43,24 +43,10 @@ class FlowConfigurationFactoryTest {
 
     @Test
     void shouldCreateExistingTableUpsertFlowConfiguration() {
-        ImportRequest request = new ImportRequest();
-        request.setLibrary("TESTLIB");
-        request.setTableName("TMP_TABLE");
-        request.setUseExistingTable(true);
-        request.setExistingTableName("PERSON");
+        ImportRequest request = existingRequest("UPSERT");
         request.setUpsertEnabled(true);
-        request.setMappings(List.of(mapping("id", 0, "ID")));
-        request.setKeyColumns(List.of("ID"));
 
-        PreviewContext previewContext = new PreviewContext();
-        ParsedCsv parsedCsv = new ParsedCsv();
-        parsedCsv.getOriginalHeaders().add("id");
-        previewContext.setParsedCsv(parsedCsv);
-        previewContext.setDbColumns(List.of(
-                new DbColumnMeta("ID", "INTEGER", java.sql.Types.INTEGER, 10, 10, 0, false, null, 1)
-        ));
-
-        FlowConfiguration configuration = factory.fromImportContext(request, previewContext);
+        FlowConfiguration configuration = factory.fromImportContext(request, existingPreview());
 
         DbTableTargetConfiguration target = (DbTableTargetConfiguration) configuration.getTarget();
         assertThat(target.getTableName()).isEqualTo("PERSON");
@@ -68,6 +54,46 @@ class FlowConfigurationFactoryTest {
         assertThat(target.getMappings()).hasSize(1);
         assertThat(target.getKeyColumns()).containsExactly("ID");
         assertThat(target.getDbColumns()).hasSize(1);
+    }
+
+    @Test
+    void shouldCreateExistingTableUpdateFlowConfiguration() {
+        FlowConfiguration configuration = factory.fromImportContext(existingRequest("UPDATE"), existingPreview());
+        DbTableTargetConfiguration target = (DbTableTargetConfiguration) configuration.getTarget();
+        assertThat(target.getWriteMode()).isEqualTo(DbTableWriteMode.UPDATE_EXISTING);
+        assertThat(target.getKeyColumns()).containsExactly("ID");
+    }
+
+    @Test
+    void shouldCreateExistingTableDeleteFlowConfiguration() {
+        FlowConfiguration configuration = factory.fromImportContext(existingRequest("DELETE"), existingPreview());
+        DbTableTargetConfiguration target = (DbTableTargetConfiguration) configuration.getTarget();
+        assertThat(target.getWriteMode()).isEqualTo(DbTableWriteMode.DELETE_EXISTING);
+        assertThat(target.getKeyColumns()).containsExactly("ID");
+    }
+
+    private ImportRequest existingRequest(String operation) {
+        ImportRequest request = new ImportRequest();
+        request.setLibrary("TESTLIB");
+        request.setTableName("TMP_TABLE");
+        request.setUseExistingTable(true);
+        request.setExistingTableName("PERSON");
+        request.setOperation(operation);
+        request.setMappings(List.of(mapping("id", 0, "ID"), mapping("name", 1, "NAME")));
+        request.setKeyColumns(List.of("ID"));
+        return request;
+    }
+
+    private PreviewContext existingPreview() {
+        PreviewContext previewContext = new PreviewContext();
+        ParsedCsv parsedCsv = new ParsedCsv();
+        parsedCsv.getOriginalHeaders().addAll(List.of("id", "name"));
+        previewContext.setParsedCsv(parsedCsv);
+        previewContext.setDbColumns(List.of(
+                new DbColumnMeta("ID", "INTEGER", java.sql.Types.INTEGER, 10, 10, 0, false, null, 1),
+                new DbColumnMeta("NAME", "VARCHAR", java.sql.Types.VARCHAR, 64, 64, 0, true, null, 2)
+        ));
+        return previewContext;
     }
 
     private ColumnProposal column(String finalName) {

--- a/src/test/java/com/zeus/upload/flow/FlowConfigurationFactoryTest.java
+++ b/src/test/java/com/zeus/upload/flow/FlowConfigurationFactoryTest.java
@@ -51,9 +51,9 @@ class FlowConfigurationFactoryTest {
         DbTableTargetConfiguration target = (DbTableTargetConfiguration) configuration.getTarget();
         assertThat(target.getTableName()).isEqualTo("PERSON");
         assertThat(target.getWriteMode()).isEqualTo(DbTableWriteMode.UPSERT_EXISTING);
-        assertThat(target.getMappings()).hasSize(1);
+        assertThat(target.getMappings()).hasSize(2);
         assertThat(target.getKeyColumns()).containsExactly("ID");
-        assertThat(target.getDbColumns()).hasSize(1);
+        assertThat(target.getDbColumns()).hasSize(2);
     }
 
     @Test

--- a/src/test/resources/e2e/delete-import.csv
+++ b/src/test/resources/e2e/delete-import.csv
@@ -1,0 +1,2 @@
+id;name;amount
+2;Bob Updated;20.00

--- a/src/test/resources/e2e/update-import.csv
+++ b/src/test/resources/e2e/update-import.csv
@@ -1,0 +1,3 @@
+id;name;amount
+1;Alice Updated;99.99
+2;Bob Updated;20.00


### PR DESCRIPTION
## Summary
- Typed JDBC binding for existing-table **UPDATE** and **DELETE** (same `ValueConversionService` path as INSERT)
- Preview UI: operation-aware badge/hints for INSERT / UPDATE / DELETE / UPSERT
- Result UI: **Rows affected** + SQL (works for create/insert/update/delete)
- Playwright E2E: full stack UPDATE (2 rows), DELETE (1 row), validation without keys
- Unit tests for `FlowConfigurationFactory` UPDATE/DELETE write modes

## Test plan
- [x] `mvn test -Dtest=FlowConfigurationFactoryTest,H2ImportIntegrationTest,H2CrudLifecycleIntegrationTest`
- [x] `mvn -Pe2e test` (18 tests, BUILD SUCCESS)
- [ ] CI green on PR
